### PR TITLE
prereqs: sanitize HTML in the pipeline — NC prq C→A, NY 250 entries cleaned + CUNY wipe-bug fix

### DIFF
--- a/data/nc/prereqs.json
+++ b/data/nc/prereqs.json
@@ -710,11 +710,11 @@
     ]
   },
   "ARC 113": {
-    "text": "ARC 114 and ARC 111 and ARC 112",
+    "text": "Take ARC-114 ARC-114A - Must be completed prior to taking this course; Take ARC-111 - Must be completed prior to taking this course.",
     "courses": [
-      "ARC 114",
       "ARC 111",
-      "ARC 112"
+      "ARC 114",
+      "ARC 114A"
     ]
   },
   "ARC 114": {
@@ -734,6 +734,13 @@
     "courses": [
       "ARC 116",
       "ARC 112"
+    ]
+  },
+  "ARC 119": {
+    "text": "ARC 113 and MAT 121",
+    "courses": [
+      "ARC 113",
+      "MAT 121"
     ]
   },
   "ARC 131": {
@@ -812,9 +819,10 @@
     ]
   },
   "ARC 220": {
-    "text": "ARC 114",
+    "text": "Take ARC-114A - Must be completed prior to taking this course; Take ARC-114 - Must be completed prior to taking this course.",
     "courses": [
-      "ARC 114"
+      "ARC 114",
+      "ARC 114A"
     ]
   },
   "ARC 221": {
@@ -1045,6 +1053,12 @@
       "ART 284"
     ]
   },
+  "ART 219": {
+    "text": "ART 218",
+    "courses": [
+      "ART 218"
+    ]
+  },
   "ART 231": {
     "text": "ART 121",
     "courses": [
@@ -1082,6 +1096,12 @@
     "courses": [
       "ART 121",
       "ART 131"
+    ]
+  },
+  "ART 246": {
+    "text": "ART 245",
+    "courses": [
+      "ART 245"
     ]
   },
   "ART 248": {
@@ -1679,10 +1699,10 @@
     ]
   },
   "AUT 181A": {
-    "text": "AUT 116 and AUT 181",
+    "text": "Take TRN-110 - Must be completed prior to taking this course; Take AUT-181 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "AUT 116",
-      "AUT 181"
+      "AUT 181",
+      "TRN 110"
     ]
   },
   "AUT 183": {
@@ -1710,9 +1730,10 @@
     ]
   },
   "AUT 221A": {
-    "text": "AUT 221",
+    "text": "TRN-110 - Must be completed prior to taking this course; Take AUT-221 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "AUT 221"
+      "AUT 221",
+      "TRN 110"
     ]
   },
   "AUT 231": {
@@ -2553,11 +2574,11 @@
     ]
   },
   "BPA 230A": {
-    "text": "CUL 110 and CUL 160 and BPA 230 and BPA 230 and CUL 110 and CUL 160",
+    "text": "Take All: CUL-110 and CUL-160 - Must be completed prior to taking this course; Take BPA-230 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "BPA 230",
       "CUL 110",
-      "CUL 160",
-      "BPA 230"
+      "CUL 160"
     ]
   },
   "BPA 240": {
@@ -2735,8 +2756,11 @@
     "courses": []
   },
   "BTB 103": {
-    "text": "Take BTB-102 - Must be taken either prior to or at the same time as this course.,<br>Take BTB-101 - Must be completed prior to taking this course.",
-    "courses": []
+    "text": "Take BTB-102 - Must be taken either prior to or at the same time as this course; Take BTB-101 - Must be completed prior to taking this course.",
+    "courses": [
+      "BTB 101",
+      "BTB 102"
+    ]
   },
   "BTB 106": {
     "text": "Take BTB-108 - Must be completed prior to taking this course.",
@@ -2763,6 +2787,18 @@
     "courses": [
       "ENG 002",
       "ENG 025"
+    ]
+  },
+  "BTC 182": {
+    "text": "BTC 181",
+    "courses": [
+      "BTC 181"
+    ]
+  },
+  "BTC 184": {
+    "text": "BTC 183",
+    "courses": [
+      "BTC 183"
     ]
   },
   "BTC 250": {
@@ -3060,6 +3096,12 @@
       "ECO 102"
     ]
   },
+  "CAR 111": {
+    "text": "MAT 003",
+    "courses": [
+      "MAT 003"
+    ]
+  },
   "CAR 111BB": {
     "text": "CAR 111AB",
     "courses": [
@@ -3086,9 +3128,10 @@
     ]
   },
   "CAR 113": {
-    "text": "CAR 111",
+    "text": "CAR 111 and CAR 112",
     "courses": [
-      "CAR 111"
+      "CAR 111",
+      "CAR 112"
     ]
   },
   "CAR 115": {
@@ -3155,10 +3198,12 @@
     ]
   },
   "CCT 289": {
-    "text": "CCT 231 or CCT 220",
+    "text": "Take CCT-250; - Must be taken either prior to or at the same time as this course; Take CCT-251 - Must be taken at the same time as this course; Take One: CCT-231 or CCT-220 - Must be completed prior to taking this course.",
     "courses": [
+      "CCT 220",
       "CCT 231",
-      "CCT 220"
+      "CCT 250",
+      "CCT 251"
     ]
   },
   "CEG 151": {
@@ -3394,9 +3439,17 @@
     ]
   },
   "CHM 130A": {
-    "text": "CHM 130",
+    "text": "Take DRE-098, ENG-002(with a minimum grade of P2), BSP-4002 (with a minimum grade of P2), RED-090, ENG-095, ENG-011, ENG-111 or ENG-025 - Must be completed prior to taking this course; Take CHM-130 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "CHM 130"
+      "BSP 4002",
+      "CHM 130",
+      "DRE 098",
+      "ENG 002",
+      "ENG 011",
+      "ENG 025",
+      "ENG 095",
+      "ENG 111",
+      "RED 090"
     ]
   },
   "CHM 131": {
@@ -4396,7 +4449,7 @@
     ]
   },
   "COS 125": {
-    "text": "COS 119 and COS 120 and COS 126",
+    "text": "Take COS-119 COS-120 - Must be completed prior to taking this course; Take COS-126 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "COS 119",
       "COS 120",
@@ -4410,8 +4463,9 @@
     ]
   },
   "COS 126": {
-    "text": "COS 120 and COS 125",
+    "text": "Take COS-119 COS-120 - Must be completed prior to taking this course; Take COS-125 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "COS 119",
       "COS 120",
       "COS 125"
     ]
@@ -4609,10 +4663,11 @@
     ]
   },
   "CSC 121": {
-    "text": "CIS 115 or CSC 120",
+    "text": "CTI 110 or MAT 171 or SGD 113",
     "courses": [
-      "CIS 115",
-      "CSC 120"
+      "CTI 110",
+      "MAT 171",
+      "SGD 113"
     ]
   },
   "CSC 122": {
@@ -5823,14 +5878,17 @@
     ]
   },
   "DEN 104": {
-    "text": "DEN 103",
+    "text": "Take DEN-101 DEN-111 - Must be completed prior to taking this course; Take DEN-106 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "DEN 103"
+      "DEN 101",
+      "DEN 106",
+      "DEN 111"
     ]
   },
   "DEN 105": {
-    "text": "DEN 106",
+    "text": "Take DEN-100 - Must be completed prior to taking this course; Take DEN-106 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "DEN 100",
       "DEN 106"
     ]
   },
@@ -5894,8 +5952,10 @@
     ]
   },
   "DEN 121": {
-    "text": "DEN 120",
+    "text": "Take DEN-110 and DEN-111 - Must be taken either prior to or at the same time as this course; Take DEN-120 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "DEN 110",
+      "DEN 111",
       "DEN 120"
     ]
   },
@@ -5959,12 +6019,12 @@
     ]
   },
   "DEN 222": {
-    "text": "BIO 163 or BIO 165 or BIO 168 and DEN 130",
+    "text": "Take DEN-110 - Must be completed prior to taking this course; Take One: BIO-163, BIO-165, or BIO-168 - Must be completed prior to taking this course.",
     "courses": [
       "BIO 163",
       "BIO 165",
       "BIO 168",
-      "DEN 130"
+      "DEN 110"
     ]
   },
   "DEN 223": {
@@ -6038,8 +6098,12 @@
     "courses": []
   },
   "DES 130": {
-    "text": "Take DES-110 DES-125 DES-135 - Must be completed prior to taking this course.",
-    "courses": []
+    "text": "ARC 111 and ARC 114 and ARC 114A",
+    "courses": [
+      "ARC 111",
+      "ARC 114",
+      "ARC 114A"
+    ]
   },
   "DES 135": {
     "text": "Take DES-110 DES-125 - Must be taken either prior to or at the same time as this course.",
@@ -6067,13 +6131,13 @@
     ]
   },
   "DES 220": {
-    "text": "DES 135 and ARC 111 and DES 110 and DFT 115 and ARC 114",
+    "text": "Take DES-125 - Must be completed prior to taking this course; Take One Set: Set 1: DES-135 and ARC-111 Set 2: DES-110 Set 3: DFT-115 - Must be completed prior to taking this course.",
     "courses": [
-      "DES 135",
       "ARC 111",
       "DES 110",
-      "DFT 115",
-      "ARC 114"
+      "DES 125",
+      "DES 135",
+      "DFT 115"
     ]
   },
   "DES 230": {
@@ -6147,11 +6211,11 @@
     ]
   },
   "DES 285": {
-    "text": "DES 230 and DES 240 and DES 210",
+    "text": "Take All: DES-230 and DES-240 - Must be completed prior to taking this course; Take DES-210 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "DES 210",
       "DES 230",
-      "DES 240",
-      "DES 210"
+      "DES 240"
     ]
   },
   "DFT 100": {
@@ -6221,6 +6285,12 @@
     "courses": [
       "DFT 151",
       "BPR 111"
+    ]
+  },
+  "DFT 170": {
+    "text": "MAT 171",
+    "courses": [
+      "MAT 171"
     ]
   },
   "DFT 231": {
@@ -6708,8 +6778,11 @@
     ]
   },
   "EDU 234A": {
-    "text": "Take EDU-119 - Must be completed prior to taking this course.,<br>Take EDU-234 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take EDU-119 - Must be completed prior to taking this course; Take EDU-234 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "EDU 119",
+      "EDU 234"
+    ]
   },
   "EDU 235": {
     "text": "EDU 119",
@@ -7115,7 +7188,7 @@
     ]
   },
   "EGR 225": {
-    "text": "EGR 220 and MAT 273",
+    "text": "Take EGR-220 - Must be completed prior to taking this course; Take MAT-273 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "EGR 220",
       "MAT 273"
@@ -7146,9 +7219,10 @@
     ]
   },
   "EGR 252": {
-    "text": "EGR 251",
+    "text": "Take MEC-145 - Must be completed prior to taking this course; Take EGR-251 - Must be completed prior to taking this course.",
     "courses": [
-      "EGR 251"
+      "EGR 251",
+      "MEC 145"
     ]
   },
   "EGR 285": {
@@ -8668,8 +8742,9 @@
     ]
   },
   "FVP 215": {
-    "text": "FVP 238 or FVP 240",
+    "text": "Take FVP-111 - Must be completed prior to taking this course; Take One: FVP-238 or FVP-240 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "FVP 111",
       "FVP 238",
       "FVP 240"
     ]
@@ -8725,10 +8800,18 @@
     ]
   },
   "GEL 113": {
-    "text": "GEL 111 or GEL 120",
+    "text": "Take DRE-098, ENG-002(with minimum grade of P2), BSP-4002 (with minimum grade of P2), RED-090, ENG-095, ENG-011, ENG-111 or ENG-025 - Must be completed prior to taking this course; Take One: GEL-111 or GEL-120 - Must be completed prior to taking this course.",
     "courses": [
+      "BSP 4002",
+      "DRE 098",
+      "ENG 002",
+      "ENG 011",
+      "ENG 025",
+      "ENG 095",
+      "ENG 111",
       "GEL 111",
-      "GEL 120"
+      "GEL 120",
+      "RED 090"
     ]
   },
   "GEL 230": {
@@ -9013,6 +9096,12 @@
       "ENG 002",
       "ENG 025",
       "ENG 111"
+    ]
+  },
+  "GRD 157": {
+    "text": "GRD 156",
+    "courses": [
+      "GRD 156"
     ]
   },
   "GRD 160": {
@@ -9324,8 +9413,9 @@
     ]
   },
   "HET 110": {
-    "text": "TRN 110",
+    "text": "Take TRN-110 - Must be completed prior to taking this course; Take MRN-121 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "MRN 121",
       "TRN 110"
     ]
   },
@@ -9398,17 +9488,21 @@
     ]
   },
   "HFS 210": {
-    "text": "HFS 110 and HFS 111",
+    "text": "Take BIO-168 or BIO-169 - Must be taken either prior to or at the same time as this course; Take PED-117 - Must be completed prior to taking this course; Take PED-118 - Must be taken either prior to or at the same time as this course; Take All: HFS-110 and HFS-111 - Must be completed prior to taking this course.",
     "courses": [
+      "BIO 168",
+      "BIO 169",
       "HFS 110",
-      "HFS 111"
+      "HFS 111",
+      "PED 117",
+      "PED 118"
     ]
   },
   "HFS 212": {
-    "text": "HFS 110 and HFS 111",
+    "text": "Take HFS-210 - Must be completed prior to taking this course; Take HFS-110 - Must be completed prior to taking this course.",
     "courses": [
       "HFS 110",
-      "HFS 111"
+      "HFS 210"
     ]
   },
   "HFS 218": {
@@ -9668,11 +9762,12 @@
     ]
   },
   "HMT 220": {
-    "text": "HMT 110 and ACC 120 and OST 138",
+    "text": "HMT 110 and ACC 120 and BUS 121 and HMT 210",
     "courses": [
       "HMT 110",
       "ACC 120",
-      "OST 138"
+      "BUS 121",
+      "HMT 210"
     ]
   },
   "HMT 225": {
@@ -12161,6 +12256,12 @@
       "MRI 270"
     ]
   },
+  "MRI 231BB": {
+    "text": "MRI 231AB",
+    "courses": [
+      "MRI 231AB"
+    ]
+  },
   "MRI 241": {
     "text": "MRI 214 and MRI 217 and MRI 260",
     "courses": [
@@ -12204,8 +12305,11 @@
     ]
   },
   "MRN 121": {
-    "text": "Take TRN-110 - Must be completed prior to taking this course.,<br>Take HET-110 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take TRN-110 - Must be completed prior to taking this course; Take HET-110 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "HET 110",
+      "TRN 110"
+    ]
   },
   "MRN 121BB": {
     "text": "MRN 121AB",
@@ -12251,8 +12355,12 @@
     "courses": []
   },
   "MSC 256": {
-    "text": "Take NET-125 MSC-152 - Must be completed prior to taking this course.,<br>Take MSC-254 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take NET-125 MSC-152 - Must be completed prior to taking this course; Take MSC-254 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "MSC 152",
+      "MSC 254",
+      "NET 125"
+    ]
   },
   "MSP 115": {
     "text": "MSP 110 (min C)",
@@ -12600,29 +12708,31 @@
     ]
   },
   "MUS 221": {
-    "text": "MUS 122",
+    "text": "Take MUS-225 - Must be taken at the same time as this course; Take MUS-122 - Must be completed prior to taking this course.",
     "courses": [
-      "MUS 122"
-    ]
-  },
-  "MUS 222": {
-    "text": "MUS 221",
-    "courses": [
-      "MUS 221"
-    ]
-  },
-  "MUS 225": {
-    "text": "MUS 126 and MUS 126 or MUS 225",
-    "courses": [
-      "MUS 126",
+      "MUS 122",
       "MUS 225"
     ]
   },
-  "MUS 226": {
-    "text": "MUS 225 and MUS 225 or MUS 226",
+  "MUS 222": {
+    "text": "Take MUS-226 - Must be taken at the same time as this course; Take MUS-221 - Must be completed prior to taking this course.",
     "courses": [
-      "MUS 225",
+      "MUS 221",
       "MUS 226"
+    ]
+  },
+  "MUS 225": {
+    "text": "Take MUS-221 - Must be taken at the same time as this course; Take MUS-126 - Must be completed prior to taking this course.",
+    "courses": [
+      "MUS 126",
+      "MUS 221"
+    ]
+  },
+  "MUS 226": {
+    "text": "Take MUS-222 - Must be taken at the same time as this course; Take MUS-225 - Must be completed prior to taking this course.",
+    "courses": [
+      "MUS 222",
+      "MUS 225"
     ]
   },
   "MUS 231": {
@@ -12662,12 +12772,16 @@
     ]
   },
   "MUS 237": {
-    "text": "Take MUS-138 - Must be completed prior to taking this course.",
-    "courses": []
+    "text": "MUS 138",
+    "courses": [
+      "MUS 138"
+    ]
   },
   "MUS 238": {
-    "text": "Take MUS-237 - Must be completed prior to taking this course.",
-    "courses": []
+    "text": "MUS 237",
+    "courses": [
+      "MUS 237"
+    ]
   },
   "MUS 241": {
     "text": "MUS 142",
@@ -13089,6 +13203,13 @@
       "NMT 132"
     ]
   },
+  "NMT 214": {
+    "text": "NMT 110 and NMT 126",
+    "courses": [
+      "NMT 110",
+      "NMT 126"
+    ]
+  },
   "NMT 215": {
     "text": "NMT 110",
     "courses": [
@@ -13100,6 +13221,12 @@
     "courses": [
       "NMT 110",
       "NMT 126"
+    ]
+  },
+  "NMT 218": {
+    "text": "NMT 132",
+    "courses": [
+      "NMT 132"
     ]
   },
   "NMT 221": {
@@ -13316,6 +13443,13 @@
       "NUR 103AB"
     ]
   },
+  "NUR 105": {
+    "text": "HSC 215A and HSC 216A",
+    "courses": [
+      "HSC 215A",
+      "HSC 216A"
+    ]
+  },
   "NUR 111": {
     "text": "PSY 150 and DRE 097 and ENG 002 and BSP 4002 and ENG 025 and ENG 111 and DMA 010 and DMA 020 and DMA 030 and MAT 003 and BSP 4003 and MAT 035 and BIO 169 (min C) and BIO 166 (min C)",
     "courses": [
@@ -13427,9 +13561,10 @@
     ]
   },
   "NUR 201": {
-    "text": "HSC 216 or NUR 131 and NUR 201C and NUR 231",
+    "text": "HSC 216 or NUR 102 or NUR 131 and NUR 201C and NUR 231",
     "courses": [
       "HSC 216",
+      "NUR 102",
       "NUR 131",
       "NUR 201C",
       "NUR 231"
@@ -13703,7 +13838,7 @@
     ]
   },
   "NUR 304A": {
-    "text": "NUR 305 and PSY 202 and NUR 304AC",
+    "text": "NUR 305 or PSY 202 and NUR 304AC",
     "courses": [
       "NUR 305",
       "PSY 202",
@@ -14080,6 +14215,14 @@
       "OST 164"
     ]
   },
