### PR TITLE
ca: fix the 17 eslint errors keeping the Test workflow red

### DIFF
--- a/scripts/ca/scrape-ccsf.ts
+++ b/scripts/ca/scrape-ccsf.ts
@@ -48,6 +48,7 @@
  */
 
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -180,7 +181,7 @@ interface MeetingInfo {
  */
 function parseMeeting(
   $: cheerio.CheerioAPI,
-  cell: cheerio.Cheerio<any>,
+  cell: cheerio.Cheerio<AnyNode>,
   year: number
 ): MeetingInfo {
   const firstLi = cell.find("li").first();
@@ -222,7 +223,7 @@ function parseMeeting(
 }
 
 /** Derive mode from the modality icon's title attribute in the row. */
-function parseMode(tdNothing: cheerio.Cheerio<any>, campus: string): Mode {
+function parseMode(tdNothing: cheerio.Cheerio<AnyNode>, campus: string): Mode {
   const title = (tdNothing.find("[title]").attr("title") ?? "").toLowerCase();
   if (title.includes("online")) {
     return title.includes("hybrid") ? "hybrid" : "online";
@@ -234,7 +235,7 @@ function parseMode(tdNothing: cheerio.Cheerio<any>, campus: string): Mode {
   return "in-person";
 }
 
-function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<any>): string | null {
+function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<AnyNode>): string | null {
   const names: string[] = [];
   cell
     .find(".field--name-field-name a, .field--name-field-name")
@@ -250,7 +251,7 @@ function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<any>): str
   return names.join("; ");
 }
 
-function tdText($: cheerio.CheerioAPI, $tr: cheerio.Cheerio<any>, cls: string): string {
+function tdText($: cheerio.CheerioAPI, $tr: cheerio.Cheerio<AnyNode>, cls: string): string {
   return cleanText($tr.find(`td.views-field-${cls} .td-container`).first().text());
 }
 
@@ -267,7 +268,7 @@ function parsePage(html: string, term: string, year: number): CourseSection[] {
     const prefix = tdText($, $tr, "field-subject-code");
     const number = tdText($, $tr, "field-course-id");
     const section = tdText($, $tr, "field-section");
-    let title = tdText($, $tr, "title");
+    const title = tdText($, $tr, "title");
 
     // Units cell contains a "Units" label div followed by the number.
     const unitsRaw = tdText($, $tr, "field-units").replace(/units/i, "").trim();

--- a/scripts/ca/scrape-imperial.ts
+++ b/scripts/ca/scrape-imperial.ts
@@ -142,12 +142,19 @@ async function fetchHtml(url: string): Promise<string> {
   return res.text();
 }
 
+/** Minimal shape of the Livewire serverMemo.data blob — only the fields we read. */
+interface LivewireData {
+  data?: Record<string, IvcSection>;
+  meetings?: Record<string, IvcMeeting[]>;
+  searchForm?: { terms?: Array<{ term_code?: unknown; term_name?: unknown }> };
+}
+
 /** Pull the Livewire serverMemo.data object out of a page's wire:initial-data blob. */
-function extractLivewireData(html: string): any {
+function extractLivewireData(html: string): LivewireData {
   const m = html.match(/wire:initial-data="([^"]*)"/);
   if (!m) throw new Error('wire:initial-data attribute not found in page');
   const decoded = decodeHtmlEntities(m[1]);
-  let obj: any;
+  let obj: { serverMemo?: { data?: LivewireData } };
   try {
     obj = JSON.parse(decoded);
   } catch (e) {
@@ -211,8 +218,8 @@ function isCreditTermCode(code: string, name: string): boolean {
 }
 
 /** Read available CREDIT term options from the searchForm in the root page blob. */
-function readTermOptions(rootData: any): TermOption[] {
-  const terms: any[] = rootData?.searchForm?.terms ?? [];
+function readTermOptions(rootData: LivewireData): TermOption[] {
+  const terms = rootData?.searchForm?.terms ?? [];
   const out: TermOption[] = [];
   for (const t of terms) {
     const code = String(t.term_code);
@@ -235,7 +242,7 @@ function formatTime(raw: string): string {
   if (!raw) return '';
   const m = raw.match(/^(\d{1,2}):(\d{2})/);
   if (!m) return '';
-  let h = Number.parseInt(m[1], 10);
+  const h = Number.parseInt(m[1], 10);
   const min = m[2];
   if (h === 0 && min === '00') return ''; // 00:00:00 sentinel = no real time (async/online)
   const ampm = h >= 12 ? 'PM' : 'AM';

--- a/scripts/ca/scrape-socccd.ts
+++ b/scripts/ca/scrape-socccd.ts
@@ -122,11 +122,10 @@ async function bootstrapToken(tenantId: string, termTenantId: string): Promise<s
   });
   // Set-Cookie may be exposed via getSetCookie() (Node 20+) or the raw header.
   const cookies: string[] =
-    typeof (res.headers as any).getSetCookie === "function"
-      ? (res.headers as any).getSetCookie()
-      : res.headers.get("set-cookie")
-        ? [res.headers.get("set-cookie") as string]
-        : [];
+    res.headers.getSetCookie?.() ??
+    (res.headers.get("set-cookie")
+      ? [res.headers.get("set-cookie") as string]
+      : []);
   for (const c of cookies) {
     const m = c.match(/\.SmartScheduleWeb\.ApiToken=([^;]+)/);
     if (m) {
@@ -240,7 +239,7 @@ function toMinutes(s: string): number | null {
 }
 
 function fmtTime(mins: number): string {
-  let h = Math.floor(mins / 60);
+  const h = Math.floor(mins / 60);
   const m = mins % 60;
   const ap = h >= 12 ? "PM" : "AM";
   let hr = h % 12;
@@ -302,6 +301,15 @@ function parseSeats(text: string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/** Minimal shape of a class-search meeting row — only the fields we read. */
+interface ApiSchedule {
+  time?: string;
+  day?: string;
+  instructionMethod?: string;
+  location?: { isLocationOnline?: boolean; displayName?: string };
+  instructor?: { instructorName?: string };
+}
+
 /**
  * Classify a section's modality from its meeting rows.
  *   - all rows online, none with a meeting day/time → "online" (asynchronous)
@@ -309,7 +317,7 @@ function parseSeats(text: string | null | undefined): number | null {
  *   - some online + some in-person rows → "hybrid"
  *   - otherwise → "in-person"
  */
-function classifyMode(schedules: any[]): string {
+function classifyMode(schedules: ApiSchedule[]): string {
   if (!schedules || schedules.length === 0) return "online";
   const rows = schedules.map((cs) => {
     const online = !!(cs.location && cs.location.isLocationOnline) || /online/i.test(cs.instructionMethod || "");
@@ -349,6 +357,9 @@ interface CourseMeta {
 }
 
 function buildSection(
+  // The class-search section blob is large and only partially read; fully
+  // typing it forces logic edits (see ApiSchedule for the meeting rows).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   raw: any,
   course: CourseMeta | undefined,
   startDate: string,
@@ -359,6 +370,7 @@ function buildSection(
   const split = splitCourseCode(code);
   if (!split) return null;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const schedules: any[] = raw.classSchedules || [];
   // Choose the primary meeting row for day/time/location/instructor: prefer a
   // row that actually has a day+time; fall back to the first row.
@@ -466,6 +478,7 @@ async function scrapeCollegeTerm(
     }
     const data = await res.json();
     total = typeof data.totalSearchResultsCount === "number" ? data.totalSearchResultsCount : 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pageSections: any[] = data.sections || [];
 
     // Build courseKey → metadata and sectionKey → start_date maps for this page.


### PR DESCRIPTION
## What this changes

**Users see nothing new.** This fixes the 17 eslint errors that have kept the `test` check red on `main` and every open PR — they predate #1401 and made every PR's CI look broken regardless of its contents. After this lands, the workflow gets past `typecheck` and `lint`; see the known gap below for what it hits next.

**Technically:** type-level fixes only, in the three CA scrapers that held all 17 errors. No runtime behavior changes — types, `const`, and cast removal.

| File | Errors | Fix |
| --- | --- | --- |
| `scripts/ca/scrape-ccsf.ts` | 5 | `cheerio.Cheerio<any>` → `cheerio.Cheerio<AnyNode>` on 4 params (the existing convention, e.g. `scripts/ks/scrape-hutchinson.ts:132`); `let title` → `const` |
| `scripts/ca/scrape-imperial.ts` | 5 | new minimal `LivewireData` interface for the Livewire `serverMemo.data` blob (sections map, meetings map, `searchForm.terms`) replacing 4 `any`s; `let h` → `const` |
| `scripts/ca/scrape-socccd.ts` | 7 | dropped both `(res.headers as any).getSetCookie` casts for the standard `res.headers.getSetCookie?.()` (convention: `scripts/sc/scrape-banner.ts:131`; raw `set-cookie` fallback kept); new `ApiSchedule` interface typing `classifyMode`'s meeting rows; `let h` → `const`; 3 targeted `eslint-disable-next-line` on the remaining section-blob `any`s, where fully typing the large API blob would have forced logic edits |

## Verification

- `npm run typecheck` — green.
- `npm run lint` — **0 errors** (was 17); warnings unchanged at 287 (out of scope).
- Diff touches only the three files; no logic changes.
- These scrapers hit live college sites on the scheduled-scrape cron, so they were deliberately **not** run as verification — for type-only edits, typecheck + lint is the proof.

## Known gap — `test:run` is also red on main

With lint fixed, the workflow's next step (`npm run test:run`) hits **7 pre-existing failures**, all in `lib/__tests__/courses-titles-for-subject.test.ts`: the Supabase mock's query chain is missing `.order` (`supabase.from(...).select(...).eq(...).eq(...).order is not a function` at `lib/courses.ts:909`). I confirmed these fail identically on pristine `main` (stash → run → pop). So this PR turns 17 lint errors into 7 test failures still to fix — a separate, out-of-scope follow-up (test-mock fix in `lib/__tests__/`), after which the `test` workflow should finally go green.

https://claude.ai/code/session_015wc1bc58GHp3Qr3hUG1vVU

---
_Generated by [Claude Code](https://claude.ai/code/session_015wc1bc58GHp3Qr3hUG1vVU)_