+  "OST 181": {
+    "text": "OST 136 or OST 137 or OST 140",
+    "courses": [
+      "OST 136",
+      "OST 137",
+      "OST 140"
+    ]
+  },
   "OST 233": {
     "text": "OST 136",
     "courses": [
@@ -14132,21 +14275,23 @@
     ]
   },
   "OST 247": {
-    "text": "MED 121 or OST 141 and OST 148 and MED 122",
+    "text": "MED 121 or OST 141 and MED 122 or OST 142 and OST 148",
     "courses": [
       "MED 121",
       "OST 141",
-      "OST 148",
-      "MED 122"
+      "MED 122",
+      "OST 142",
+      "OST 148"
     ]
   },
   "OST 248": {
-    "text": "MED 121 or OST 141 and OST 148 and MED 122",
+    "text": "MED 121 or OST 141 and MED 122 and OST 148 and OST 248 and OST 248",
     "courses": [
       "MED 121",
       "OST 141",
+      "MED 122",
       "OST 148",
-      "MED 122"
+      "OST 248"
     ]
   },
   "OST 249": {
@@ -14159,10 +14304,11 @@
     ]
   },
   "OST 250": {
-    "text": "MED 121 or OST 141",
+    "text": "MED 121 or OST 141 and OST 148",
     "courses": [
       "MED 121",
-      "OST 141"
+      "OST 141",
+      "OST 148"
     ]
   },
   "OST 251": {
@@ -14237,26 +14383,37 @@
     ]
   },
   "OTA 110": {
-    "text": "BIO 165 or BIO 168 and ACA 122",
+    "text": "Take OTA-120 OTA-140 - Must be taken either prior to or at the same time as this course; Take One: BIO-165 or BIO-168 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "BIO 165",
       "BIO 168",
-      "ACA 122"
+      "OTA 120",
+      "OTA 140"
     ]
   },
   "OTA 120": {
-    "text": "OTA 110",
+    "text": "Take OTA-140 - Must be taken either prior to or at the same time as this course; Take OTA-110 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "OTA 110"
+      "OTA 110",
+      "OTA 140"
     ]
   },
   "OTA 130": {
-    "text": "OTA 110 and BIO 168 (min C) and OTA 120 (min C) and OTA 140 (min C)",
+    "text": "Take OTA-120 OTA-140 - Must be completed prior to taking this course; Take OTA-150 OTA-161 OTA-170 - Must be taken either prior to or at the same time as this course; Take OTA-110 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "OTA 110",
-      "BIO 168",
       "OTA 120",
-      "OTA 140"
+      "OTA 140",
+      "OTA 150",
+      "OTA 161",
+      "OTA 170"
+    ]
+  },
+  "OTA 130L": {
+    "text": "OTA 110 and OTA 130C",
+    "courses": [
+      "OTA 110",
+      "OTA 130C"
     ]
   },
   "OTA 135": {
@@ -14268,79 +14425,99 @@
     ]
   },
   "OTA 140": {
-    "text": "OTA 110",
+    "text": "Take OTA-120 - Must be taken either prior to or at the same time as this course; Take OTA-110 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "OTA 110"
+      "OTA 110",
+      "OTA 120"
     ]
   },
   "OTA 150": {
-    "text": "PSY 241 and OTA 170 and BIO 169 (min C) and OTA 130 (min C) and OTA 163",
+    "text": "Take OTA-110 OTA-120 OTA-140 - Must be completed prior to taking this course; Take OTA-130 OTA-161 - Must be taken either prior to or at the same time as this course; Take PSY-241 and OTA-170 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "PSY 241",
-      "OTA 170",
-      "BIO 169",
+      "OTA 110",
+      "OTA 120",
       "OTA 130",
-      "OTA 163"
+      "OTA 140",
+      "OTA 161",
+      "OTA 170",
+      "PSY 241"
     ]
   },
   "OTA 161": {
-    "text": "OTA 120 (min C) and OTA 140 (min C) and OTA 130 and OTA 180",
+    "text": "Take OTA-110 - Must be completed prior to taking this course; Take OTA-150 OTA-170 - Must be taken either prior to or at the same time as this course; Take OTA-120 and OTA-140 - Must be completed prior to taking this course.",
     "courses": [
+      "OTA 110",
       "OTA 120",
       "OTA 140",
-      "OTA 130",
-      "OTA 180"
+      "OTA 150",
+      "OTA 170"
     ]
   },
   "OTA 162": {
-    "text": "OTA 120 (min C) and OTA 140 (min C) and OTA 130 and OTA 250",
+    "text": "Take OTA-150 OTA-161 OTA-170 - Must be completed prior to taking this course; Take OTA-220 - Must be taken either prior to or at the same time as this course; Take OTA-120 and OTA-140 - Must be completed prior to taking this course; Take OTA-130 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "OTA 120",
-      "OTA 140",
       "OTA 130",
-      "OTA 250"
+      "OTA 140",
+      "OTA 150",
+      "OTA 161",
+      "OTA 170",
+      "OTA 220"
     ]
   },
   "OTA 163": {
-    "text": "OTA 120 (min C) and OTA 140 (min C) and OTA 130 and OTA 150",
+    "text": "Take OTA-220 - Must be completed prior to taking this course; Take OTA-180, OTA-240 and OTA-250 - Must be taken either prior to or at the same time as this course; Take OTA-120 and OTA-140 - Must be completed prior to taking this course; Take OTA-130 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "OTA 120",
-      "OTA 140",
       "OTA 130",
-      "OTA 150"
+      "OTA 140",
+      "OTA 180",
+      "OTA 220",
+      "OTA 240",
+      "OTA 250"
     ]
   },
   "OTA 170": {
-    "text": "OTA 130 and BIO 168 (min C) and BIO 169 (min C)",
+    "text": "Take OTA-110 OTA-120 OTA-140 - Must be completed prior to taking this course; Take OTA-150 OTA-161 - Must be taken either prior to or at the same time as this course; Take OTA-130 - Must be taken either prior to or at the same time as this course.",
     "courses": [
+      "OTA 110",
+      "OTA 120",
       "OTA 130",
-      "BIO 168",
-      "BIO 169"
-    ]
-  },
-  "OTA 180": {
-    "text": "PSY 281 and OTA 130 and ENG 112 (min C) and PSY 281 (min C) and OTA 161",
-    "courses": [
-      "PSY 281",
-      "OTA 130",
-      "ENG 112",
+      "OTA 140",
+      "OTA 150",
       "OTA 161"
     ]
   },
+  "OTA 180": {
+    "text": "Take OTA-220 - Must be completed prior to taking this course; Take OTA-163 OTA-240 OTA-250 - Must be taken either prior to or at the same time as this course; Take PSY-281 - Must be completed prior to taking this course; Take OTA-130 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "OTA 130",
+      "OTA 163",
+      "OTA 220",
+      "OTA 240",
+      "OTA 250",
+      "PSY 281"
+    ]
+  },
   "OTA 220": {
-    "text": "OTA 120 and OTA 130 and OTA 120 (min C) and OTA 130 (min C) and OTA 170 (min C)",
+    "text": "Take OTA-150 OTA-161 OTA-170 - Must be completed prior to taking this course; Take OTA-162 - Must be taken either prior to or at the same time as this course; Take OTA-120 and OTA-130 - Must be completed prior to taking this course.",
     "courses": [
       "OTA 120",
       "OTA 130",
+      "OTA 150",
+      "OTA 161",
+      "OTA 162",
       "OTA 170"
     ]
   },
   "OTA 240": {
-    "text": "OTA 140 and OTA 130 (min C) and OTA 140 (min C) and OTA 170 (min C)",
+    "text": "Take OTA-220 - Must be completed prior to taking this course; Take OTA-163 OTA-180 OTA-250 - Must be taken either prior to or at the same time as this course; Take OTA-140 - Must be completed prior to taking this course.",
     "courses": [
       "OTA 140",
-      "OTA 130",
-      "OTA 170"
+      "OTA 163",
+      "OTA 180",
+      "OTA 220",
+      "OTA 250"
     ]
   },
   "OTA 245": {
@@ -14350,13 +14527,14 @@
     ]
   },
   "OTA 250": {
-    "text": "PSY 241 and OTA 170 and OTA 180 and OTA 130 (min C) and OTA 162",
+    "text": "Take OTA-220 - Must be completed prior to taking this course; Take OTA-163 OTA-240 - Must be taken either prior to or at the same time as this course; Take PSY-241, OTA-170 and OTA-180 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "PSY 241",
+      "OTA 163",
       "OTA 170",
       "OTA 180",
-      "OTA 130",
-      "OTA 162"
+      "OTA 220",
+      "OTA 240",
+      "PSY 241"
     ]
   },
   "OTA 260": {
@@ -14474,6 +14652,84 @@
       "OTD 611",
       "OTD 615",
       "OTD 617"
+    ]
+  },
+  "OTD 640": {
+    "text": "OTD 630 and OTD 631 and OTD 635 and OTD 637",
+    "courses": [
+      "OTD 630",
+      "OTD 631",
+      "OTD 635",
+      "OTD 637"
+    ]
+  },
+  "OTD 641": {
+    "text": "OTD 630 and OTD 631 and OTD 635 and OTD 637",
+    "courses": [
+      "OTD 630",
+      "OTD 631",
+      "OTD 635",
+      "OTD 637"
+    ]
+  },
+  "OTD 642": {
+    "text": "OTD 630 and OTD 631 and OTD 635 and OTD 637",
+    "courses": [
+      "OTD 630",
+      "OTD 631",
+      "OTD 635",
+      "OTD 637"
+    ]
+  },
+  "OTD 648": {
+    "text": "OTD 630 and OTD 631 and OTD 635 and OTD 637",
+    "courses": [
+      "OTD 630",
+      "OTD 631",
+      "OTD 635",
+      "OTD 637"
+    ]
+  },
+  "OTD 653": {
+    "text": "OTD 640 and OTD 641 and OTD 642 and OTD 648",
+    "courses": [
+      "OTD 640",
+      "OTD 641",
+      "OTD 642",
+      "OTD 648"
+    ]
+  },
+  "OTD 655": {
+    "text": "OTD 640 and OTD 641 and OTD 642 and OTD 648",
+    "courses": [
+      "OTD 640",
+      "OTD 641",
+      "OTD 642",
+      "OTD 648"
+    ]
+  },
+  "OTD 658": {
+    "text": "OTD 640 and OTD 641 and OTD 642 and OTD 648",
+    "courses": [
+      "OTD 640",
+      "OTD 641",
+      "OTD 642",
+      "OTD 648"
+    ]
+  },
+  "OTD 659": {
+    "text": "OTD 640 and OTD 641 and OTD 642 and OTD 648",
+    "courses": [
+      "OTD 640",
+      "OTD 641",
+      "OTD 642",
+      "OTD 648"
+    ]
+  },
+  "OTD 672": {
+    "text": "OTD 624",
+    "courses": [
+      "OTD 624"
     ]
   },
   "PBT 100": {
@@ -14706,8 +14962,13 @@
     ]
   },
   "PHM 120": {
-    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course.,<br>Take PHM-118 PHM-136 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course; Take PHM-118 PHM-136 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "PHM 110",
+      "PHM 111",
+      "PHM 118",
+      "PHM 136"
+    ]
   },
   "PHM 125": {
     "text": "PHM 120 (min C) and DRE 097 and ENG 002 and BSP 4002 and ENG 111 and DMA 010 and DMA 020 and DMA 030 and MAT 003 and BSP 4003",
@@ -14741,8 +15002,13 @@
     ]
   },
   "PHM 136": {
-    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course.,<br>Take PHM-118 PHM-120 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take PHM-110 PHM-111; - Must be completed prior to taking this course; Take PHM-118 PHM-120 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "PHM 110",
+      "PHM 111",
+      "PHM 118",
+      "PHM 120"
+    ]
   },
   "PHM 140": {
     "text": "DRE 097 and ENG 002 and BSP 4002 and ENG 111 and DMA 010 and DMA 020 and DMA 030 and MAT 003 and BSP 4003",
@@ -15079,11 +15345,18 @@
     ]
   },
   "PHY 131": {
-    "text": "MAT 121 or MAT 171 and ENG 025",
+    "text": "Take DRE-098, ENG-002(with minimum grade of P2), BSP-4002 (with minimum grade of P2), RED-090, ENG-095, ENG-011, ENG-111 or ENG-025 - Must be completed prior to taking this course; Take One: MAT-121 or MAT-171 - Must be completed prior to taking this course.",
     "courses": [
+      "BSP 4002",
+      "DRE 098",
+      "ENG 002",
+      "ENG 011",
+      "ENG 025",
+      "ENG 095",
+      "ENG 111",
       "MAT 121",
       "MAT 171",
-      "ENG 025"
+      "RED 090"
     ]
   },
   "PHY 133": {
@@ -15250,6 +15523,18 @@
     "courses": [
       "BIO 163",
       "MED 121"
+    ]
+  },
+  "PSG 110C": {
+    "text": "PSG 110L",
+    "courses": [
+      "PSG 110L"
+    ]
+  },
+  "PSG 110L": {
+    "text": "PSG 110C",
+    "courses": [
+      "PSG 110C"
     ]
   },
   "PSG 111": {
@@ -16549,6 +16834,13 @@
     ]
   },
   "SEC 150": {
+    "text": "NET 125 and SEC 110",
+    "courses": [
+      "NET 125",
+      "SEC 110"
+    ]
+  },
+  "SEC 151": {
     "text": "SEC 110",
     "courses": [
       "SEC 110"
@@ -17245,16 +17537,17 @@
     ]
   },
   "SPA 281": {
-    "text": "SPA 182 (min C) and SPA 211",
+    "text": "TAKE SPA-182 - Must be completed prior to taking this course; Take SPA-211 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "SPA 182",
       "SPA 211"
     ]
   },
   "SPA 282": {
-    "text": "SPA 212",
+    "text": "Take SPA-281 - Must be completed prior to taking this course; Take SPA-212 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "SPA 212"
+      "SPA 212",
+      "SPA 281"
     ]
   },
   "SPE 216": {
@@ -17678,8 +17971,11 @@
     ]
   },
   "SUR 134": {
-    "text": "SUR 123 and SUR 123AB and SUR 123BB and SUR 135",
+    "text": "Take SUR-123AB SUR-123BB - Must be completed prior to taking this course; SUR-135 BIO-175 MAT-110 OR MAT-143 - Must be taken at the same time as this course; Take SUR-123 - Must be completed prior to taking this course.",
     "courses": [
+      "BIO 175",
+      "MAT 110",
+      "MAT 143",
       "SUR 123",
       "SUR 123AB",
       "SUR 123BB",
@@ -17687,20 +17983,26 @@
     ]
   },
   "SUR 135": {
-    "text": "SUR 123 and SUR 134 and BIO 275 and SUR 122",
+    "text": "SUR-123AB SUR-123BB - Must be completed prior to taking this course; Take SUR-123 - Must be completed prior to taking this course; Take SUR-134 - Must be taken either prior to or at the same time as this course.",
     "courses": [
       "SUR 123",
-      "SUR 134",
-      "BIO 275",
-      "SUR 122"
+      "SUR 123AB",
+      "SUR 123BB",
+      "SUR 134"
     ]
   },
   "SUR 137": {
-    "text": "SUR 123 and SUR 134 and SUR 135",
+    "text": "Take SUR-123AB, SUR-123BB, SUR-134, and SUR-135 - Must be completed prior to taking this course; Take SUR-211 SUR-210 ENG-114 COM-120 PSY-150 - Must be taken either prior to or at the same time as this course.",
     "courses": [
-      "SUR 123",
+      "COM 120",
+      "ENG 114",
+      "PSY 150",
+      "SUR 123AB",
+      "SUR 123BB",
       "SUR 134",
-      "SUR 135"
+      "SUR 135",
+      "SUR 210",
+      "SUR 211"
     ]
   },
   "SUR 210": {
@@ -17908,9 +18210,10 @@
     ]
   },
   "TRN 145": {
-    "text": "TRN 120",
+    "text": "TRN 120 and AUT 181",
     "courses": [
-      "TRN 120"
+      "TRN 120",
+      "AUT 181"
     ]
   },
   "TRN 145A": {
@@ -18120,8 +18423,11 @@
     ]
   },
   "VET 220": {
-    "text": "Take VET-132 - Must be completed prior to taking this course.,<br>Take VET-213 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take VET-132 - Must be completed prior to taking this course; Take VET-213 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "VET 132",
+      "VET 213"
+    ]
   },
   "VET 237": {
     "text": "CHM 130 and CHM 130A",
@@ -18654,8 +18960,22 @@
     ]
   },
   "WBL 115U": {
-    "text": "Take HSE-110 SAB-110 HSE-112 HSE-123 HSE-125 SAB-120 - Must be completed prior to taking this course.,<br>Take WBL-111U SAB-135 SAB-240 - Must be taken either prior to or at the same time as this course.,<br>Take One: WBL-111, WBL-112, WBL-113 or WBL-114 - Must be taken either prior to or at the same time as this course.",
-    "courses": []
+    "text": "Take HSE-110 SAB-110 HSE-112 HSE-123 HSE-125 SAB-120 - Must be completed prior to taking this course; Take WBL-111U SAB-135 SAB-240 - Must be taken either prior to or at the same time as this course; Take One: WBL-111, WBL-112, WBL-113 or WBL-114 - Must be taken either prior to or at the same time as this course.",
+    "courses": [
+      "HSE 110",
+      "HSE 112",
+      "HSE 123",
+      "HSE 125",
+      "SAB 110",
+      "SAB 120",
+      "SAB 135",
+      "SAB 240",
+      "WBL 111",
+      "WBL 111U",
+      "WBL 112",
+      "WBL 113",
+      "WBL 114"
+    ]
   },
   "WBL 115V": {
     "text": "WBL 111 or WBL 112 or WBL 113 or WBL 114",
@@ -18708,6 +19028,14 @@
     "text": "WBL 111",
     "courses": [
       "WBL 111"
+    ]
+  },
+  "WBL 122": {
+    "text": "WBL 111 or WBL 112 or WBL 113",
+    "courses": [
+      "WBL 111",
+      "WBL 112",
+      "WBL 113"
     ]
   },
   "WBL 123": {

--- a/data/ny/prereqs.json
+++ b/data/ny/prereqs.json
@@ -320,11 +320,8 @@
     ]
   },
   "ACC 1100": {
-    "text": "<p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5jChangeinPrereq-ACC1100-FundamentalsofAccountingI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5jChangeinPrereq-ACC1100-FundamentalsofAccountingI.pdf</a></p>",
-    "courses": [
-      "FALL 2023",
-      "FEB 2024"
-    ]
+    "text": "Explanation : The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5jChangeinPrereq-ACC1100-FundamentalsofAccountingI.pdf",
+    "courses": []
   },
   "ACC 111": {
     "text": "Successful completion (DVP) of MAT 020 or successful completion (DVP) of MAT 040 or placement into MAT 092 or higher",
@@ -477,25 +474,25 @@
     ]
   },
   "ACC 360": {
-    "text": "<p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Government &amp; Not-for-Profit Accounting course content. </p>",
+    "text": "This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Government & Not-for-Profit Accounting course content",
     "courses": [
       "ACC 122",
       "ACC 222"
     ]
   },
   "ACC 370": {
-    "text": "<p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Forensic Accounting &amp; Fraud Analysis course content. </p>",
+    "text": "This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Forensic Accounting & Fraud Analysis course content",
     "courses": [
       "ACC 122",
       "ACC 222"
     ]
   },
   "ACCT 223": {
-    "text": "<p>5/31/24 - Per Central, even if the Pre-Requisites / Co-Requisites is in CD. The Enrollment Requirement Group needs to be inputted in CD because this field maps with CUNYfirst. Requirement was approved on March'23 AUR.</p>",
+    "text": "5/31/24 - Per Central, even if the Pre-Requisites / Co-Requisites is in CD. The Enrollment Requirement Group needs to be inputted in CD because this field maps with CUNYfirst. Requirement was approved on March'23 AUR",
     "courses": []
   },
   "ACL 215": {
-    "text": "<p>This change is prerequisite will make sure that students are more adequately prepared for the writing required for this course. </p>",
+    "text": "This change is prerequisite will make sure that students are more adequately prepared for the writing required for this course",
     "courses": []
   },
   "ACL 225": {
@@ -1305,7 +1302,7 @@
     ]
   },
   "AMST 203": {
-    "text": "<p>Updated eff term, hrs., pre-requisite, department, workload hrs.</p><p>6/25/25:1st time- change made for registration purposes.&nbsp;</p>",
+    "text": "Updated eff term, hrs., pre-requisite, department, workload hrs; 6/25/25:1st time- change made for registration purposes",
     "courses": []
   },
   "AMT 106": {
@@ -2197,7 +2194,7 @@
     ]
   },
   "ART 233": {
-    "text": "<p>This revision removes ART 101 from the list of prerequisites, as it is not an appropriate prerequisite for a photography course. </p>",
+    "text": "This revision removes ART 101 from the list of prerequisites, as it is not an appropriate prerequisite for a photography course",
     "courses": [
       "ART 101"
     ]
@@ -2517,7 +2514,7 @@
     ]
   },
   "ARTS 243": {
-    "text": "<p>This elective course will be popular with students in Digital Art (DAD) and Art AS programs. Since DAD only has only 5 elective credits, removing the burden of a prerequisite will allow students to take the course and fit it into their schedules.</p>",
+    "text": "This elective course will be popular with students in Digital Art (DAD) and Art AS programs. Since DAD only has only 5 elective credits, removing the burden of a prerequisite will allow students to take the course and fit it into their schedules",
     "courses": []
   },
   "ARTS 252": {
@@ -3547,13 +3544,13 @@
     ]
   },
   "BIO 46": {
-    "text": "<p><strong>This minor change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course.&nbsp; Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.</strong></p><p>&nbsp;</p>",
+    "text": "This minor change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course. Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.",
     "courses": [
       "BIO 18"
     ]
   },
   "BIO 47": {
-    "text": "<p><strong>This change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course.&nbsp; Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.</strong></p>",
+    "text": "This change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course. Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.",
     "courses": [
       "BIO 18"
     ]
@@ -3604,7 +3601,7 @@
     ]
   },
   "BIOL 211": {
-    "text": "<p>11/7/24 - Added Pre-requisite &amp; Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre &amp; co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023.</p><table><tbody><tr><td><p>8/16/24 - Repeat fields changed back to original settings. </p><p></p></td></tr></tbody></table><p>8/27/24: change made for registration purposes</p><p>8/27/24: change made to reflect original set up after the registration.</p><p>1/21/25: change made for registration purposes</p>",
+    "text": "11/7/24 - Added Pre-requisite & Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre & co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023; 8/16/24 - Repeat fields changed back to original settings; 8/27/24: change made for registration purposes; 8/27/24: change made to reflect original set up after the registration; 1/21/25: change made for registration purposes",
     "courses": []
   },
   "BIOL 221": {
@@ -3634,17 +3631,17 @@
     "courses": []
   },
   "BIS 13": {
-    "text": "<table><tbody><tr><td><p><strong>Rationale: This moves the KEY 10 prerequisite to become a corequisite and to create a uniform verbiage for all new and revised courses in the Department.</strong></p></td></tr></tbody></table>",
+    "text": "Rationale: This moves the KEY 10 prerequisite to become a corequisite and to create a uniform verbiage for all new and revised courses in the Department.",
     "courses": [
       "KEY 10"
     ]
   },
   "BIS 23": {
-    "text": "<p><strong>Rationale: This change to the prerequisite is designed to eliminate unnecessary and redundant prerequisites from prior courses in the degree and to create a uniform verbiage for all new and revised courses in the Department.</strong></p>",
+    "text": "Rationale: This change to the prerequisite is designed to eliminate unnecessary and redundant prerequisites from prior courses in the degree and to create a uniform verbiage for all new and revised courses in the Department.",
     "courses": []
   },
   "BIS 31": {
-    "text": "<p><strong> This change to the prerequisite is designed to update for currently offered courses and to create a uniform verbiage for all new and revised courses in the Department.</strong></p>",
+    "text": "This change to the prerequisite is designed to update for currently offered courses and to create a uniform verbiage for all new and revised courses in the Department.",
     "courses": []
   },
   "BIT 101": {
@@ -3760,7 +3757,7 @@
     ]
   },
   "BLS 150W": {
-    "text": "<p>Writing-Intensive iteration.</p><p>Minimum English Pre/Co-Requisite of ENG 100 added.</p>",
+    "text": "Writing-Intensive iteration; Minimum English Pre/Co-Requisite of ENG 100 added",
     "courses": [
       "ENG 100"
     ]
@@ -4326,8 +4323,10 @@
     ]
   },
   "BUS 21": {
-    "text": "<p>The Department of Business and Information Systems is proposing a revision and restoration of BUS 21, Small Business Management, to its current offerings.&nbsp; The importance of small businesses and entrepreneurship in our global and national economies cannot be overstated.&nbsp; The restoration of BUS 21 will provide students with valuable academic and practical knowledge.&nbsp; This knowledge can serve to help them in the transfer to a senior college or if they desire to pursue a small business career after completing their associate degree.&nbsp; The revision of the course prerequisites will allow students in their second semester to enroll in BUS 21.&nbsp; This revised course is separately proposed for inclusion in the Business Administration AS degree in the Management and Marketing options.</p>",
-    "courses": []
+    "text": "The Department of Business and Information Systems is proposing a revision and restoration of BUS 21, Small Business Management, to its current offerings. The importance of small businesses and entrepreneurship in our global and national economies cannot be overstated. The restoration of BUS 21 will provide students with valuable academic and practical knowledge. This knowledge can serve to help them in the transfer to a senior college or if they desire to pursue a small business career after completing their associate degree. The revision of the course prerequisites will allow students in their second semester to enroll in BUS 21. This revised course is separately proposed for inclusion in the Business Administration AS degree in the Management and Marketing options",
+    "courses": [
+      "BUS 21"
+    ]
   },
   "BUS 210": {
     "text": "ENG 101",
@@ -4494,8 +4493,10 @@
     "courses": []
   },
   "BUS 54": {
-    "text": "<p>The prerequisite for BUS 54 is being modified to allow students in the new AAS degree in Entrepreneurship and Small Business Management to enroll in this course.&nbsp; The description is being modified to provide students with a clearer understanding of Entrepreneurship and what will be covered in this class.&nbsp; This change will not affect the transferability of this course to any other CUNY senior college.&nbsp;</p>",
-    "courses": []
+    "text": "The prerequisite for BUS 54 is being modified to allow students in the new AAS degree in Entrepreneurship and Small Business Management to enroll in this course. The description is being modified to provide students with a clearer understanding of Entrepreneurship and what will be covered in this class. This change will not affect the transferability of this course to any other CUNY senior college.",
+    "courses": [
+      "BUS 54"
+    ]
   },
   "BUSI 212": {
     "text": "ENGL 103/A, BUSI 102",
@@ -5144,7 +5145,7 @@
     ]
   },
   "CH 900": {
-    "text": "<p>The course description is outdated, and it has been updated to provide more details. Additionally, requiring a full year of chemistry as a prerequisite is not necessary for most co-op sponsors we have worked with. Also, permitting students to participate only after taking General Chemistry II may prevent strong students from participating in available internship opportunities before they graduate.</p>",
+    "text": "The course description is outdated, and it has been updated to provide more details. Additionally, requiring a full year of chemistry as a prerequisite is not necessary for most co-op sponsors we have worked with. Also, permitting students to participate only after taking General Chemistry II may prevent strong students from participating in available internship opportunities before they graduate",
     "courses": []
   },
   "CH 901": {
@@ -5376,7 +5377,7 @@
     ]
   },
   "CHEM 120": {
-    "text": "<p>Correct description format and removed pre-requisites as they were approved in Jan/Feb 2023 CAPPR. This was changed on 4/5/23 in Cf, but somehow did not reflect in Cf or CD when posted in April.</p>",
+    "text": "Correct description format and removed pre-requisites as they were approved in Jan/Feb 2023 CAPPR. This was changed on 4/5/23 in Cf, but somehow did not reflect in Cf or CD when posted in April",
     "courses": []
   },
   "CHEM 201": {
@@ -5392,7 +5393,7 @@
     ]
   },
   "CHEM 211": {
-    "text": "<p>Added Pre-requisite &amp; Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre &amp; co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023.</p>",
+    "text": "Added Pre-requisite & Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre & co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023",
     "courses": []
   },
   "CHINS 102": {
@@ -5454,9 +5455,10 @@
     ]
   },
   "CHM 11": {
-    "text": "<p><strong>Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 11. In an attempt to compensate somewhat for the loss of CHM 02, we propose adding one hour of instruction to CHM 11, consistent with the structure at Hostos, BMCC, Queensborough and Guttman. Note that the prerequisite math requirement for CHM 11 was increased last year from MTH 05 to MTH 06/28/28.5, which is consistent with peer CUNY community colleges. This change should result in mathematically better-prepared students in CHM 11.</strong></p>",
+    "text": "Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 11. In an attempt to compensate somewhat for the loss of CHM 02, we propose adding one hour of instruction to CHM 11, consistent with the structure at Hostos, BMCC, Queensborough and Guttman. Note that the prerequisite math requirement for CHM 11 was increased last year from MTH 05 to MTH 06/28/28.5, which is consistent with peer CUNY community colleges. This change should result in mathematically better-prepared students in CHM 11.",
     "courses": [
       "CHM 02",
+      "CHM 11",
       "MTH 05",
       "MTH 06"
     ]
@@ -5511,9 +5513,10 @@
     ]
   },
   "CHM 17": {
-    "text": "<p><strong>Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 17. In an attempt to compensate somewhat for the loss of CHM 02, the course has been revised to dedicate slightly more time to basic topics during lecture and lab hours.</strong></p>",
+    "text": "Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 17. In an attempt to compensate somewhat for the loss of CHM 02, the course has been revised to dedicate slightly more time to basic topics during lecture and lab hours.",
     "courses": [
-      "CHM 02"
+      "CHM 02",
+      "CHM 17"
     ]
   },
   "CHM 201": {
@@ -5632,11 +5635,10 @@
     ]
   },
   "CIS 1200": {
-    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required. </p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5l.%20Change%20in%20Prereq%20-%20CIS%201200%20-Introduction%20to%20Operating%20Systems.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5l. Change in Prereq - CIS 1200 -Introduction to Operating Systems</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5lChangeinPrereq-CIS1200-IntroductiontoOperatingSystems.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5lChangeinPrereq-CIS1200-IntroductiontoOperatingSystems.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "text": "Explanation : Decision of faculty committee has determined that a passing grade in CP 500 is required; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5l. Change in Prereq - CIS 1200 -Introduction to Operating Systems ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5lChangeinPrereq-CIS1200-IntroductiontoOperatingSystems.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)",
     "courses": [
-      "CP 500",
-      "FALL 2024",
-      "FEB 2025"
+      "CIS 1200",
+      "CP 500"
     ]
   },
   "CIS 123": {
@@ -5789,12 +5791,10 @@
     ]
   },
   "CIS 2100": {
-    "text": "<p><u>5/19/2025:</u> Requisite from JAN 2025 attached to course.</p><p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5m.%20Change%20in%20Prereq%20-%20CIS%202100%20-%20Introduction%20to%20Web%20Page%20Development.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5m. Change in Prereq - CIS 2100 - Introduction to Web Page Development</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5mChangeinPrereq-CIS2100-IntroductiontoWebPageDevelopment.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5mChangeinPrereq-CIS2100-IntroductiontoWebPageDevelopment.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "text": "5/19/2025: Requisite from JAN 2025 attached to course; Explanation : Decision of faculty committee has determined that a passing grade in CP 500 is required; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5m. Change in Prereq - CIS 2100 - Introduction to Web Page Development ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5mChangeinPrereq-CIS2100-IntroductiontoWebPageDevelopment.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)",
     "courses": [
-      "CP 500",
-      "FALL 2024",
-      "FEB 2025",
-      "JAN 2025"
+      "CIS 2100",
+      "CP 500"
     ]
   },
   "CIS 211": {
@@ -6009,11 +6009,10 @@
     ]
   },
   "CIS 3100": {
-    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5n.%20Change%20in%20Prereq%20-%20CIS%203100%20-%20Introduction%20to%20Database.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5n. Change in Prereq - CIS 3100 - Introduction to Database</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5nChangeinPrereq-CIS3100-IntroductiontoDatabase.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5nChangeinPrereq-CIS3100-IntroductiontoDatabase.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "text": "Explanation : Decision of faculty committee has determined that a passing grade in CP 500 is required; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5n. Change in Prereq - CIS 3100 - Introduction to Database ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5nChangeinPrereq-CIS3100-IntroductiontoDatabase.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)",
     "courses": [
-      "CP 500",
-      "FALL 2024",
-      "FEB 2025"
+      "CIS 3100",
+      "CP 500"
     ]
   },
   "CIT 100": {
@@ -6350,8 +6349,9 @@
     ]
   },
   "CLE 11": {
-    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "text": "The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program",
     "courses": [
+      "CLE 11",
       "MTH 13",
       "MTH 28",
       "RAD 12",
@@ -6359,7 +6359,7 @@
     ]
   },
   "CLE 51": {
-    "text": "<p>Change in Prerequisites</p>",
+    "text": "Change in Prerequisites",
     "courses": []
   },
   "CLT 200L": {
@@ -7040,9 +7040,10 @@
     "courses": []
   },
   "COM 31": {
-    "text": "<p><strong>Rationale:</strong> The prerequisites, description and content of COM 31 are being modified to bring this course into equivalence with Baruch’s COM 2020 and allow students to receive transfer credit at Baruch.&nbsp; This change will not affect the transferability of this course to any other CUNY senior college.&nbsp;</p>",
+    "text": "Rationale: The prerequisites, description and content of COM 31 are being modified to bring this course into equivalence with Baruch’s COM 2020 and allow students to receive transfer credit at Baruch. This change will not affect the transferability of this course to any other CUNY senior college.",
     "courses": [
-      "COM 2020"
+      "COM 2020",
+      "COM 31"
     ]
   },
   "COMM 101H": {
@@ -7234,13 +7235,12 @@
     ]
   },
   "CP 2100": {
-    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5o.%20Change%20in%20Prereq%20-%20CP%202100%20-%20C%2B%2B%20Programming%201.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5o. Change in Prereq - CP 2100 - C++ Programming 1</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5oChangeinPrereq-CP2100-CplusplusProgramming1.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5oChangeinPrereq-CP2100-CplusplusProgramming1.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p><p>Amanda Kalin7/27 10:32 AM&nbsp;</p><table><tbody><tr><td><p><strong>Listed in Course Dog &amp; CUNYFirst</strong></p></td><td><p><strong>Correction</strong></p></td></tr><tr><td><p>CP 2100 - C Programming I</p></td><td><p>CP 2100 - C<strong>++ </strong>Programming I</p></td></tr><tr><td><p>CP 2200 - &nbsp;C Programming II</p></td><td><p>CP 2200 - &nbsp;C<strong>++</strong> Programming II</p></td></tr><tr><td><p>ACC 1100 - Fundamentals of Accounting&nbsp;</p></td><td><p>ACC 1100 - Fundamentals of Accounting <strong>I</strong></p></td></tr></tbody></table>",
+    "text": "Explanation : Decision of faculty committee has determined that a passing grade in CP 500 is required; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5o. Change in Prereq - CP 2100 - C++ Programming 1 ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5oChangeinPrereq-CP2100-CplusplusProgramming1.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed); Amanda Kalin7/27 10:32 AM Listed in Course Dog & CUNYFirst ; Correction; CP 2100 - C Programming I; CP 2100 - C ++ Programming I; CP 2200 - C Programming II; CP 2200 - C ++ Programming II; ACC 1100 - Fundamentals of Accounting ACC 1100 - Fundamentals of Accounting I",
     "courses": [
       "ACC 1100",
+      "CP 2100",
       "CP 2200",
-      "CP 500",
-      "FALL 2024",
-      "FEB 2025"
+      "CP 500"
     ]
   },
   "CP 212": {
@@ -7332,18 +7332,16 @@
     ]
   },
   "CP 500": {
-    "text": "<p><u>Explanation</u>: The change in prerequisite and pre-/co-requisite reflect the introduction of the ACCUPLACER mathematics exam and removal of MAT R300, which is no longer offered. </p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5j.%20Change%20in%20Pre%20and%20Pre-Co%20Req%20-%20CP%20500%20-%20Introduction%20to%20Computer%20Programming.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5j. Change in Pre and Pre-Co Req - CP 500 - Introduction to Computer Programming</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5jChangeinPreandPre-CoReq-CP500-IntroductiontoComputerProgramming.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5jChangeinPreandPre-CoReq-CP500-IntroductiontoComputerProgramming.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "text": "Explanation : The change in prerequisite and pre-/co-requisite reflect the introduction of the ACCUPLACER mathematics exam and removal of MAT R300, which is no longer offered; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5j. Change in Pre and Pre-Co Req - CP 500 - Introduction to Computer Programming ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5jChangeinPreandPre-CoReq-CP500-IntroductiontoComputerProgramming.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)",
     "courses": [
-      "FALL 2024",
-      "FEB 2025"
+      "CP 500"
     ]
   },
   "CP 6200": {
-    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5p.%20Change%20in%20Prereq%20-%20CP%206200%20-%20Java%20Programming%202.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5p. Change in Prereq - CP 6200 - Java Programming 2</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5pChangeinPrereq-CP6200-JavaProgramming2.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5pChangeinPrereq-CP6200-JavaProgramming2.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "text": "Explanation : Decision of faculty committee has determined that a passing grade in CP 500 is required; CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR; 5p. Change in Prereq - CP 6200 - Java Programming 2 ; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5pChangeinPrereq-CP6200-JavaProgramming2.pdf ; 11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)",
     "courses": [
       "CP 500",
-      "FALL 2024",
-      "FEB 2025"
+      "CP 6200"
     ]
   },
   "CPS 142": {
@@ -7593,11 +7591,11 @@
     ]
   },
   "CRT 100": {
-    "text": "<p>Need to update prereq</p>",
+    "text": "Need to update prereq",
     "courses": []
   },
   "CRT 100.6": {
-    "text": "<p>ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central.</p>",
+    "text": "ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central",
     "courses": []
   },
   "CRT 101": {
@@ -7802,7 +7800,7 @@
     ]
   },
   "CSC 203": {
-    "text": "<p>This change lowers the prerequisite to precalculus makes the course more accessible to a broader range of students, encouraging participation from those interested in data science but who may not have completed calculus yet. The course focuses on programming and data analysis concepts that rely more on algebraic reasoning and basic mathematical logic rather than advanced calculus, making precalculus a sufficient foundation. </p>",
+    "text": "This change lowers the prerequisite to precalculus makes the course more accessible to a broader range of students, encouraging participation from those interested in data science but who may not have completed calculus yet. The course focuses on programming and data analysis concepts that rely more on algebraic reasoning and basic mathematical logic rather than advanced calculus, making precalculus a sufficient foundation",
     "courses": []
   },
   "CSC 204": {
@@ -7876,20 +7874,22 @@
     ]
   },
   "CSC 275": {
-    "text": "<table><tbody><tr><td><p>CSC 275 is a continuation of CSC 215. CSC 215 cannot be a corequisite course.</p></td></tr></tbody></table><p>Added the Major Gateway Course Attribute(s)</p>",
-    "courses": [
-      "CSC 215"
-    ]
-  },
-  "CSC 300": {
-    "text": "<p>Updating Prerequisite since CSC 275 is a continuation of CSC 215, and CSC 300 requires strong mathematical understanding.</p><p>Added the Major Gateway Course Attribute(s)</p>",
+    "text": "CSC 275 is a continuation of CSC 215. CSC 215 cannot be a corequisite course; Added the Major Gateway Course Attribute(s)",
     "courses": [
       "CSC 215",
       "CSC 275"
     ]
   },
+  "CSC 300": {
+    "text": "Updating Prerequisite since CSC 275 is a continuation of CSC 215, and CSC 300 requires strong mathematical understanding; Added the Major Gateway Course Attribute(s)",
+    "courses": [
+      "CSC 215",
+      "CSC 275",
+      "CSC 300"
+    ]
+  },
   "CSN 100": {
-    "text": "<p>Update prerequisites</p>",
+    "text": "Update prerequisites",
     "courses": []
   },
   "CSP 127": {
@@ -8438,7 +8438,7 @@
     ]
   },
   "CWE 31": {
-    "text": "<p><strong>This minor change to the prerequisite is designed to create a uniform verbiage for all new and revised courses in the Department and to allow student in the newly approved AS in Accounting and AS in Marketing to enroll in this required course.</strong></p>",
+    "text": "This minor change to the prerequisite is designed to create a uniform verbiage for all new and revised courses in the Department and to allow student in the newly approved AS in Accounting and AS in Marketing to enroll in this required course.",
     "courses": []
   },
   "CWE 41": {
@@ -8867,11 +8867,11 @@
     ]
   },
   "DAT 33": {
-    "text": "<p>Update Pre-requities</p>",
+    "text": "Update Pre-requities",
     "courses": []
   },
   "DAT 49": {
-    "text": "<p>Change in Prereqs</p>",
+    "text": "Change in Prereqs",
     "courses": []
   },
   "DD 108": {
@@ -9621,18 +9621,12 @@
     ]
   },
   "ECO 1200": {
-    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5kChangeinPrereq-ECO1200-Macroeconomics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5kChangeinPrereq-ECO1200-Macroeconomics.pdf</a></p>",
-    "courses": [
-      "FALL 2023",
-      "FEB 2024"
-    ]
+    "text": "5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo); Explanation : The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5kChangeinPrereq-ECO1200-Macroeconomics.pdf",
+    "courses": []
   },
   "ECO 1300": {
-    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p></p><p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5lChangeinPrereq-ECO1300-Microeconomics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5lChangeinPrereq-ECO1300-Microeconomics.pdf</a></p>",
-    "courses": [
-      "FALL 2023",
-      "FEB 2024"
-    ]
+    "text": "5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo); Explanation : The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5lChangeinPrereq-ECO1300-Microeconomics.pdf",
+    "courses": []
   },
   "ECO 171": {
     "text": "MAT 100 or high school Mathematics Course II or by advisement",
@@ -9793,7 +9787,7 @@
     ]
   },
   "EDS 202": {
-    "text": "<p>update prereq</p>",
+    "text": "update prereq",
     "courses": []
   },
   "EDU 101": {
@@ -9833,7 +9827,7 @@
     ]
   },
   "EDU 16": {
-    "text": "<p>Improved shortening/change in prereqs</p>",
+    "text": "Improved shortening/change in prereqs",
     "courses": []
   },
   "EDU 19": {
@@ -9941,23 +9935,25 @@
     ]
   },
   "EDU 30": {
-    "text": "<p><strong>Updating course pre and corequisites to align with current department advising practices. &nbsp;As EDU 10 is the gateway course for early childhood and childhood education, so is EDU 70 the gateway course for Liberal Arts – Secondary Education option.</strong></p>",
+    "text": "Updating course pre and corequisites to align with current department advising practices. As EDU 10 is the gateway course for early childhood and childhood education, so is EDU 70 the gateway course for Liberal Arts – Secondary Education option.",
     "courses": [
       "EDU 10",
       "EDU 70"
     ]
   },
   "EDU 70": {
-    "text": "<p><strong>Rationale: Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the first semester.&nbsp; EDU 70, like EDU 10, should be a first semester course introducing students to the fundamental theories and practices for secondary education.</strong></p>",
+    "text": "Rationale: Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the first semester. EDU 70, like EDU 10, should be a first semester course introducing students to the fundamental theories and practices for secondary education.",
     "courses": [
-      "EDU 10"
+      "EDU 10",
+      "EDU 70"
     ]
   },
   "EDU 71": {
-    "text": "<p><strong>Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the second semester. Just as EDU 12 can be taken with EDU 10, or can be taken prior to EDU 10, or as a stand alone elective, EDU 71 should be available to students who need to take both courses at the same time, in the cases of transfer, change of curriculum, or for paraprofessional certification.</strong></p>",
+    "text": "Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the second semester. Just as EDU 12 can be taken with EDU 10, or can be taken prior to EDU 10, or as a stand alone elective, EDU 71 should be available to students who need to take both courses at the same time, in the cases of transfer, change of curriculum, or for paraprofessional certification.",
     "courses": [
       "EDU 10",
-      "EDU 12"
+      "EDU 12",
+      "EDU 71"
     ]
   },
   "EDUC 101": {
@@ -9975,7 +9971,7 @@
     ]
   },
   "EDUC 222": {
-    "text": "<table><tbody><tr><td><p>The College proposes removing the pre-requisite that students must be LAS-SSE majors in order to enroll in the course. We hope that opening Education courses to students in other programs allows more students who might be interested in teaching to take a Gateway course in education while attending community college. </p></td></tr></tbody></table>",
+    "text": "The College proposes removing the pre-requisite that students must be LAS-SSE majors in order to enroll in the course. We hope that opening Education courses to students in other programs allows more students who might be interested in teaching to take a Gateway course in education while attending community college",
     "courses": []
   },
   "EDUC 230": {
@@ -10077,7 +10073,7 @@
     ]
   },
   "EET 162L": {
-    "text": "EET 121 DC & AC Circuits and Laboratory&nbsp;and MAT 130 Applied Algebra & Trigonometry",
+    "text": "EET 121 DC & AC Circuits and Laboratory and MAT 130 Applied Algebra & Trigonometry",
     "courses": [
       "EET 121",
       "MAT 130"
@@ -10774,55 +10770,55 @@
     ]
   },
   "ELA 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELA 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELA 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELA 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELA 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 202": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELC 203": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELE 150": {
-    "text": "<p>Updating the prereqs for this course</p>",
+    "text": "Updating the prereqs for this course",
     "courses": []
   },
   "ELEC 128": {
@@ -10867,165 +10863,165 @@
     ]
   },
   "ELF 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELF 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELF 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELF 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELI 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELI 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELI 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELI 200": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELJ 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELJ 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELJ 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELJ 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELJ 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELK 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELK 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELK 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELK 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELK 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELM 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELM 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELM 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELN 122": {
-    "text": "<p>Adding the prerequisite for the class. Prerequisite: Math Proficiency</p><p>Pre/Co-Requisite: ENG102</p>",
+    "text": "Adding the prerequisite for the class. Prerequisite: Math Proficiency; Pre/Co-Requisite: ENG102",
     "courses": [
       "ENG 102"
     ]
   },
   "ELP 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELP 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELP 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELP 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELR 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELR 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELR 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 104": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 106": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 200": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 204": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELS 209": {
-    "text": "<p>Removing prereq based on special action from 10/23/2023. </p>",
+    "text": "Removing prereq based on special action from 10/23/2023",
     "courses": []
   },
   "ELS 210": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELT 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELT 107": {
@@ -11136,35 +11132,35 @@
     ]
   },
   "ELU 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELV 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELV 103": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELV 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELV 201": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELY 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELY 105": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "ELZ 102": {
-    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "text": "Removing the prerequisites for the Modern Languages and Literatures (ML) Program",
     "courses": []
   },
   "EMB 101": {
@@ -11850,7 +11846,7 @@
     ]
   },
   "ENG 110": {
-    "text": "<p>Currently, Language and Cognition students must wait until after grades are posted to register in gateway English courses. This change to English 110 pre-requisites would allow students to pre-register for gateway English classes while enrolled in preceding ESL co-requisite courses ESL 30/31 and ESL 86/88. </p>",
+    "text": "Currently, Language and Cognition students must wait until after grades are posted to register in gateway English courses. This change to English 110 pre-requisites would allow students to pre-register for gateway English classes while enrolled in preceding ESL co-requisite courses ESL 30/31 and ESL 86/88",
     "courses": [
       "ESL 30",
       "ESL 86"
@@ -11933,7 +11929,7 @@
     ]
   },
   "ENG 165": {
-    "text": "<p>Change Prerequisites</p>",
+    "text": "Change Prerequisites",
     "courses": []
   },
   "ENG 170": {
@@ -12041,15 +12037,15 @@
     ]
   },
   "ENG 211": {
-    "text": "<p>Update to add description of prerequisites.</p>",
+    "text": "Update to add description of prerequisites",
     "courses": []
   },
   "ENG 212": {
-    "text": "<p>Update to add description of prerequisite(s).</p>",
+    "text": "Update to add description of prerequisite(s)",
     "courses": []
   },
   "ENG 213": {
-    "text": "<p>Update to add description of prerequisites.</p>",
+    "text": "Update to add description of prerequisites",
     "courses": []
   },
   "ENG 214": {
@@ -12109,7 +12105,7 @@
     ]
   },
   "ENG 219": {
-    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "text": "Update to add prereq and description of prerequisite(s)",
     "courses": []
   },
   "ENG 220": {
@@ -12476,7 +12472,7 @@
     ]
   },
   "ENG 295": {
-    "text": "<p>The revision of ENG295 is necessary as the course is no longer the capstone for the English Major: the term capstone was removed from the description; other &nbsp;changes include removal of ENG102 and completion of 40 credits as a prerequisite and the course no longer being writing intensive.</p>",
+    "text": "The revision of ENG295 is necessary as the course is no longer the capstone for the English Major: the term capstone was removed from the description; other changes include removal of ENG102 and completion of 40 credits as a prerequisite and the course no longer being writing intensive",
     "courses": [
       "ENG 102"
     ]
@@ -12514,16 +12510,6 @@
     "courses": [
       "ENG 121",
       "ENG 201"
-    ]
-  },
-  "ENG 6000": {
-    "text": "<p><u>5/27/2025 -</u></p><p><strong>From:</strong>&nbsp;Jaime Berco &lt;Jaime.Berco@kbcc.cuny.edu&gt;<br><strong>Sent:</strong>&nbsp;Tuesday, May 27, 2025 11:55 AM<br><strong>To:</strong>&nbsp;KCC Academic Scheduling &lt;Academic_Scheduling@kbcc.cuny.edu&gt;; Seanna Carter &lt;Seanna.Carter@kbcc.cuny.edu&gt;; Avery Mullen &lt;Avery.Mullen@kbcc.cuny.edu&gt;; Shavone Sease &lt;Shavone.Sease@kbcc.cuny.edu&gt;<br><strong>Cc:</strong>&nbsp;Mary Dawson &lt;mdawson@kbcc.cuny.edu&gt;; Gordon Alley-Young &lt;Gordon.Young@kbcc.cuny.edu&gt;; Cynthia Olvina &lt;Cynthia.Olvina@kbcc.cuny.edu&gt;; KCC Faculty Workload &lt;Faculty.Workload@kbcc.cuny.edu&gt;<br><strong>Subject:</strong>&nbsp;ENG6000 - Updating Workload Hours</p><p>Please have the default number of workload hours updated for ENG6000 to the following:</p><p>ENG6000 (Creative Writing: Screenwriting)</p><p>0 Hours -&gt; 3 Hours</p><hr><hr><p><u>Explanation</u>: The removal ENG 5900 – Introduction to Creative Writing, as a prerequisite is inline with the other Creative Writing Courses (ENG 5600, ENG 5700, ENG 5800, and ENG 5900), which only require students to complete ENG 1200. Students do not need to complete ENG 5900 in order to be successful in this course.</p><p>SPRING 2023 CURRICULUM COMMITTEE FOR NOV/DEC AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3eChangeinPrerequisite-ENG6000-CreativeWriting_Screenwriting.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3eChangeinPrerequisite-ENG6000-CreativeWriting_Screenwriting.pdf</a></p>",
-    "courses": [
-      "ENG 1200",
-      "ENG 5600",
-      "ENG 5700",
-      "ENG 5800",
-      "ENG 5900"
     ]
   },
   "ENGL 101": {
@@ -13130,7 +13116,7 @@
     "courses": []
   },
   "ESL 10": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 101": {
@@ -13140,11 +13126,11 @@
     ]
   },
   "ESL 11": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 12": {
-    "text": "<p>Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "text": "Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 122": {
@@ -13152,23 +13138,23 @@
     "courses": []
   },
   "ESL 20": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 21": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 22": {
-    "text": "<p>Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "text": "Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 30": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESL 31": {
-    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "text": "Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses",
     "courses": []
   },
   "ESW 201": {
@@ -13303,10 +13289,11 @@
     ]
   },
   "ET 575": {
-    "text": "<p>Pre-requisite and co-requisites updated to improve student outcomes for students in the 7 applicable programs. &nbsp;For the current “Prereq: ET502 or ET574 or coreq: MA440 or Department Permission” we found that some students were taking both ET-574 and ET-575 at the same time due to math placement in MA-440.&nbsp; This was unintended and proved to be quite challenging for the students.&nbsp; It was clear that students who took ET-574 before ET-575 were more successful.&nbsp; Thus, we are proposing to change the prerequisite to be “A grade of C or better in one of the following: ET574 or ET712 or ET502 or MA441”.</p>",
+    "text": "Pre-requisite and co-requisites updated to improve student outcomes for students in the 7 applicable programs. For the current “Prereq: ET502 or ET574 or coreq: MA440 or Department Permission” we found that some students were taking both ET-574 and ET-575 at the same time due to math placement in MA-440. This was unintended and proved to be quite challenging for the students. It was clear that students who took ET-574 before ET-575 were more successful. Thus, we are proposing to change the prerequisite to be “A grade of C or better in one of the following: ET574 or ET712 or ET502 or MA441”",
     "courses": [
       "ET 502",
       "ET 574",
+      "ET 575",
       "ET 712",
       "MA 440",
       "MA 441"
@@ -13410,7 +13397,7 @@
     ]
   },
   "ET 760": {
-    "text": "<p>This course was offered for the first time in Spring 2024 and after teaching the material we find the proposed course requirements make more impact on the student success in this course. Students who took the course and had the proposed prerequisite classes had better success in the class than those who did not.&nbsp; The pre- and co-requisite updates are based on the skills needed to be proficient in the topics covered in the course. </p>",
+    "text": "This course was offered for the first time in Spring 2024 and after teaching the material we find the proposed course requirements make more impact on the student success in this course. Students who took the course and had the proposed prerequisite classes had better success in the class than those who did not. The pre- and co-requisite updates are based on the skills needed to be proficient in the topics covered in the course",
     "courses": []
   },
   "ET 842": {
@@ -14399,17 +14386,19 @@
     "courses": []
   },
   "FMP 341": {
-    "text": "<p>Removing FMP-241 as a prerequisite for FMP-341 will help students stay on track for graduation, especially when enrollment in FMP-241 is limited due to capacity. Based on a review of retention data, CTMP has determined that completing FMP-241 before FMP-341 is not essential and that this change will effectively address the issue.</p><p>We are adding FMP-141 as a prerequisite. </p><p>We are also updating the class from 4 Lecture hours to reflect the approved official syllabus as 2 Lecture Hours, 2 Lab Hours. </p>",
+    "text": "Removing FMP-241 as a prerequisite for FMP-341 will help students stay on track for graduation, especially when enrollment in FMP-241 is limited due to capacity. Based on a review of retention data, CTMP has determined that completing FMP-241 before FMP-341 is not essential and that this change will effectively address the issue; We are adding FMP-141 as a prerequisite; We are also updating the class from 4 Lecture hours to reflect the approved official syllabus as 2 Lecture Hours, 2 Lab Hours",
     "courses": [
       "FMP 141",
-      "FMP 241"
+      "FMP 241",
+      "FMP 341"
     ]
   },
   "FMP 342": {
-    "text": "<p>Removing FMP-241 as a prerequisite for FMP-342 will help students stay on track for graduation, especially when enrollment in FMP-241 is limited due to capacity. Based on a review of retention data, CTMP has determined that completing FMP-241 before FMP-342 is not essential and that this change will effectively address the issue.</p><p>We are adding FMP-141 as a prerequisite. </p><p>We are also updating the class from 4 Lecture hours to reflect the approved official syllabus as 2 Lecture Hours, 2 Lab Hours. </p>",
+    "text": "Removing FMP-241 as a prerequisite for FMP-342 will help students stay on track for graduation, especially when enrollment in FMP-241 is limited due to capacity. Based on a review of retention data, CTMP has determined that completing FMP-241 before FMP-342 is not essential and that this change will effectively address the issue; We are adding FMP-141 as a prerequisite; We are also updating the class from 4 Lecture hours to reflect the approved official syllabus as 2 Lecture Hours, 2 Lab Hours",
     "courses": [
       "FMP 141",
-      "FMP 241"
+      "FMP 241",
+      "FMP 342"
     ]
   },
   "FR 111": {
@@ -15541,7 +15530,7 @@
     ]
   },
   "HCM 11": {
-    "text": "<p><strong>This change is proposed to ensure that students possess adequate writing skills to succeed in this course. The current lack of prerequisites allows students with ESL need to take the course, putting them at a significant disadvantage. </strong>Change in Department</p>",
+    "text": "This change is proposed to ensure that students possess adequate writing skills to succeed in this course. The current lack of prerequisites allows students with ESL need to take the course, putting them at a significant disadvantage. Change in Department",
     "courses": []
   },
   "HCTAL 250": {
@@ -15661,11 +15650,12 @@
     ]
   },
   "HIS 11": {
-    "text": "<p>HIS 11 was created to serve students enrolled in remedial English and Reading classes (ENG 02 and RDL 02). When CUNY phased out stand-alone remedial classes in favor of co-requisite developmental classes, HIS 11’s corequisite English class was changed to the replacement for ENG 02, which was ENG 110. Faculty from English and Reading created a corequisite class for students who needed additional reading support, ENG 100, and that has been a successful course. The pass rate of ENG 100 students who have been allowed to enroll in HIS 11 is commensurate with that of students co-enrolled in ENG 110. Therefore, we are extending the corequisite options to include ENG 100.</p>",
+    "text": "HIS 11 was created to serve students enrolled in remedial English and Reading classes (ENG 02 and RDL 02). When CUNY phased out stand-alone remedial classes in favor of co-requisite developmental classes, HIS 11’s corequisite English class was changed to the replacement for ENG 02, which was ENG 110. Faculty from English and Reading created a corequisite class for students who needed additional reading support, ENG 100, and that has been a successful course. The pass rate of ENG 100 students who have been allowed to enroll in HIS 11 is commensurate with that of students co-enrolled in ENG 110. Therefore, we are extending the corequisite options to include ENG 100",
     "courses": [
       "ENG 02",
       "ENG 100",
       "ENG 110",
+      "HIS 11",
       "RDL 02"
     ]
   },
@@ -16182,11 +16172,11 @@
     ]
   },
   "HITE 120": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HITE 160": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HITE 200": {
@@ -16196,19 +16186,19 @@
     ]
   },
   "HITE 210": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HITE 215": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HITE 230": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HITE 254": {
-    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "text": "Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites",
     "courses": []
   },
   "HLT 100": {
@@ -16483,11 +16473,12 @@
     ]
   },
   "HSC 91": {
-    "text": "<p><strong>Rationale: Either PSY 11 or SOC 11 is allowed as a prerequisite for SOC 35, so students are not required to take both. ENG 110 is already a corequisite to HSC 12, which is a prerequisite to HSC 91; therefore, it is redundant to include here. HSC 11 corequisite is not necessary for success in HSC 91.</strong></p>",
+    "text": "Rationale: Either PSY 11 or SOC 11 is allowed as a prerequisite for SOC 35, so students are not required to take both. ENG 110 is already a corequisite to HSC 12, which is a prerequisite to HSC 91; therefore, it is redundant to include here. HSC 11 corequisite is not necessary for success in HSC 91.",
     "courses": [
       "ENG 110",
       "HSC 11",
       "HSC 12",
+      "HSC 91",
       "PSY 11",
       "SOC 11",
       "SOC 35"
@@ -16534,25 +16525,25 @@
     ]
   },
   "HSS 101": {
-    "text": "<p>Updating the pre/co req requirements. Pre-requisites: English Proficiency, Math Proficiency and Pre-Requisites / Co-Requisites: HSF90 or equivalent. Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "text": "Updating the pre/co req requirements. Pre-requisites: English Proficiency, Math Proficiency and Pre-Requisites / Co-Requisites: HSF90 or equivalent. Updating the Academic Department from Health Science to Community Health and Wellness",
     "courses": [
       "HSF 90"
     ]
   },
   "HSS 216": {
-    "text": "<p>Removal of SCN 195 as a pre/co-requisite enables students from other programs to enroll in this course. Title and course description updated to more clearly reflect the content. Classroom hours reduced to match course credit. </p>",
+    "text": "Removal of SCN 195 as a pre/co-requisite enables students from other programs to enroll in this course. Title and course description updated to more clearly reflect the content. Classroom hours reduced to match course credit",
     "courses": [
       "SCN 195"
     ]
   },
   "HSS 290": {
-    "text": "<p>The course title is changed as the program is no longer called Health and Human Services. SSP101 is removed as a prerequisite as it does not transfer to other programs.</p>",
+    "text": "The course title is changed as the program is no longer called Health and Human Services. SSP101 is removed as a prerequisite as it does not transfer to other programs",
     "courses": [
       "SSP 101"
     ]
   },
   "HSS 295": {
-    "text": "<p>This course revisions reflect current practice and terminology in the field of Human Services. Additionally, the use of OER course materials enables students to engage with the most recent best practices in the field. SSP101 prerequisite has been removed as it is not part of the program core.</p>",
+    "text": "This course revisions reflect current practice and terminology in the field of Human Services. Additionally, the use of OER course materials enables students to engage with the most recent best practices in the field. SSP101 prerequisite has been removed as it is not part of the program core",
     "courses": [
       "SSP 101"
     ]
@@ -16572,7 +16563,7 @@
     ]
   },
   "HSVC 223": {
-    "text": "<p>1/29/25 - Requirement group # was not removed which is the change that was requested submitted to remove the pre-requisite.</p><table><tbody><tr><td><p>The College proposes removing the pre-requisite of HSVC 103 in order open the course to students in programs of study outside of Human Services.</p></td></tr></tbody></table>",
+    "text": "1/29/25 - Requirement group # was not removed which is the change that was requested submitted to remove the pre-requisite; The College proposes removing the pre-requisite of HSVC 103 in order open the course to students in programs of study outside of Human Services",
     "courses": [
       "HSVC 103"
     ]
@@ -16666,15 +16657,15 @@
     ]
   },
   "HUA 121": {
-    "text": "<p>This revision of the course updates the catalog description, objectives, grading standards and course outline to reflect current practice in teaching this course. Prerequisites and corequisites are removed to facilitate enrollment.</p>",
+    "text": "This revision of the course updates the catalog description, objectives, grading standards and course outline to reflect current practice in teaching this course. Prerequisites and corequisites are removed to facilitate enrollment",
     "courses": []
   },
   "HUA 131": {
-    "text": "<p>Updated to match pre/co req in proposal. English Proficiency, Math Proficiency</p>",
+    "text": "Updated to match pre/co req in proposal. English Proficiency, Math Proficiency",
     "courses": []
   },
   "HUA 145": {
-    "text": "<p>Removing the HUA230 Intermediate Photography prerequisite and replacing it with either HUA130, HUA131 or HUV 240 will make the course available to students in other majors. The revision also adds the competencies and abilities for assessment.</p>",
+    "text": "Removing the HUA230 Intermediate Photography prerequisite and replacing it with either HUA130, HUA131 or HUV 240 will make the course available to students in other majors. The revision also adds the competencies and abilities for assessment",
     "courses": [
       "HUA 130",
       "HUA 131",
@@ -16683,75 +16674,75 @@
     ]
   },
   "HUA 231": {
-    "text": "<p>The course is being revised to include the assessment of Integrative Learning and Digital Communication. Prerequisites are changed to make the course available to a wider group of students.</p>",
+    "text": "The course is being revised to include the assessment of Integrative Learning and Digital Communication. Prerequisites are changed to make the course available to a wider group of students",
     "courses": []
   },
   "HUA 234": {
-    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "text": "Update to add prereq and description of prerequisite(s)",
     "courses": []
   },
   "HUA 238": {
-    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "text": "Update to add prereq and description of prerequisite(s)",
     "courses": []
   },
   "HUA 245": {
-    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "text": "Updated to add prerequisite and description of prerequisite(s)",
     "courses": []
   },
   "HUA 280": {
-    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "text": "Updated to add prerequisite and description of prerequisite(s)",
     "courses": []
   },
   "HUA 291": {
-    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "text": "Updated to add prerequisite and description of prerequisite(s)",
     "courses": []
   },
   "HUC 116": {
-    "text": "<p>Updating prereq to ENG/A101 from HUC101 and HUC106.</p>",
+    "text": "Updating prereq to ENG/A101 from HUC101 and HUC106",
     "courses": [
       "HUC 101",
       "HUC 106"
     ]
   },
   "HUC 192": {
-    "text": "<p>Approved by Central. Update prereq to ENG/A101 from HUC101 and HUC106.</p>",
+    "text": "Approved by Central. Update prereq to ENG/A101 from HUC101 and HUC106",
     "courses": [
       "HUC 101",
       "HUC 106"
     ]
   },
   "HUI 107": {
-    "text": "<p>Update the prereqs for the class. </p>",
+    "text": "Update the prereqs for the class",
     "courses": []
   },
   "HUI 109": {
-    "text": "<p>Update to pre-requisites. </p>",
+    "text": "Update to pre-requisites",
     "courses": []
   },
   "HUI 113": {
-    "text": "<p>The prerequisites are being removed from this course to allow students greater flexibility in enrolling in it throughout the degree. The previous prerequisites were not necessary for the study of industrial design history. The course number is being changed from HUI213 to HUI113 in recognition of this course being taken by students in the first year of the degree.</p>",
+    "text": "The prerequisites are being removed from this course to allow students greater flexibility in enrolling in it throughout the degree. The previous prerequisites were not necessary for the study of industrial design history. The course number is being changed from HUI213 to HUI113 in recognition of this course being taken by students in the first year of the degree",
     "courses": [
       "HUI 213"
     ]
   },
   "HUI 114": {
-    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "text": "Update to correct/add pre-requisites",
     "courses": []
   },
   "HUI 129": {
-    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "text": "Update to correct/add pre-requisites",
     "courses": []
   },
   "HUI 190": {
-    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "text": "Update to correct/add pre-requisites",
     "courses": []
   },
   "HUI 209": {
-    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "text": "Update to correct/add pre-requisites",
     "courses": []
   },
   "HUI 214": {
-    "text": "<p> The course number is being changed from HUI118 to HUI214 in recognition of this course running in the second year of the degree. The current corequisite of HUI109 is causing enrollment problems for students and is therefore removed. This course was originally based on an engineering course with extra hours, but that is not necessary for the industrial design version.</p>",
+    "text": "The course number is being changed from HUI118 to HUI214 in recognition of this course running in the second year of the degree. The current corequisite of HUI109 is causing enrollment problems for students and is therefore removed. This course was originally based on an engineering course with extra hours, but that is not necessary for the industrial design version",
     "courses": [
       "HUI 109",
       "HUI 118"
@@ -16770,7 +16761,7 @@
     ]
   },
   "HUI 295": {
-    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "text": "Update to correct/add pre-requisites",
     "courses": []
   },
   "HUM 100": {
@@ -16905,7 +16896,7 @@
     ]
   },
   "HUZ 291": {
-    "text": "<p>This course is being submitted as a new course, with the new 3-letter Photography subject area indicator HUZ in the course number, so that photography courses at LaGuardia are discoverable when searching for courses via CUNYfirst. The prerequisites have been updated to ensure the students have a basic digital and studio photography knowledge before taking this option.</p>",
+    "text": "This course is being submitted as a new course, with the new 3-letter Photography subject area indicator HUZ in the course number, so that photography courses at LaGuardia are discoverable when searching for courses via CUNYfirst. The prerequisites have been updated to ensure the students have a basic digital and studio photography knowledge before taking this option",
     "courses": []
   },
   "HVA 103": {
@@ -17410,12 +17401,14 @@
     ]
   },
   "INFT 216": {
-    "text": "<table><tbody><tr><td><p>The College proposes updated the course pre-requisites to better align with the content of the course.</p></td></tr></tbody></table>",
+    "text": "The College proposes updated the course pre-requisites to better align with the content of the course",
     "courses": []
   },
   "INFT 221": {
-    "text": "<table><tbody><tr><td><p>The College proposes updating the pre-requisites for INFT 221 to reflect the skills required for current course content.</p></td></tr></tbody></table>",
-    "courses": []
+    "text": "The College proposes updating the pre-requisites for INFT 221 to reflect the skills required for current course content",
+    "courses": [
+      "INFT 221"
+    ]
   },
   "INFT 226": {
     "text": "Pre-Requisite INFT 216",
@@ -17424,8 +17417,10 @@
     ]
   },
   "INFT 233": {
-    "text": "<table><tbody><tr><td><p>The College proposes updating the pre-requisites for INFT 233 to better align with course sequencing across all of our IT programming.</p></td></tr></tbody></table>",
-    "courses": []
+    "text": "The College proposes updating the pre-requisites for INFT 233 to better align with course sequencing across all of our IT programming",
+    "courses": [
+      "INFT 233"
+    ]
   },
   "INT 105": {
     "text": "INT 101",
@@ -18164,11 +18159,10 @@
     ]
   },
   "JRL 3100": {
-    "text": "<p><u>7/9/2024</u> Correction: remove Civic Engagement</p><p><u>Explanation</u>: Upon reevaluation of the pre-/co-requisite of ENG 1200 - Composition I by the Communications and Performing Arts Department determined that students already directly learn journalistic writing nuances along with foundational writing principles in JRL 3100 - Basic Journalism, fostering a seamless learning experience. Additionally, removing the pre-/co-requisite facilitates a smoother academic journey for students. Students would be able to delve directly into JRL 3100 without the potential delay or scheduling conflict of first completing ENG 1200. Furthermore, not all students may have had the chance to complete ENG 1200 or an equivalent before entering the Journalism program. By removing this barrier, we are ensuring that all students, regardless of their prior coursework, have an equal opportunity to pursue JRL 3100</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5xChangePrer-_Coreq-JRL3100-BasicJournalism.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5xChangePrer-_Coreq-JRL3100-BasicJournalism.pdf</a></p>",
+    "text": "7/9/2024 Correction: remove Civic Engagement; Explanation : Upon reevaluation of the pre-/co-requisite of ENG 1200 - Composition I by the Communications and Performing Arts Department determined that students already directly learn journalistic writing nuances along with foundational writing principles in JRL 3100 - Basic Journalism, fostering a seamless learning experience. Additionally, removing the pre-/co-requisite facilitates a smoother academic journey for students. Students would be able to delve directly into JRL 3100 without the potential delay or scheduling conflict of first completing ENG 1200. Furthermore, not all students may have had the chance to complete ENG 1200 or an equivalent before entering the Journalism program. By removing this barrier, we are ensuring that all students, regardless of their prior coursework, have an equal opportunity to pursue JRL 3100; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5xChangePrer-_Coreq-JRL3100-BasicJournalism.pdf",
     "courses": [
       "ENG 1200",
-      "FALL 2023",
-      "FEB 2024"
+      "JRL 3100"
     ]
   },
   "LA 112": {
@@ -18218,10 +18212,11 @@
     ]
   },
   "LAW 19": {
-    "text": "<p><strong>The Paralegal and Legal Studies AAS degree was modified in spring 2019 (effective fall 2019).&nbsp; As part of the program modifications, DAT 10 (Computer Fundamentals and Applications) was removed from the required courses, and DAT 33 (Microcomputer Applications) was added.&nbsp; At that time, the Department’s proposals inadvertently omitted a change in the prerequisite for LAW 19, which was left as only DAT 10 only.&nbsp; The requested change allows students who were enrolled in the AAS degree prior to the spring 2019 modification, are enrolled in the Paralegal Certificate program (which still requires DAT 10) or have completed DAT 10 instead of DAT 33 for any other reason to enroll in LAW 19, a required course in both the AAS degree and the Certificate programs.</strong></p>",
+    "text": "The Paralegal and Legal Studies AAS degree was modified in spring 2019 (effective fall 2019). As part of the program modifications, DAT 10 (Computer Fundamentals and Applications) was removed from the required courses, and DAT 33 (Microcomputer Applications) was added. At that time, the Department’s proposals inadvertently omitted a change in the prerequisite for LAW 19, which was left as only DAT 10 only. The requested change allows students who were enrolled in the AAS degree prior to the spring 2019 modification, are enrolled in the Paralegal Certificate program (which still requires DAT 10) or have completed DAT 10 instead of DAT 33 for any other reason to enroll in LAW 19, a required course in both the AAS degree and the Certificate programs.",
     "courses": [
       "DAT 10",
-      "DAT 33"
+      "DAT 33",
+      "LAW 19"
     ]
   },
   "LAW 200": {
@@ -18320,35 +18315,40 @@
     ]
   },
   "LAW 47": {
-    "text": "<p>The proposed change in LAW 47 corequisite is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies) as the American Bar Association has recently required an increased focus on ethics in this introductory Paralegal course.&nbsp; As this prerequisite has been waived several times in recent years, students have shown to be successful in completing LAW 47 without simultaneously enrolling in LAW 17.&nbsp; In addition, this change aligns the corequisite for LAW 47 with most other Paralegal and Legal Studies courses.</p>",
+    "text": "The proposed change in LAW 47 corequisite is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies) as the American Bar Association has recently required an increased focus on ethics in this introductory Paralegal course. As this prerequisite has been waived several times in recent years, students have shown to be successful in completing LAW 47 without simultaneously enrolling in LAW 17. In addition, this change aligns the corequisite for LAW 47 with most other Paralegal and Legal Studies courses",
     "courses": [
-      "LAW 17"
+      "LAW 17",
+      "LAW 47"
     ]
   },
   "LAW 64": {
-    "text": "<p>The proposed change in LAW 64 prerequisite is made to align the pre/corequisites for LAW 64 with most other Paralegal and Legal Studies courses.&nbsp; The current prerequisite of POL 11 (American National Government) is not necessary for student success in LAW 64.&nbsp;</p>",
+    "text": "The proposed change in LAW 64 prerequisite is made to align the pre/corequisites for LAW 64 with most other Paralegal and Legal Studies courses. The current prerequisite of POL 11 (American National Government) is not necessary for student success in LAW 64.",
     "courses": [
+      "LAW 64",
       "POL 11"
     ]
   },
   "LAW 91": {
-    "text": "<p>The proposed change in LAW 91 prerequisite is made to remove the requirement of both LAW 17 (Introduction to Paralegal Studies) and LAW 47 (Civil Procedure) along with other outdated items.&nbsp;&nbsp; Students will be prepared for LAW 91 after completing either LAW 17 or LAW 47.&nbsp; The additional credit and grade average requirements are no longer necessary.</p>",
+    "text": "The proposed change in LAW 91 prerequisite is made to remove the requirement of both LAW 17 (Introduction to Paralegal Studies) and LAW 47 (Civil Procedure) along with other outdated items. Students will be prepared for LAW 91 after completing either LAW 17 or LAW 47. The additional credit and grade average requirements are no longer necessary",
     "courses": [
       "LAW 17",
-      "LAW 47"
+      "LAW 47",
+      "LAW 91"
     ]
   },
   "LAW 95": {
-    "text": "<p>The proposed change in LAW 95 prerequisites is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies).&nbsp;&nbsp; Students will be prepared for LAW 95 after completing LAW 47.&nbsp; Since LAW 17 is a co-requisite for LAW 47, we feel that this as an unnecessary redundancy.&nbsp; The change in English prerequisite aligns the verbiage to what is used throughout the college.</p>",
+    "text": "The proposed change in LAW 95 prerequisites is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies). Students will be prepared for LAW 95 after completing LAW 47. Since LAW 17 is a co-requisite for LAW 47, we feel that this as an unnecessary redundancy. The change in English prerequisite aligns the verbiage to what is used throughout the college",
     "courses": [
       "LAW 17",
-      "LAW 47"
+      "LAW 47",
+      "LAW 95"
     ]
   },
   "LAW 96": {
-    "text": "<p>The proposed change in LAW 96 prerequisites is made to remove redundant prerequisites, already required for LAW 95, and to include an option for permission from the Department.&nbsp;</p>",
+    "text": "The proposed change in LAW 96 prerequisites is made to remove redundant prerequisites, already required for LAW 95, and to include an option for permission from the Department.",
     "courses": [
-      "LAW 95"
+      "LAW 95",
+      "LAW 96"
     ]
   },
   "LC 112": {
@@ -18546,7 +18546,7 @@
     ]
   },
   "LIB 105": {
-    "text": "<p>Adding prereqs</p>",
+    "text": "Adding prereqs",
     "courses": []
   },
   "LIB 171": {
@@ -18561,7 +18561,7 @@
     ]
   },
   "LIN 100.6": {
-    "text": "<p>ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central.</p><p></p>",
+    "text": "ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central",
     "courses": []
   },
   "LIN 102": {
@@ -18593,10 +18593,11 @@
     ]
   },
   "LIN 105": {
-    "text": "<p>Changing the pre-co requisites to ESL 86/88/91 or ENG 100/110 or higher makes LIN 105 consistent with the other Language and Cognition Linguistics courses.</p>",
+    "text": "Changing the pre-co requisites to ESL 86/88/91 or ENG 100/110 or higher makes LIN 105 consistent with the other Language and Cognition Linguistics courses",
     "courses": [
       "ENG 100",
-      "ESL 86"
+      "ESL 86",
+      "LIN 105"
     ]
   },
   "LIN 105W": {
@@ -18613,7 +18614,7 @@
     ]
   },
   "LIN 220": {
-    "text": "<p>This revision updates the prerequisite renumbering for this course. </p>",
+    "text": "This revision updates the prerequisite renumbering for this course",
     "courses": []
   },
   "LIT 200": {
@@ -18815,43 +18816,43 @@
     ]
   },
   "LPN 101": {
-    "text": "<p>This revision corrects the course title to what was submitted in the program proposal and removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course. </p>",
+    "text": "This revision corrects the course title to what was submitted in the program proposal and removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 103": {
-    "text": "<p>This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 104": {
-    "text": "<p>This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 201": {
-    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 202": {
-    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 203": {
-    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
   },
   "LPN 204": {
-    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "text": "This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course",
     "courses": [
       "LPN 102"
     ]
@@ -19654,7 +19655,7 @@
     ]
   },
   "MAT 120SI": {
-    "text": "<p>MA 10 is a sufficient pre-requisite for MAT120SI</p>",
+    "text": "MA 10 is a sufficient pre-requisite for MAT120SI",
     "courses": [
       "MA 10"
     ]
@@ -19759,7 +19760,7 @@
     ]
   },
   "MAT 150SI": {
-    "text": "<p>MA 10 is a sufficient pre-requisite for MAT150 SI.</p>",
+    "text": "MA 10 is a sufficient pre-requisite for MAT150 SI",
     "courses": [
       "MA 10",
       "MAT 150"
@@ -19772,14 +19773,15 @@
     ]
   },
   "MAT 157": {
-    "text": "<p>As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course. </p>",
+    "text": "As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course",
     "courses": [
+      "MAT 157",
       "MAT 51",
       "MAT 56"
     ]
   },
   "MAT 157.5": {
-    "text": "<p>As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course. To comply with the mandate, the Math Department has proposed MAT 157.5.</p>",
+    "text": "As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course. To comply with the mandate, the Math Department has proposed MAT 157.5",
     "courses": [
       "MAT 157",
       "MAT 51",
@@ -19855,9 +19857,9 @@
     ]
   },
   "MAT 2010": {
-    "text": "<p><u>5/9/2024</u> - ADDED PATHWAYS RCMQ (REDO)</p><p></p><p><u>Explanation</u>: The change in course title clarifies content for prospective enrollees in the course. The change in course description reflects the addition of MAT 20B0, which serves as a CUNY corequisite model course for Statistics. Students are informed they will not receive credit for MAT 20B0 if they completed MAT 2010. </p><p>COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR:</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3fChangeinTitleandDescription-MAT2010-IntegratedStatistics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3fChangeinTitleandDescription-MAT2010-IntegratedStatistics.pdf</a></p>",
+    "text": "5/9/2024 - ADDED PATHWAYS RCMQ (REDO); Explanation : The change in course title clarifies content for prospective enrollees in the course. The change in course description reflects the addition of MAT 20B0, which serves as a CUNY corequisite model course for Statistics. Students are informed they will not receive credit for MAT 20B0 if they completed MAT 2010; COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR:; https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3fChangeinTitleandDescription-MAT2010-IntegratedStatistics.pdf",
     "courses": [
-      "DEC 2023"
+      "MAT 2010"
     ]
   },
   "MAT 202": {
@@ -19898,9 +19900,8 @@
     ]
   },
   "MAT 20B0": {
-    "text": "<p><u>Explanation</u>: The new course MAT 20B0 - Statistics with Algebra was created to align with the CUNY transition, effective Fall 2022, to remove courses that follow Elementary Algebra, but precede the first-level Pathways MQR course.&nbsp; This new pedagogical approach to Elementary Statistics with more supported interaction for preparing students who are CUNY Math certified yet do not have the prerequisite for MAT 2000, and who want a first course in statistics.</p><p>MAT 20B0 - Statistics with Algebra , uses a lab-based model and more supported interaction for the development and fine-tuning of algebraic skills needed for mastery of statistical concepts. </p><p>This course has been submitted as a STEM Variant under MQR as the following degree programs require Statistics - A.A.S. Physical Therapist Assistant and A.A.S. Polysomnographic Technology. </p><p>COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/2aNewCourse-MAT20B0-StatisticswithAlgebra.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/2aNewCourse-MAT20B0-StatisticswithAlgebra.pdf</a></p>",
+    "text": "Explanation : The new course MAT 20B0 - Statistics with Algebra was created to align with the CUNY transition, effective Fall 2022, to remove courses that follow Elementary Algebra, but precede the first-level Pathways MQR course. This new pedagogical approach to Elementary Statistics with more supported interaction for preparing students who are CUNY Math certified yet do not have the prerequisite for MAT 2000, and who want a first course in statistics; MAT 20B0 - Statistics with Algebra , uses a lab-based model and more supported interaction for the development and fine-tuning of algebraic skills needed for mastery of statistical concepts; This course has been submitted as a STEM Variant under MQR as the following degree programs require Statistics - A.A.S. Physical Therapist Assistant and A.A.S. Polysomnographic Technology; COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/2aNewCourse-MAT20B0-StatisticswithAlgebra.pdf",
     "courses": [
-      "DEC 2023",
       "MAT 2000"
     ]
   },
@@ -21702,13 +21703,14 @@
     ]
   },
   "MTH 21": {
-    "text": "<p>The Department of Mathematics and Computer Science is proposing changes in course title and description of MTH 21 Survey of Mathematics I. The part II of the course, MTH 22 Survey of Mathematics II, has not been offered for many years. MTH 21 exposes students to the utility and relevance of mathematics in the context of every-day experience; hence we propose the new title, A Mathematical World. The new course description matches its corequisite course MTH 21.5. It also aligns better to the topics covered.</p>",
+    "text": "The Department of Mathematics and Computer Science is proposing changes in course title and description of MTH 21 Survey of Mathematics I. The part II of the course, MTH 22 Survey of Mathematics II, has not been offered for many years. MTH 21 exposes students to the utility and relevance of mathematics in the context of every-day experience; hence we propose the new title, A Mathematical World. The new course description matches its corequisite course MTH 21.5. It also aligns better to the topics covered",
     "courses": [
+      "MTH 21",
       "MTH 22"
     ]
   },
   "MTH 21.5": {
-    "text": "<p>This course is the corequisite version of MTH 21, A Mathematical World. One hybrid section was run experimentally in Spring 2022.&nbsp; The pass rate was 44.4% as compared with 37.5% for MTH 23.5 in hybrid modality. MTH 21.5 is now proposed for permanency, per CUNY’s decision to replace all stand-alone remedial courses with corequisite courses. This course has been approved for Required Core B Mathematical and Quantitative Reasoning by the CCCRC.</p><p>&nbsp;</p>",
+    "text": "This course is the corequisite version of MTH 21, A Mathematical World. One hybrid section was run experimentally in Spring 2022. The pass rate was 44.4% as compared with 37.5% for MTH 23.5 in hybrid modality. MTH 21.5 is now proposed for permanency, per CUNY’s decision to replace all stand-alone remedial courses with corequisite courses. This course has been approved for Required Core B Mathematical and Quantitative Reasoning by the CCCRC",
     "courses": [
       "MTH 21",
       "MTH 23"
@@ -21812,7 +21814,7 @@
     ]
   },
   "MUS 121": {
-    "text": "<p>The addition of a corequisite of MUS-111 Musicianship I will be added for students who do not demonstrate sufficient musical aptitude through the Basic Musicianship Aptitude Test (BMAT) and the Music Theory Placement Exam (MTPE). This addition is part of the program revisions necessary for NASM accreditation.</p>",
+    "text": "The addition of a corequisite of MUS-111 Musicianship I will be added for students who do not demonstrate sufficient musical aptitude through the Basic Musicianship Aptitude Test (BMAT) and the Music Theory Placement Exam (MTPE). This addition is part of the program revisions necessary for NASM accreditation",
     "courses": [
       "MUS 111"
     ]
@@ -21885,15 +21887,15 @@
     ]
   },
   "MUS 141": {
-    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "text": "Updating Corequisite courses",
     "courses": []
   },
   "MUS 142": {
-    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "text": "Updating Corequisite courses",
     "courses": []
   },
   "MUS 143": {
-    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "text": "Updating Corequisite courses",
     "courses": []
   },
   "MUS 144": {
@@ -23338,7 +23340,7 @@
     ]
   },
   "NUR 211": {
-    "text": "<p>prereq update</p>",
+    "text": "prereq update",
     "courses": []
   },
   "NUR 213": {
@@ -23390,15 +23392,15 @@
     ]
   },
   "NUR 313": {
-    "text": "<p>prereq update</p>",
+    "text": "prereq update",
     "courses": []
   },
   "NUR 411": {
-    "text": "<p>update prereq</p>",
+    "text": "update prereq",
     "courses": []
   },
   "NUR 415": {
-    "text": "<p>update prereq</p>",
+    "text": "update prereq",
     "courses": []
   },
   "NUTR 119": {
@@ -24517,7 +24519,7 @@
     "courses": []
   },
   "PHI 100": {
-    "text": "<p>HUM 100 not needed as pre-requisite. </p>",
+    "text": "HUM 100 not needed as pre-requisite",
     "courses": [
       "HUM 100"
     ]
@@ -25193,7 +25195,7 @@
     ]
   },
   "PNR 101": {
-    "text": "<p>Add prerequisite</p>",
+    "text": "Add prerequisite",
     "courses": []
   },
   "PO 112": {
@@ -25235,7 +25237,7 @@
     "courses": []
   },
   "POL 42": {
-    "text": "<p>Add Prerequisites</p>",
+    "text": "Add Prerequisites",
     "courses": []
   },
   "POL 50": {
@@ -25245,11 +25247,8 @@
     ]
   },
   "POL 9300": {
-    "text": "<p><u>Explanation</u>: Removal of references to deleted curricular requirements. The Global and Environmental Concentration under the A.A. Liberal Arts has been deleted and there is no reason to limit the course to only Liberal Arts majors. In turn, an update to the course description and prerequisite were required. </p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5mChangeinDescriptionandPrereq-POL9300-GlobalPolitics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5mChangeinDescriptionandPrereq-POL9300-GlobalPolitics.pdf</a></p>",
-    "courses": [
-      "FALL 2023",
-      "FEB 2024"
-    ]
+    "text": "Explanation : Removal of references to deleted curricular requirements. The Global and Environmental Concentration under the A.A. Liberal Arts has been deleted and there is no reason to limit the course to only Liberal Arts majors. In turn, an update to the course description and prerequisite were required; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5mChangeinDescriptionandPrereq-POL9300-GlobalPolitics.pdf",
+    "courses": []
   },
   "POLSC 102": {
     "text": "ENG 101 Ready: Successful completion of ENG 92 or ENG 101 or ESL 122 or Course Placement",
@@ -25362,10 +25361,9 @@
     ]
   },
   "PSG 103": {
-    "text": "<p><u>Explanation</u>: MAT 20B0 (passed at Spring 2023 Curriculum Committee &amp; June 2023 College Council) is a new Statistics corequisite model course being added as an option under Mathematics and Quantitative Reasoning (MQR) for the A.A.S. Polysomnographic Technology. In turn, the prerequisite for PSG 103 is being updated to reflect this option.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5iChangeinPrereq-PSG103-ClinicalPracticuminSleepMedicineI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5iChangeinPrereq-PSG103-ClinicalPracticuminSleepMedicineI.pdf</a></p>",
+    "text": "Explanation : MAT 20B0 (passed at Spring 2023 Curriculum Committee & June 2023 College Council) is a new Statistics corequisite model course being added as an option under Mathematics and Quantitative Reasoning (MQR) for the A.A.S. Polysomnographic Technology. In turn, the prerequisite for PSG 103 is being updated to reflect this option; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5iChangeinPrereq-PSG103-ClinicalPracticuminSleepMedicineI.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024"
+      "PSG 103"
     ]
   },
   "PSY 103": {
@@ -26041,7 +26039,7 @@
     "courses": []
   },
   "PTA 900": {
-    "text": "<p>Removed Coreq PTA 800 from description .</p>",
+    "text": "Removed Coreq PTA 800 from description",
     "courses": [
       "PTA 800"
     ]
@@ -26296,11 +26294,12 @@
     "courses": []
   },
   "RAD 12": {
-    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "text": "The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program",
     "courses": [
       "CLE 11",
       "MTH 13",
       "MTH 28",
+      "RAD 12",
       "RAD 16"
     ]
   },
@@ -26344,12 +26343,13 @@
     ]
   },
   "RAD 16": {
-    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "text": "The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program",
     "courses": [
       "CLE 11",
       "MTH 13",
       "MTH 28",
-      "RAD 12"
+      "RAD 12",
+      "RAD 16"
     ]
   },
   "RAD 200": {
@@ -27040,15 +27040,16 @@
     ]
   },
   "SCB 207": {
-    "text": "<p>This course is part of the program core for the Associate of Science Degree in Biotechnology track of the Biology Program. We propose changing the prerequisites to SCB201 or SCB101 and MAT 115/117 to increase course enrollment and enable students from other majors to take SCB 207. This will not affect students in the Biotechnology track, as they are required to take SCB 201 as part of their major. </p><p>We propose adding an introduction to Python and R to the curriculum, as these are essential skills for students in data analysis and bioinformatics. </p>",
+    "text": "This course is part of the program core for the Associate of Science Degree in Biotechnology track of the Biology Program. We propose changing the prerequisites to SCB201 or SCB101 and MAT 115/117 to increase course enrollment and enable students from other majors to take SCB 207. This will not affect students in the Biotechnology track, as they are required to take SCB 201 as part of their major; We propose adding an introduction to Python and R to the curriculum, as these are essential skills for students in data analysis and bioinformatics",
     "courses": [
       "MAT 115",
       "SCB 101",
-      "SCB 201"
+      "SCB 201",
+      "SCB 207"
     ]
   },
   "SCB 208": {
-    "text": "<p>Course was approved for Pathways Scientific World category by the CCRC. Updated Prereqs for this course for Fall 2025.</p>",
+    "text": "Course was approved for Pathways Scientific World category by the CCRC. Updated Prereqs for this course for Fall 2025",
     "courses": []
   },
   "SCB 257": {
@@ -27079,23 +27080,23 @@
     ]
   },
   "SCH 205": {
-    "text": "<p>Updated to add prerequisite and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "text": "Updated to add prerequisite and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness",
     "courses": []
   },
   "SCH 215": {
-    "text": "<p>Prerequisites have been changed to reflect changes in the program curriculum and opening the course to students in other programs. </p>",
+    "text": "Prerequisites have been changed to reflect changes in the program curriculum and opening the course to students in other programs",
     "courses": []
   },
   "SCH 225": {
-    "text": "<p>Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "text": "Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness",
     "courses": []
   },
   "SCH 235": {
-    "text": "<p>Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "text": "Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness",
     "courses": []
   },
   "SCH 285": {
-    "text": "<p>Updating course content and objectives to align with CUNY Community Health Major Gateway objectives and change from program curriculum as the previous capstone course. Prerequisities have been adjusted to reflect the course's new place within the program curriculum. Updates now align the course with the Council on Education for Public Health (CEPH) 4-year degree program accreditation standards. Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "text": "Updating course content and objectives to align with CUNY Community Health Major Gateway objectives and change from program curriculum as the previous capstone course. Prerequisities have been adjusted to reflect the course's new place within the program curriculum. Updates now align the course with the Council on Education for Public Health (CEPH) 4-year degree program accreditation standards. Updating the Academic Department from Health Science to Community Health and Wellness",
     "courses": []
   },
   "SCI 141": {
@@ -27116,7 +27117,7 @@
     ]
   },
   "SCI 215": {
-    "text": "<table><tbody><tr><td><p>This proposal is in support of three changes that have occurred since this course was created: </p><p>1) This course was approved for CUNY Pathways Flexible Core,</p><p>2) GCC student math requirement has changed and not all students are required to take MATH 103, and</p><p>3) The Science A.S. Degree map has changed and MATH 103 is no longer required.</p><p> </p><p>In response, we would like to remove the MATH and ENGL pre-requisites so that they do not continue to provide a barrier to student enrollment. We have also revised the course description to reflect updates to the course.</p></td></tr></tbody></table>",
+    "text": "This proposal is in support of three changes that have occurred since this course was created: ; 1) This course was approved for CUNY Pathways Flexible Core; 2) GCC student math requirement has changed and not all students are required to take MATH 103, and; 3) The Science A.S. Degree map has changed and MATH 103 is no longer required; In response, we would like to remove the MATH and ENGL pre-requisites so that they do not continue to provide a barrier to student enrollment. We have also revised the course description to reflect updates to the course",
     "courses": [
       "MATH 103"
     ]
@@ -27236,44 +27237,45 @@
     ]
   },
   "SCV 101": {
-    "text": "<p>This revised course will be offered to clinical phase, Veterinary Technology students only.!&nbsp; The credits, instructional objectives and grading standards are being revised to reflect that the course will no longer teach students about Vet Tech program admission nor offer an introduction to anatomy. Medical dosing will be introduced in this course to augment the new Vet Tech math requirement and prerequisite MAT115/MAT117.</p>",
+    "text": "This revised course will be offered to clinical phase, Veterinary Technology students only.! The credits, instructional objectives and grading standards are being revised to reflect that the course will no longer teach students about Vet Tech program admission nor offer an introduction to anatomy. Medical dosing will be introduced in this course to augment the new Vet Tech math requirement and prerequisite MAT115/MAT117",
     "courses": [
       "MAT 115",
       "MAT 117"
     ]
   },
   "SCV 151": {
-    "text": "<p>SCV151 is a required course for the Veterinary Technology major. It is open to the college</p><p>community at all levels so that pre-clinical Veterinary Technology students have the option</p><p>to take the course prior to entering the clinical phase.The revision of the prerequisite(s) for</p><p>Shelter Medicine and Management (SCV151) is being proposed because its former prerequisite,</p><p>Introduction to Veterinary Technology (SCV101), is now a second semester, clinical phase Veterinary Technology course .</p>",
+    "text": "SCV151 is a required course for the Veterinary Technology major. It is open to the college; community at all levels so that pre-clinical Veterinary Technology students have the option; to take the course prior to entering the clinical phase.The revision of the prerequisite(s) for; Shelter Medicine and Management (SCV151) is being proposed because its former prerequisite; Introduction to Veterinary Technology (SCV101), is now a second semester, clinical phase Veterinary Technology course",
     "courses": [
       "SCV 101"
     ]
   },
   "SCV 202": {
-    "text": "<p>This course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This lecture course will be a corequisite to either SCV203 (on-campus) or SCV204 (off-campus)</p>",
+    "text": "This course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This lecture course will be a corequisite to either SCV203 (on-campus) or SCV204 (off-campus)",
     "courses": [
       "SCV 203",
       "SCV 204"
     ]
   },
   "SCV 203": {
-    "text": "<p>This course is being proposed to provide the on-campus veterinary nursing lab for the Veterinary Nursing Option I track of veterinary nursing training. This on-campus course will be a corequisite to SCV202. The SCV202/SCV203 course pair replaces Veterinary Nursing I (SCV210).</p>",
+    "text": "This course is being proposed to provide the on-campus veterinary nursing lab for the Veterinary Nursing Option I track of veterinary nursing training. This on-campus course will be a corequisite to SCV202. The SCV202/SCV203 course pair replaces Veterinary Nursing I (SCV210)",
     "courses": [
       "SCV 202",
       "SCV 210"
     ]
   },
   "SCV 204": {
-    "text": "<p>This new course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This course will be a corequisite to SCV202. The SCV202/SCV204 course pair replaces Veterinary Nursing I (SCV210).</p>",
+    "text": "This new course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This course will be a corequisite to SCV202. The SCV202/SCV204 course pair replaces Veterinary Nursing I (SCV210)",
     "courses": [
       "SCV 202",
       "SCV 210"
     ]
   },
   "SEC 35": {
-    "text": "<p>SEC 35 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision.&nbsp; The current prerequisites, KEY 11 and WPR 11, are no longer part of the MOA AAS degree.&nbsp; The new prerequisite of BIO 22 will prepare students for the content of SEC 35. Minor grammatical changes have been made to the course description.</p>",
+    "text": "SEC 35 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision. The current prerequisites, KEY 11 and WPR 11, are no longer part of the MOA AAS degree. The new prerequisite of BIO 22 will prepare students for the content of SEC 35. Minor grammatical changes have been made to the course description",
     "courses": [
       "BIO 22",
       "KEY 11",
+      "SEC 35",
       "WPR 11"
     ]
   },
@@ -27485,13 +27487,13 @@
     "courses": []
   },
   "SOCI 203": {
-    "text": "<table><tbody><tr><td><p>The College proposes revising the course description and removing the pre-requisite of HSVC 103 in order to open the course to students in programs of study outside of Human Services.</p></td></tr></tbody></table>",
+    "text": "The College proposes revising the course description and removing the pre-requisite of HSVC 103 in order to open the course to students in programs of study outside of Human Services",
     "courses": [
       "HSVC 103"
     ]
   },
   "SOCI 214": {
-    "text": "<table><tbody><tr><td><p>The College proposes removing the pre-requisites for the course in order to broaden access and enable more students to enroll in the course.</p></td></tr></tbody></table>",
+    "text": "The College proposes removing the pre-requisites for the course in order to broaden access and enable more students to enroll in the course",
     "courses": []
   },
   "SOCY 101": {
@@ -27820,11 +27822,11 @@
     ]
   },
   "SPE 100": {
-    "text": "<p>update prereq RG</p>",
+    "text": "update prereq RG",
     "courses": []
   },
   "SPE 102": {
-    "text": "<p>Update prereq RG</p>",
+    "text": "Update prereq RG",
     "courses": []
   },
   "SPE 201": {
@@ -27860,28 +27862,31 @@
     ]
   },
   "SPN 109": {
-    "text": "<p>This semester, the World Languages and Cultures Department is running two sections of an introductory medical Spanish course that has not been offered in quite some time. The revamped course, SPN 108-Spanish for Health Professions, has generated significant interest, and both sections have strong enrollment (16 students in one section, 10 students in the other). The course has also garnered interest from students who are either heritage or native speakers of Spanish—a total of 26 students who enrolled in SPN 108 were identified as having a degree of knowledge and fluency that exceeds what is covered in an introductory language course. Unfortunately, this cohort of students could not be allowed to take the class because of their more advanced fluency. Many of these students asked to remain enrolled in the course so that they could learn medical terminology in Spanish. However, in keeping with best practices in language pedagogy, courses with a wide spectrum of linguistic ability and knowledge pose challenges to true beginners, who often feel that they are making insufficient progress when they compare their output to that of more advanced students, as well as to heritage/native speakers, who benefit from a different approach to grammatical instruction that assumes prior knowledge.</p><p>To accommodate heritage and native speakers interested in taking a medical Spanish course and to ensure instructional environments conducive to learners at all levels, the department proposes modifying another course currently on the books, SPN 19-Elementary Spanish for Nurses and Hospital Personnel II. The modified course, SPN 109-Spanish for Health Professions II, will be designed for students with intermediate to advanced fluency and will cover medical terminology, cultural topics relevant to Spanish-speaking communities in medical settings (e.g., attitudes toward healthcare professionals and more holistic/traditional forms of medicine; regional differences in diet; the role of families in caring for aging and sick relatives), and grammatical concepts typically presented in upper-level Spanish classes. This course will not only provide students with the kind of technical vocabulary in which they have expressed interest but will also help students refine their reading and writing skills in Spanish (two linguistic competencies that are often weaker than speaking and listening ability in heritage and some native speakers), thereby giving students a greater set of skills to employ in their chosen medical field.</p><p>The proposed reduction in the number of credits is intended to make this course Pathways compliant and to make it easier for students in the allied health fields who may be interested in taking a medical Spanish class to accommodate the course in their respective programs of study. The revised course title will create consistency between this course and SPN 108-Spanish for Health Professions. The revised course number also aims to create continuity between this course and SPN 108, aligning with the department’s regular Spanish offerings, all of which have three-digit designations. The revised prerequisite helps distinguish this upper intermediate-low advanced course from the beginner-level SPN 108. Finally, the proposed changes to the course description specify the level of the course and provide greater clarity regarding the class’s lexical, grammatical, and cultural content.</p><p>&nbsp;</p>",
+    "text": "This semester, the World Languages and Cultures Department is running two sections of an introductory medical Spanish course that has not been offered in quite some time. The revamped course, SPN 108-Spanish for Health Professions, has generated significant interest, and both sections have strong enrollment (16 students in one section, 10 students in the other). The course has also garnered interest from students who are either heritage or native speakers of Spanish—a total of 26 students who enrolled in SPN 108 were identified as having a degree of knowledge and fluency that exceeds what is covered in an introductory language course. Unfortunately, this cohort of students could not be allowed to take the class because of their more advanced fluency. Many of these students asked to remain enrolled in the course so that they could learn medical terminology in Spanish. However, in keeping with best practices in language pedagogy, courses with a wide spectrum of linguistic ability and knowledge pose challenges to true beginners, who often feel that they are making insufficient progress when they compare their output to that of more advanced students, as well as to heritage/native speakers, who benefit from a different approach to grammatical instruction that assumes prior knowledge; To accommodate heritage and native speakers interested in taking a medical Spanish course and to ensure instructional environments conducive to learners at all levels, the department proposes modifying another course currently on the books, SPN 19-Elementary Spanish for Nurses and Hospital Personnel II. The modified course, SPN 109-Spanish for Health Professions II, will be designed for students with intermediate to advanced fluency and will cover medical terminology, cultural topics relevant to Spanish-speaking communities in medical settings (e.g., attitudes toward healthcare professionals and more holistic/traditional forms of medicine; regional differences in diet; the role of families in caring for aging and sick relatives), and grammatical concepts typically presented in upper-level Spanish classes. This course will not only provide students with the kind of technical vocabulary in which they have expressed interest but will also help students refine their reading and writing skills in Spanish (two linguistic competencies that are often weaker than speaking and listening ability in heritage and some native speakers), thereby giving students a greater set of skills to employ in their chosen medical field; The proposed reduction in the number of credits is intended to make this course Pathways compliant and to make it easier for students in the allied health fields who may be interested in taking a medical Spanish class to accommodate the course in their respective programs of study. The revised course title will create consistency between this course and SPN 108-Spanish for Health Professions. The revised course number also aims to create continuity between this course and SPN 108, aligning with the department’s regular Spanish offerings, all of which have three-digit designations. The revised prerequisite helps distinguish this upper intermediate-low advanced course from the beginner-level SPN 108. Finally, the proposed changes to the course description specify the level of the course and provide greater clarity regarding the class’s lexical, grammatical, and cultural content",
     "courses": [
       "SPN 108",
+      "SPN 109",
       "SPN 19"
     ]
   },
   "SPN 112": {
-    "text": "<p>Including SPN 108-Spanish for Health Professions among the prerequisites for SPN 112 will make it clear to students (and advisors) that SPN 111 and SPN 108 are equivalent and that both courses prepare students for successful completion of SPN 112. The proposed change in course description is intended to highlight the equivalency between SPN 108 and SPN 111, provide more information regarding the course’s grammatical, lexical, and cultural content, and make clear that the course is not intended for heritage or native speakers.</p>",
+    "text": "Including SPN 108-Spanish for Health Professions among the prerequisites for SPN 112 will make it clear to students (and advisors) that SPN 111 and SPN 108 are equivalent and that both courses prepare students for successful completion of SPN 112. The proposed change in course description is intended to highlight the equivalency between SPN 108 and SPN 111, provide more information regarding the course’s grammatical, lexical, and cultural content, and make clear that the course is not intended for heritage or native speakers",
     "courses": [
       "SPN 108",
-      "SPN 111"
+      "SPN 111",
+      "SPN 112"
     ]
   },
   "SPN 120": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses",
     "courses": [
       "SPN 113",
-      "SPN 117"
+      "SPN 117",
+      "SPN 120"
     ]
   },
   "SPN 121": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -27889,7 +27894,7 @@
     ]
   },
   "SPN 122": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p><p>&nbsp;</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -27897,7 +27902,7 @@
     ]
   },
   "SPN 124": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -27905,7 +27910,7 @@
     ]
   },
   "SPN 125": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -27913,14 +27918,14 @@
     ]
   },
   "SPN 126": {
-    "text": "<p>The Department of World Languages and Cultures plans to offer its business Spanish course for the first time in several years. The course increases the diversity of the department’s course offerings, as current upper-level Spanish classes are mostly dedicated to history, cultural, and/or literary production. The course, which will be of interest both to students in the AA-Spanish Option and to students in other AA-Liberal Arts and Sciences degree programs, aligns with a larger nationwide trend of developing classes dedicated to Spanish for the professions. The proposed change in course title reflects the international reach of Spanish in the business world and aligns with comparable courses at several CUNY schools, including Hunter (SPAN 37143-Spanish for Global Work), LaGuardia (ELS 220-Spanish for Global Business), and City College (SPAN 32600-Spanish in the Business World). We propose changing the course number to create greater consistency with the department’s regular offerings in Spanish, all of which have three-digit course numbers. Similarly, the revised pre-requisite also aligns with the department’s regular Pathways offerings at the intermediate and advanced levels, all of which have SPN 113 and/or the Spanish placement test as a pre-requisite. Finally, the proposed revision to the course description seeks to add clarity regarding the level of the class (i.e., this is an upper-intermediate to low-advanced course and specifying that the class is only intended for advanced-level students may dissuade students who place into intermediate-level courses from enrolling.)</p><p>&nbsp;</p>",
+    "text": "The Department of World Languages and Cultures plans to offer its business Spanish course for the first time in several years. The course increases the diversity of the department’s course offerings, as current upper-level Spanish classes are mostly dedicated to history, cultural, and/or literary production. The course, which will be of interest both to students in the AA-Spanish Option and to students in other AA-Liberal Arts and Sciences degree programs, aligns with a larger nationwide trend of developing classes dedicated to Spanish for the professions. The proposed change in course title reflects the international reach of Spanish in the business world and aligns with comparable courses at several CUNY schools, including Hunter (SPAN 37143-Spanish for Global Work), LaGuardia (ELS 220-Spanish for Global Business), and City College (SPAN 32600-Spanish in the Business World). We propose changing the course number to create greater consistency with the department’s regular offerings in Spanish, all of which have three-digit course numbers. Similarly, the revised pre-requisite also aligns with the department’s regular Pathways offerings at the intermediate and advanced levels, all of which have SPN 113 and/or the Spanish placement test as a pre-requisite. Finally, the proposed revision to the course description seeks to add clarity regarding the level of the class (i.e., this is an upper-intermediate to low-advanced course and specifying that the class is only intended for advanced-level students may dissuade students who place into intermediate-level courses from enrolling.)",
     "courses": [
       "ELS 220",
       "SPN 113"
     ]
   },
   "SPN 130": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -27928,7 +27933,7 @@
     ]
   },
   "SPN 131": {
-    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "text": "The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language",
     "courses": [
       "SPN 113",
       "SPN 117",
@@ -28144,10 +28149,8 @@
     ]
   },
   "ST 100": {
-    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>The program is adding a new course, ST 990 – Integrated Healthcare Sciences and Medical Terminology (3 credits, 3 hours lecture). This will serve as a Gateway course for program admission and addresses the ARC/STSA CCST-7e requirements. In addition, the course incorporates some content for sterile processing in line with ARC/STSA CCST- 7e requirements, allowing students who have the sterile processing credential to receive Credit for Prior Learning (CPL) for the course. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5aChangeinPrereqandCorequ-ST100-SurgicalTechnologyI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5aChangeinPrereqandCorequ-ST100-SurgicalTechnologyI.pdf</a></p>",
+    "text": "Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; The program is adding a new course, ST 990 – Integrated Healthcare Sciences and Medical Terminology (3 credits, 3 hours lecture). This will serve as a Gateway course for program admission and addresses the ARC/STSA CCST-7e requirements. In addition, the course incorporates some content for sterile processing in line with ARC/STSA CCST- 7e requirements, allowing students who have the sterile processing credential to receive Credit for Prior Learning (CPL) for the course; ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements; In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5aChangeinPrereqandCorequ-ST100-SurgicalTechnologyI.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
       "ST 200",
       "ST 990"
     ]
@@ -28172,47 +28175,38 @@
     ]
   },
   "ST 300": {
-    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. This included revisions to ST 300 – Surgical Technology III and the determination that the course could be reconfigured to a 3 credit 3 hour lecture. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>Revisions to course description reflects that the corequisite course of ST 3P00 – Practicum I is a clinical component as opposed to a practice laboratory</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5cChangeinCrd_Hrs_Description_Prereq_Coreq-ST300-SurgicalTechnologyIII.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5cChangeinCrd_Hrs_Description_Prereq_Coreq-ST300-SurgicalTechnologyIII.pdf</a></p>",
+    "text": "Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. This included revisions to ST 300 – Surgical Technology III and the determination that the course could be reconfigured to a 3 credit 3 hour lecture; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements; Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes; Revisions to course description reflects that the corequisite course of ST 3P00 – Practicum I is a clinical component as opposed to a practice laboratory; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5cChangeinCrd_Hrs_Description_Prereq_Coreq-ST300-SurgicalTechnologyIII.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
       "ST 200",
+      "ST 300",
       "ST 400"
     ]
   },
   "ST 3P00": {
-    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5dChangeinPrereq_Coreq-ST3P00-PracticumI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5dChangeinPrereq_Coreq-ST3P00-PracticumI.pdf</a></p>",
+    "text": "Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements; Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5dChangeinPrereq_Coreq-ST3P00-PracticumI.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
       "ST 200",
       "ST 300",
       "ST 400"
     ]
   },
   "ST 400": {
-    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5eChangeinPrereq_Coreq-ST400-SurgicalProcedures.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5eChangeinPrereq_Coreq-ST400-SurgicalProcedures.pdf</a></p>",
+    "text": "Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5eChangeinPrereq_Coreq-ST400-SurgicalProcedures.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
-      "ST 300"
+      "ST 300",
+      "ST 400"
     ]
   },
   "ST 4P00": {
-    "text": "<p>11/20/2024 - Per A Kalin <a href=\"https://cuny907.sharepoint.com/sites/CUNYChancellorUniversityReportsandAcademicUniversityReportCA/Shared%20Documents/General/2008/2%20-%20JUNE%202008%20Chancellor%27s%20Report%20-%20Part%20A_%20Academic%20Matters.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">JUNE 2008 Chancellor's Report - Part A_ Academic Matters.pdf</a> ST 4P00 Changed from 3crs - 2crs.</p><p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRUCULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5fChangeinPrereq_Coreq-ST4P00-PracticumII.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5fChangeinPrereq_Coreq-ST4P00-PracticumII.pdf</a></p>",
+    "text": "11/20/2024 - Per A Kalin JUNE 2008 Chancellor's Report - Part A_ Academic Matters.pdf ST 4P00 Changed from 3crs - 2crs; 5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo); Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes; CURRUCULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5fChangeinPrereq_Coreq-ST4P00-PracticumII.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
-      "JUNE 2008",
       "ST 300",
       "ST 400"
     ]
   },
   "ST 6P00": {
-    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Material covered in ST 4500 – Surgical Pharmacology has been distributed to ST 300. In addition, the changes to course sequencing, with ST 400, ST 4P00 and ST 300 and ST 3P00 be taken in the same semester, allowed for better alignment with student clinical and lecture expectations, in turn making ST 4500 redundant within the curriculum. In turn, an update to the pre-/co-requisite for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5hChangeinPre-_Co-req-ST6P00-PracticumIV.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5hChangeinPre-_Co-req-ST6P00-PracticumIV.pdf</a></p>",
+    "text": "5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo); Explanation : The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date; The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care; Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e; In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program; Material covered in ST 4500 – Surgical Pharmacology has been distributed to ST 300. In addition, the changes to course sequencing, with ST 400, ST 4P00 and ST 300 and ST 3P00 be taken in the same semester, allowed for better alignment with student clinical and lecture expectations, in turn making ST 4500 redundant within the curriculum. In turn, an update to the pre-/co-requisite for the course was required to reflect these changes; CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR; https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5hChangeinPre-_Co-req-ST6P00-PracticumIV.pdf",
     "courses": [
-      "FALL 2023",
-      "FEB 2024",
       "ST 300",
       "ST 400",
       "ST 4500"
@@ -28945,29 +28939,29 @@
     ]
   },
   "TRS 202": {
-    "text": "<p>This prerequisite change aims to raise proficiency level in Spanish of entering students. </p>",
+    "text": "This prerequisite change aims to raise proficiency level in Spanish of entering students",
     "courses": []
   },
   "TRS 233": {
-    "text": "<p>This prerequisite change aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "text": "This prerequisite change aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate",
     "courses": []
   },
   "TRS 234": {
-    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "text": "This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate",
     "courses": []
   },
   "TRS 235": {
-    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "text": "This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate",
     "courses": []
   },
   "TRS 237": {
-    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate and to remove TRS 202 as a mandatory course and allow room for an extra TRS 23x course.</p>",
+    "text": "This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate and to remove TRS 202 as a mandatory course and allow room for an extra TRS 23x course",
     "courses": [
       "TRS 202"
     ]
   },
   "TRS 345": {
-    "text": "<p>This course number change is to more accurately represent the course level and prerequisite change aims to expand students' course options at the TRS 23x level. </p>",
+    "text": "This course number change is to more accurately represent the course level and prerequisite change aims to expand students' course options at the TRS 23x level",
     "courses": []
   },
   "TS 025": {
@@ -29811,9 +29805,10 @@
     ]
   },
   "WPR 21": {
-    "text": "<p>WPR 21 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision.&nbsp; The current co-requisite, KEY 11, is no longer part of the MOA AAS degree and thus eliminated.&nbsp; The course credits are being reduced from three down to two.&nbsp; The current course hours (3 recitation) does not adequately reflect how the course is taught. &nbsp;The course relies heavily on computer applications (MS Word) and thus two of the hours are lab hours.&nbsp; The change correctly computes the total credits for a 1-hour recitation, 2-hour lab course.</p>",
+    "text": "WPR 21 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision. The current co-requisite, KEY 11, is no longer part of the MOA AAS degree and thus eliminated. The course credits are being reduced from three down to two. The current course hours (3 recitation) does not adequately reflect how the course is taught. The course relies heavily on computer applications (MS Word) and thus two of the hours are lab hours. The change correctly computes the total credits for a 1-hour recitation, 2-hour lab course",
     "courses": [
-      "KEY 11"
+      "KEY 11",
+      "WPR 21"
     ]
   },
   "WRT 001": {

--- a/scripts/lib/__tests__/prereq-sanitize.test.ts
+++ b/scripts/lib/__tests__/prereq-sanitize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractCourseCodes,
+  hasMarkup,
+  sanitizeCourseList,
+  sanitizePrereqEntry,
+  sanitizePrereqText,
+} from "../prereq-sanitize";
+
+describe("sanitizePrereqText", () => {
+  it("converts NC's ',<br>' separators to '; ' (verbatim BTB 103 fixture)", () => {
+    // data/nc/prereqs.json "BTB 103" as re-contaminated by the 2026-06-10
+    // prereqs cron tick — the case PR #973 fixed in data only.
+    const raw =
+      "Take BTB-102 - Must be taken either prior to or at the same time as this course.,<br>Take BTB-101 - Must be completed prior to taking this course.";
+    expect(sanitizePrereqText(raw)).toBe(
+      "Take BTB-102 - Must be taken either prior to or at the same time as this course; Take BTB-101 - Must be completed prior to taking this course.",
+    );
+  });
+
+  it("strips NY's <p>/<u> change-log markup and decodes &amp;", () => {
+    const raw =
+      "<p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Government &amp; Not-for-Profit course.</p>";
+    const clean = sanitizePrereqText(raw);
+    expect(clean).not.toMatch(/[<>]/);
+    expect(clean).toContain("Government & Not-for-Profit");
+  });
+
+  it("decodes double-encoded &amp;nbsp;", () => {
+    expect(sanitizePrereqText("MATH&amp;nbsp;141 min 2.0")).toBe(
+      "MATH 141 min 2.0",
+    );
+  });
+
+  it("leaves plain text untouched", () => {
+    const plain = "ACCT 101 with a C or better, or entry code";
+    expect(sanitizePrereqText(plain)).toBe(plain);
+  });
+});
+
+describe("extractCourseCodes", () => {
+  it("mines hyphenated NC codes into 'PREFIX NUMBER' form", () => {
+    expect(
+      extractCourseCodes(
+        "Take BTB-102 - Must be taken either prior to or at the same time as this course; Take BTB-101 - Must be completed prior to taking this course.",
+      ),
+    ).toEqual(["BTB 101", "BTB 102"]);
+  });
+
+  it("handles space-run lists and excludes term stamps", () => {
+    expect(
+      extractCourseCodes("Take PHM-110 PHM-111; effective FALL 2023"),
+    ).toEqual(["PHM 110", "PHM 111"]);
+  });
+});
+
+describe("sanitizeCourseList", () => {
+  it("drops NY's effective-term tokens but keeps real codes", () => {
+    expect(sanitizeCourseList(["FALL 2023", "FEB 2024", "ACC 122"])).toEqual([
+      "ACC 122",
+    ]);
+  });
+
+  it("keeps May-prefixed real codes intact (only MONTH+YEAR shapes drop)", () => {
+    expect(sanitizeCourseList(["MAY 150", "MAY 2024"])).toEqual(["MAY 150"]);
+  });
+});
+
+describe("sanitizePrereqEntry", () => {
+  it("re-mines courses[] when markup was present (NC entries had empty arrays)", () => {
+    const { text, courses } = sanitizePrereqEntry(
+      "Take BTB-102 - Must be taken either prior to or at the same time as this course.,<br>Take BTB-101 - Must be completed prior to taking this course.",
+      [],
+    );
+    expect(text).not.toMatch(/[<>]/);
+    expect(courses).toEqual(["BTB 101", "BTB 102"]);
+  });
+
+  it("does not re-mine clean entries — scraper-provided courses stay as-is", () => {
+    const { text, courses } = sanitizePrereqEntry(
+      "AUB 111 and AUB 121, or instructor consent. See ENG 101.",
+      ["AUB 111", "AUB 121"],
+    );
+    expect(text).toContain("ENG 101");
+    // ENG 101 is mentioned in prose but the scraper chose not to list it —
+    // clean entries are not second-guessed.
+    expect(courses).toEqual(["AUB 111", "AUB 121"]);
+  });
+
+  it("flags markup via hasMarkup", () => {
+    expect(hasMarkup("a <br> b")).toBe(true);
+    expect(hasMarkup("R&D 101 — no entities here")).toBe(false);
+    expect(hasMarkup("Tom &amp; Jerry")).toBe(true);
+  });
+});

--- a/scripts/lib/aggregate-prereqs.ts
+++ b/scripts/lib/aggregate-prereqs.ts
@@ -28,6 +28,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { getAllStates, getStateConfig } from "../../lib/states/registry";
+import { sanitizePrereqEntry } from "./prereq-sanitize";
 
 interface CourseSection {
   course_prefix: string;
@@ -188,7 +189,12 @@ export function aggregateState(
         const number = section.course_number?.trim();
         if (!prefix || !number) continue;
 
-        mergePrereq(prereqs, `${prefix} ${number}`, text || "", courses || []);
+        // Scrapers sometimes deliver raw markup (",<br>" separators, "<p>"
+        // prose) and term-stamp junk in courses[] — clean it here so a
+        // cron rebuild can never re-contaminate prereqs.json (PR #973 fixed
+        // the data only, and the next scheduled run reverted it).
+        const clean = sanitizePrereqEntry(text || "", courses || []);
+        mergePrereq(prereqs, `${prefix} ${number}`, clean.text, clean.courses);
       }
     }
   }
@@ -232,7 +238,8 @@ export function aggregateState(
         const number = c.number?.trim();
         if (!prefix || !number) continue;
 
-        mergePrereq(prereqs, `${prefix} ${number}`, text, courseList);
+        const clean = sanitizePrereqEntry(text, courseList);
+        mergePrereq(prereqs, `${prefix} ${number}`, clean.text, clean.courses);
       }
     }
   }

--- a/scripts/lib/prereq-sanitize.ts
+++ b/scripts/lib/prereq-sanitize.ts
@@ -1,0 +1,109 @@
+/**
+ * prereq-sanitize.ts — HTML/entity cleanup for prerequisite entries.
+ *
+ * Course scrapers sometimes deliver prerequisite_text with raw markup
+ * (NC sections carry ",<br>" separators; NY catalog text arrives as full
+ * "<p>…</p>" change-log prose) and prerequisite_courses arrays polluted
+ * with effective-term tokens ("FALL 2023"). The aggregator
+ * (scripts/lib/aggregate-prereqs.ts) used to copy both verbatim, so any
+ * data-only cleanup (PR #973) was reverted by the next prereqs cron tick.
+ * Sanitizing here — at the point entries are built — is the durable fix.
+ */
+
+/** Tags that read as separators between requirement clauses. */
+const SEPARATOR_TAG = /<\s*(?:br|\/p|\/li|\/div|\/tr)\s*\/?\s*>/gi;
+
+/** Month / season + 4-digit year — an effective-term stamp, not a course. */
+const TERM_TOKEN =
+  /^(?:FALL|SPRING|SUMMER|WINTER|JAN(?:UARY)?|FEB(?:RUARY)?|MAR(?:CH)?|APR(?:IL)?|MAY|JUNE?|JULY?|AUG(?:UST)?|SEPT?(?:EMBER)?|OCT(?:OBER)?|NOV(?:EMBER)?|DEC(?:EMBER)?)\s+(?:19|20)\d{2}$/;
+
+function decodeEntities(s: string): string {
+  return (
+    s
+      .replace(/&nbsp;?/gi, " ")
+      .replace(/&#160;?/g, " ")
+      .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;|&apos;/g, "'")
+      // Second pass: double-encoded "&amp;nbsp;" only becomes "&nbsp;"
+      // after the &amp; decode above (seen in WA acalog catalogs).
+      .replace(/&nbsp;?/gi, " ")
+      .replace(/&#160;?/g, " ")
+      .replace(/ /g, " ")
+  );
+}
+
+/**
+ * Strip markup from prerequisite text. Block/line-break tags become "; "
+ * so multi-clause requirements stay readable ("Take BTB-102 …; Take
+ * BTB-101 …"); every other tag is dropped outright.
+ */
+export function sanitizePrereqText(raw: string): string {
+  if (!raw) return "";
+  let text = raw
+    // Punctuation immediately before a separator tag would double up once
+    // the tag becomes "; " ("…course.,<br>Take…" → "…course.; Take…") —
+    // drop it so the separator stands alone.
+    .replace(/\s*[.,;]+\s*(?=<\s*(?:br|\/p|\/li|\/div|\/tr)\b)/gi, "")
+    .replace(SEPARATOR_TAG, "; ")
+    .replace(/<[^>]+>/g, " ");
+  text = decodeEntities(text)
+    .replace(/\s+/g, " ")
+    .replace(/\s*;\s*(?:;\s*)+/g, "; ") // collapse ";  ;" runs
+    .replace(/^[\s;,.]+|[\s;,]+$/g, "")
+    .trim();
+  return text;
+}
+
+/** True when sanitizing would change anything markup-related. */
+export function hasMarkup(raw: string): boolean {
+  return /<[a-z/!]|&[a-z]+;|&#\d+;?/i.test(raw);
+}
+
+/**
+ * Pull "PREFIX NUMBER" course codes out of (already sanitized) prereq
+ * text. Handles hyphenated forms ("BTB-102" → "BTB 102") and common-
+ * course-numbering "&" suffixes. Term stamps ("FALL 2023") are excluded.
+ */
+export function extractCourseCodes(text: string): string[] {
+  const out = new Set<string>();
+  const re = /\b([A-Z]{2,6}&?)[-\s]+(\d{1,4}[A-Z]{0,2})\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (TERM_TOKEN.test(code)) continue;
+    out.add(code);
+  }
+  return Array.from(out).sort();
+}
+
+/** Drop non-course tokens (effective-term stamps) from a courses array. */
+export function sanitizeCourseList(courses: string[]): string[] {
+  return courses.filter((c) => !TERM_TOKEN.test(c.trim().toUpperCase()));
+}
+
+/**
+ * Sanitize one prereq entry. When the original text carried markup, the
+ * upstream scraper's course extraction usually missed codes hidden behind
+ * tags (NC's 8 ",<br>" entries all had empty courses[]) — in that case the
+ * cleaned text is re-mined and unioned in. Clean-text entries keep their
+ * scraper-provided courses untouched (minus term-stamp junk) so this never
+ * perturbs the 99% of entries that were already fine.
+ */
+export function sanitizePrereqEntry(
+  text: string,
+  courses: string[],
+): { text: string; courses: string[] } {
+  const dirty = hasMarkup(text);
+  const cleanText = dirty ? sanitizePrereqText(text) : text;
+  let cleanCourses = sanitizeCourseList(courses);
+  if (dirty) {
+    cleanCourses = Array.from(
+      new Set([...cleanCourses, ...extractCourseCodes(cleanText)]),
+    ).sort();
+  }
+  return { text: cleanText, courses: cleanCourses };
+}

--- a/scripts/ny/scrape-catalog-prereqs.ts
+++ b/scripts/ny/scrape-catalog-prereqs.ts
@@ -35,6 +35,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { chromium, type Browser, type Page, type Request } from "playwright";
+import { sanitizePrereqEntry, sanitizePrereqText } from "../lib/prereq-sanitize";
 
 // CUNY community college Coursedog subdomains. Slug matches the subdomain.
 // Some schools may 500 intermittently — we log and continue past failures.
@@ -250,7 +251,10 @@ function extractPrereqString(course: CourseDoc): string | null {
  * this verbatim.
  */
 function normalizePrereqText(raw: string): string {
-  let t = raw.replace(/\s+/g, " ").trim();
+  // Some CUNY customFields values arrive as full "<p><u>Explanation</u>…"
+  // change-log prose — strip markup/entities before the local cleanup
+  // (250 NY entries shipped with raw tags before this pass existed).
+  let t = sanitizePrereqText(raw).replace(/\s+/g, " ").trim();
   t = t.replace(PREREQ_PREFIX_RE, "").trim();
   t = t.replace(/[.;,]+\s*$/, "").trim();
   return t;
@@ -259,6 +263,16 @@ function normalizePrereqText(raw: string): string {
 // Boilerplate that means "no real prereq". CUNY reuses a handful of these.
 const BOILERPLATE_RE =
   /^(none|n\/a|not applicable|no prerequisites?( required)?)\.?$/i;
+
+/**
+ * The customFields scan keys off a "PREREQ" marker, which occasionally
+ * matches pasted curriculum-committee email threads instead of prereq text
+ * (KBCC's ENG 6000 shipped a full From/Sent/Subject thread with staff
+ * email addresses to prod). Real prereq text never has mail headers.
+ */
+function isJunkPrereq(text: string): boolean {
+  return /@/.test(text) && /\b(From|Sent|Subject|Cc):\s/.test(text);
+}
 
 /**
  * Extract course codes referenced in the prereq text. CUNY uses three forms:
@@ -388,9 +402,11 @@ async function scrapeSchool(
     const raw = extractPrereqString(c);
     if (!raw) continue;
     const text = normalizePrereqText(raw);
-    if (!text || BOILERPLATE_RE.test(text)) continue;
-    const courses = extractCourseCodes(text, key);
-    prereqs[key] = { text, courses };
+    if (!text || BOILERPLATE_RE.test(text) || isJunkPrereq(text)) continue;
+    // sanitizePrereqEntry drops effective-term stamps ("FALL 2023") the
+    // code regex otherwise matches as courses.
+    const clean = sanitizePrereqEntry(text, extractCourseCodes(text, key));
+    prereqs[key] = { text: clean.text, courses: clean.courses };
     hits++;
   }
   console.log(`  ${hits} courses with prereqs (of ${pool.length} scanned)`);
@@ -426,21 +442,49 @@ async function main() {
   if (limit > 0) console.log(`  limit=${limit} per school`);
 
   const browser = await chromium.launch({ headless: true });
+
+  // Seed from the committed file so a CUNY-only run can't wipe what the
+  // SUNY acalog scraper contributed (same failure class as the MA
+  // 1946→1020 wipe — this script used to write CUNY-only output).
+  // Re-sanitizing the preserved entries makes every cron tick self-healing
+  // for legacy contamination, not just newly scraped text.
   const merged: Record<string, PrereqEntry> = {};
+  const seededKeys = new Set<string>();
+  const outDirEarly = path.join(process.cwd(), "data", "ny");
+  const outPathEarly = path.join(outDirEarly, "prereqs.json");
+  try {
+    const existing = JSON.parse(fs.readFileSync(outPathEarly, "utf-8")) as Record<
+      string,
+      PrereqEntry
+    >;
+    for (const [k, v] of Object.entries(existing)) {
+      if (!v || typeof v !== "object") continue;
+      if (isJunkPrereq(v.text ?? "")) continue; // shed legacy email-thread junk
+      const clean = sanitizePrereqEntry(v.text ?? "", v.courses ?? []);
+      merged[k] = { ...v, text: clean.text, courses: clean.courses };
+      seededKeys.add(k);
+    }
+    console.log(`  seeded ${Object.keys(merged).length} existing entries (sanitized)`);
+  } catch {
+    // no existing file — fresh build
+  }
   const counts: { slug: string; count: number }[] = [];
 
   for (const school of targets) {
     try {
       const res = await scrapeSchool(browser, school, limit);
       counts.push({ slug: school.slug, count: Object.keys(res).length });
-      // Merge: last writer wins. If two schools describe the same course key
-      // with different text, keep the one with more referenced courses (more
-      // informative). This is rare — CUNY codes like "ENGL 101" exist on
-      // multiple campuses but the prereq boilerplate tends to match.
+      // Merge: a freshly scraped entry always replaces a seeded (previous
+      // run) one for the same key — newer catalog data wins over stale.
+      // Between two schools in the SAME run, keep the entry with more
+      // referenced courses (more informative). This is rare — CUNY codes
+      // like "ENGL 101" exist on multiple campuses but the prereq
+      // boilerplate tends to match.
       for (const [k, v] of Object.entries(res)) {
         const existing = merged[k];
-        if (!existing || v.courses.length > existing.courses.length) {
+        if (!existing || seededKeys.has(k) || v.courses.length > existing.courses.length) {
           merged[k] = v;
+          seededKeys.delete(k);
         }
       }
     } catch (e) {


### PR DESCRIPTION
## What changes for someone using the site

Prerequisite text in North Carolina and New York stops showing raw HTML. Eight NC courses (BTB 103, EDU 234A, MRN 121, MSC 256, PHM 120, PHM 136, VET 220, WBL 115U) displayed literal `,<br>` mid-sentence — and because the markup hid the course codes, their prerequisite chains dead-ended in the planner. Now BTB 103 resolves its full chain (BTB 101 → DFT-100, BTB 102). In NY, 250 entries lose their `<p>`/`<u>` markup, 40 bogus "FALL 2023"-style entries disappear from prerequisite lists, and one Kingsborough course that was displaying a **pasted staff email thread** (with employee email addresses) as its "prerequisite" is dropped.

## What changed on the technical front

**Why this won't regress:** PR #973 cleaned the same 8 NC entries by editing the data file — and the next scheduled prereqs run regenerated the file from course sections and put the HTML straight back. The durable fix is in the pipeline: a new shared `scripts/lib/prereq-sanitize.ts` (tag-strip with `<br>` → `; ` separators, entity decode including double-encoded `&amp;nbsp;`, term-stamp filtering, and re-mining course codes from cleaned text when markup hid them) wired into:

- `scripts/lib/aggregate-prereqs.ts` — both entry-build call sites; covers NC and every other `aggregate-from-courses` state on every future cron tick
- `scripts/ny/scrape-catalog-prereqs.ts` (CUNY Coursedog) — the actual source of NY's contamination (NY is *not* an aggregate state; the goal's premise was corrected mid-investigation)

**Two adjacent CUNY scraper bugs fixed in passing, same failure class:**
- It wrote CUNY-only output to `data/ny/prereqs.json`, so a CUNY-only cron tick would have wiped every entry the SUNY acalog scraper contributed (the MA 1946→1020 wipe pattern). It now seeds from the existing file — re-sanitizing those entries, so every run self-heals legacy contamination — with fresh-beats-seeded merge semantics.
- Its `PREREQ` marker scan occasionally matched pasted curriculum-committee email threads; a mail-header guard (`@` + `From:/Sent:/Subject:`) drops those at scrape time and sheds existing ones at seed time.

Data in this PR was regenerated through the real pipeline (aggregator run for NC; a minimal CUNY run for NY that exercises the seed-sanitize path): NC 2,490 → 2,517 entries, NY 4,681 → 4,680, both with **zero** entries containing markup.

## Test plan

- [x] 11 new unit tests in `scripts/lib/__tests__/prereq-sanitize.test.ts` with verbatim NC/NY fixtures (102 lib tests pass total)
- [x] `npx tsc --noEmit`, `npm run check:data` (0 errors), prereq-regression check (NC 101.1% of HEAD)
- [x] Dev: `/api/nc/prereqs/chain?course=BTB 103` resolves the previously dead-ended chain
- [ ] Post-merge: next scheduled prereqs run keeps both files clean (the thing #973 couldn't do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
