### PR TITLE
dc: 26 UDC-CC programs from curriculum PDFs — unlock the Degree-Path Planner

### DIFF
--- a/data/dc/programs/udc-cc.json
+++ b/data/dc/programs/udc-cc.json
@@ -1,0 +1,4807 @@
+{
+  "college_slug": "udc-cc",
+  "catalog_year": "",
+  "catalog_url": "https://www.udc.edu/cc/",
+  "scraped_at": "2026-06-11T17:51:52.522Z",
+  "programs": [
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Architectural Engineering Technology",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/architectural-engineering/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101C",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "111C",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "111C",
+              "title": "Technical Mathematics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "101C",
+              "title": "Architectural Drawing & Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "114C",
+              "title": "Materials & Methods of Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "122C",
+              "title": "Introduction to History of Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "112C",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112C",
+              "title": "Technical Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "102C",
+              "title": "Architectural Drawing & Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "116C",
+              "title": "Materials & Methods of Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "205C",
+              "title": "Introduction to Computer Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "101C",
+              "title": "Introduction to College Physics I (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "103C",
+              "title": "Introduction to College Physics I (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "201C",
+              "title": "Architectural Drawing & Design III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "206C",
+              "title": "CADD Documents/Specifications & Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "244C",
+              "title": "Mechanical & Electrical Systems (Env. Sys. I)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "102C",
+              "title": "Introduction to College Physics II (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "104C",
+              "title": "Introduction to College Physics II (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "202C",
+              "title": "Architectural Drawing I Design IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "232C",
+              "title": "Structural Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "246C",
+              "title": "Environmental Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "292C",
+              "title": "Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Associate in Science (A.S.) in Business Administration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/business-administration/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundations of Writing I Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "214C",
+              "title": "Economics of Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "105C",
+              "title": "Intermediate Algebra Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BGMT",
+              "number": "104C",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "250C",
+              "title": "Applications in Business) Gen Ed* &**",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations of Writing II Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLAW",
+              "number": "214C",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BGMT",
+              "number": "208C",
+              "title": "Business Communications **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116C",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "108C",
+              "title": "Intro to Social Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201C",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201C",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201C",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Ed",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "210C",
+              "title": "Discovery Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "202C",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202C",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "220C",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "270C",
+              "title": "Discover Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "260C",
+              "title": "Discovery Science & Lab",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Computer Accounting Technology",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/computer-accounting-technology/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "105C",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "105C",
+              "title": "Introduction to Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OADM",
+              "number": "104C",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201C",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116C",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202C",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "250C",
+              "title": "Discovery Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "301",
+              "title": "Intermediate Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "325",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLPC",
+              "number": "214C",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "312",
+              "title": "Federal Income Tax Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "201C",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "302",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "407",
+              "title": "Accounting for Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLAW",
+              "number": "318",
+              "title": "Commercial Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Associate of Science (A.S.) Computer Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/computer-science/index",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015C",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "115C",
+              "title": "Computing Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "220",
+              "title": "Discrete Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "140C",
+              "title": "Foundation Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "210C",
+              "title": "Discovery Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "270C",
+              "title": "Discovery Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "241C",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "285",
+              "title": "Professional Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Construction Management",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/construction-management/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101C",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "111C",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "111C",
+              "title": "Technical Mathematics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "101C",
+              "title": "Construction Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "121C",
+              "title": "Construction Field Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "101C",
+              "title": "Architectural Drawing and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "112C",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112C",
+              "title": "Technical Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "102C",
+              "title": "Construction Management II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "112C",
+              "title": "Surveying (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "113C",
+              "title": "Surveying (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "114C",
+              "title": "Materials and Methods of Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMTC",
+              "number": "201C",
+              "title": "Construction Management III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "211C",
+              "title": "Site Planning (for Construction Mgmt Majors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "224C",
+              "title": "Cost Estimating (for Construction Mgmt Majors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "206C",
+              "title": "CADD Documents/Specifications & Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "244C",
+              "title": "Mechanical & Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMTC",
+              "number": "202C",
+              "title": "Construction Management IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMTC",
+              "number": "235C",
+              "title": "Planning and Scheduling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "113C",
+              "title": "Technical Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101C",
+              "title": "Introduction to College Physics I (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "103C",
+              "title": "Introduction to College Physics I (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Corrections Administration",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/corrections-administration/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "015C",
+              "title": "Introduction to Algebra and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "100C",
+              "title": "Criminal Justice Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "102C",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quan & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "232",
+              "title": "Criminal Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIM",
+              "number": "203C",
+              "title": "Forensic Sciences/Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "222C",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "224C",
+              "title": "Issues in Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "137C",
+              "title": "Psychology of Adjustment OR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "271",
+              "title": "Dynamics of Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLI",
+              "number": "206C",
+              "title": "Introduction to American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "175C",
+              "title": "Geo-spatial Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "221C",
+              "title": "Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "234C",
+              "title": "Juvenile Justice Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "272C",
+              "title": "Conflict Resolution/Mediation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "310",
+              "title": "Ethics and Public Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CORRECTIONS SPECIAL TOPICS COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIM",
+              "number": "111C",
+              "title": "Contemporary Police Systems & Problems*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "115C",
+              "title": "History & Philosophy of Corrections*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "150C",
+              "title": "Justice Issues in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "235C",
+              "title": "Probation, Class and Parole*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "294C",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Associate in Arts (A.A.) in Education",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/education/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015C",
+              "title": "English Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations of Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundations of Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundations of Writing I Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundations of Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "101C",
+              "title": "Orient Infant-Toddler Professional Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105C",
+              "title": "Principle of Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations of Writing II Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "201C",
+              "title": "Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "202C",
+              "title": "Hlth/Saf&Nur Inf/Todl Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "203C",
+              "title": "Responsive Curr Inf & Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "105C",
+              "title": "World Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "204C",
+              "title": "Inf/Tod Soc-Emotnl Dev & Guidn",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "205C",
+              "title": "Physical Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "206C",
+              "title": "Physical & Cognitive Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDIT",
+              "number": "207C",
+              "title": "Infant/Toddler Learning/Care Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "208C",
+              "title": "3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "209C",
+              "title": "Infant/Toddler Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDIT",
+              "number": "210C",
+              "title": "Ldshp/Mgmt Infant.Toddler Prof",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts (A.A.) in Education — Childhood",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/education/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015C",
+              "title": "English Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations of Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundations of Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundations of Writing I Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundations of Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "104C",
+              "title": "History and Philosophy of ECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105C",
+              "title": "Principles of Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations of Writing II Gen Ed",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "204C",
+              "title": "Curriculum Content ECE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "224C",
+              "title": "Planning and Administering ECE Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "208C",
+              "title": "Emergent Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "105C",
+              "title": "World Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "209C",
+              "title": "Play Activities and Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "207C",
+              "title": "Understanding Self & Rel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "230C",
+              "title": "Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "245C",
+              "title": "Child in the Familty",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPED",
+              "number": "204C",
+              "title": "Intro to Edu of Except Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "231C",
+              "title": "Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts (A.A.) in Education – Option III",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/education/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "015C",
+              "title": "Introduction to Algebra and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "105C",
+              "title": "World Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDFN",
+              "number": "120C",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quan & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENSC",
+              "number": "107C",
+              "title": "Integrated Science I (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENSC",
+              "number": "109C",
+              "title": "Integrated Science I (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "105C",
+              "title": "Introduction to Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDPY",
+              "number": "144C",
+              "title": "Human Development & Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "214C",
+              "title": "Teacher, Child, School & Community Interactions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDFN",
+              "number": "204C",
+              "title": "Guiding Functions of the Teacher",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "230C",
+              "title": "Practicum I (Elementary/Secondary)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPED",
+              "number": "204C",
+              "title": "Intro to the Education of Exceptional Children",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RDNG",
+              "number": "204C",
+              "title": "Tech for Aides in Reading/Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDPY",
+              "number": "214C",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "231C",
+              "title": "Practicum II (Elementary/Secondary)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDFN",
+              "number": "205C",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science (A.S.) in Engineering Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/engineering-science/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "015C",
+              "title": "or placement test",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation of Oral Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCEN",
+              "number": "101C",
+              "title": "Introduction to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "140C",
+              "title": "Foundation Ethics & Values",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AETC",
+              "number": "205C",
+              "title": "CAD",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "210C",
+              "title": "Discovery Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "270C",
+              "title": "Discovery Loc/Glob Cultural Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Fashion Merchandising",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/fashion-merchandising/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundations of Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundations of Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundations of Oral Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "101C",
+              "title": "Fashion Merchandising Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "103C",
+              "title": "Principles of Clothing Construction I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRCT",
+              "number": "109C",
+              "title": "Digital Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "121C",
+              "title": "Textiles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "104C",
+              "title": "Principles of Clothing & Construction II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSMD",
+              "number": "225C",
+              "title": "Principles of Retail Buying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "244C",
+              "title": "Product Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "296C",
+              "title": "Fashion Merchandising Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSMD",
+              "number": "255C",
+              "title": "Trend Forecasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "261C",
+              "title": "Introduction to Fashion Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSMD",
+              "number": "299C",
+              "title": "Fashion Merchandising Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Science (A.S.) in Hospitality and Tourism Management",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/hospitality-management/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "105C",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "104C",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "250C",
+              "title": "Applications in Business) * &**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201C",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116C",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "110C",
+              "title": "Front Office Management and Guest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FBMT",
+              "number": "106C",
+              "title": "Food and Beverage Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "214C",
+              "title": "Economics of Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201C",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "260C",
+              "title": "Discovery Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundations of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "200C",
+              "title": "Hospitality Sales & Meeting Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "215C",
+              "title": "Managing Sustainable Hotel Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "202C",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BGMT",
+              "number": "208C",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "280C",
+              "title": "Hotel Food and Beverage Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMGT",
+              "number": "211C",
+              "title": "Hospitality Human Resources and Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRVL",
+              "number": "100C",
+              "title": "Dynamics of Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate of Science (A.S.) Information Technology|Concentration: System",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/information-technology/index",
+      "total_credits": 64,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "110C",
+              "title": "Introduction to Programming (Lecture)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "111C",
+              "title": "Introduction to Programming (Lab)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "121C",
+              "title": "Windows Operating System Fund.",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINX",
+              "number": "110C",
+              "title": "LINUX I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "200C",
+              "title": "4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "185C",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "115C",
+              "title": "Introduction to Cybersecurity (Sec+)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "210C",
+              "title": "Windows Server II-MS Certified: Azure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "100C",
+              "title": "AWS Cloud Practitioner Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "140",
+              "title": "Foundation Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINX",
+              "number": "120C",
+              "title": "LINUX II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "220C",
+              "title": "4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "240C",
+              "title": "AWS Certified System Ops Administrator-",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate of Science (A.S.) Information Technology|Concentration: Networking",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/information-technology/index",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "110C",
+              "title": "Introduction to Programming (Lecture)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "111C",
+              "title": "Introduction to Programming (Lab)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "121C",
+              "title": "Windows Operating System Fund.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "100C",
+              "title": "AWS Cloud Practitioner Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINX",
+              "number": "110C",
+              "title": "LINUX I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "115C",
+              "title": "Introduction to Cybersecurity (Sec+)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "185C",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "140",
+              "title": "Foundation Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "225",
+              "title": "AWS Certified Advanced Networking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate of Science (A.S.) Information Technology|Concentration: Cybersecurity",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/information-technology/index",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "110C",
+              "title": "Introduction to Programming (Lecture)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "111C",
+              "title": "Introduction to Programming (Lab)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "121C",
+              "title": "Windows Operating System Fund.",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINX",
+              "number": "110C",
+              "title": "LINUX I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "115C",
+              "title": "Introduction to Cybersecurity (Sec+)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "185C",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "100C",
+              "title": "AWS Cloud Practitioner Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "201C",
+              "title": "Certified Ethical Hacker",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "140",
+              "title": "Foundation Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "115C",
+              "title": "and CCNA I or CMOP",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "215C",
+              "title": "Cybersecurity Operations Associate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "215C",
+              "title": "Cloud Security-AWS Security Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate of Science (A.S.) Information Technology|Concentration: Cloud",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/information-technology/index",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "110C",
+              "title": "Introduction to Programming (Lecture)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "111C",
+              "title": "Introduction to Programming (Lab)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "121C",
+              "title": "Windows Operating System Fund.",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LINX",
+              "number": "110C",
+              "title": "LINUX I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CYSE",
+              "number": "115C",
+              "title": "Introduction to Cybersecurity (Sec+)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "185C",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "210C",
+              "title": "AWS Solutions Architect-Assoc",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "215C",
+              "title": "AWS Security Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "100C",
+              "title": "AWS Cloud Practitioner Essentials",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "140",
+              "title": "Foundation Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "225C",
+              "title": "AWS Certified Advanced Networking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "240C",
+              "title": "4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Law Enforcement",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/law-enforcement/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "015C",
+              "title": "Introduction to Algebra and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "100C",
+              "title": "Criminal Justice Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "102C",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quan & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "232",
+              "title": "Criminal Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIM",
+              "number": "203C",
+              "title": "Forensic Sciences/Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "222C",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "224C",
+              "title": "Issues in Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "137C",
+              "title": "Psychology of Adjustment OR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "271",
+              "title": "Dynamics of Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLI",
+              "number": "206C",
+              "title": "Introduction to American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "175C",
+              "title": "Geo-spatial Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "221C",
+              "title": "Investigations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "234C",
+              "title": "Juvenile Justice Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "272C",
+              "title": "Conflict Resolution/Mediation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "310",
+              "title": "Ethics and Public Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "LAW ENFORCEMENT SPECIAL TOPICS COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIM",
+              "number": "111C",
+              "title": "Contemporary Police Systems & Problems*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "115C",
+              "title": "History & Philosophy of Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "150C",
+              "title": "Justice Issues in Society*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "294C",
+              "title": "Special Topics*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Associate in Applied Science (A.A.S.) in Legal Assistant",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/legal-assistant/index",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "015",
+              "title": "English Fundamentals and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "015C",
+              "title": "Introduction to Algebra and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LATC",
+              "number": "161C",
+              "title": "Legal Research and Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LATC",
+              "number": "181C",
+              "title": "Introduction to Para-Legalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "250C",
+              "title": "Effective Use of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quant & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LATC",
+              "number": "162C",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LATC",
+              "number": "171C",
+              "title": "Legal Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BGMT",
+              "number": "104C",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLAW",
+              "number": "214C",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LATC",
+              "number": "263C",
+              "title": "Investigative Techniques/Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LATC",
+              "number": "278C",
+              "title": "Law Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mortuary Science",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/mortuary-science/index",
+      "total_credits": 71,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111C",
+              "title": "Anatomy and Physiology I - Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113C",
+              "title": "Anatomy and Physiology I - Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "105C",
+              "title": "Fundamentals of Chemistry -Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "106C",
+              "title": "Fundamentals of Chemistry - Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "104C",
+              "title": "Funeral Service Orientation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing in the",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111C",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113C",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "105",
+              "title": "Fundamentals of Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "106",
+              "title": "Fundamentals of Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "104C",
+              "title": "Funeral Service Orientation",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTC",
+              "number": "105C",
+              "title": "Descriptive Pathology and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation of Oral",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "205C",
+              "title": "Funeral Merchandise and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201C",
+              "title": "Financial Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTC",
+              "number": "124C",
+              "title": "Thanatochemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "155C",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "107C",
+              "title": "History and Practice of",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "101C",
+              "title": "Intro to Public Health Info. IT",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTC",
+              "number": "220C",
+              "title": "Embalming and Disposition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "223C",
+              "title": "Embalming and Disposition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "206C",
+              "title": "Funeral Service Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "254C",
+              "title": "Psychology of Grief",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "131C",
+              "title": "Restorative Art I (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Curriculum",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTC",
+              "number": "230C",
+              "title": "Embalming and Disposition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "213C",
+              "title": "Restorative Art II (Lecture)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "214C",
+              "title": "Restorative Art II (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "135C",
+              "title": "Funeral Service Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTC",
+              "number": "294C",
+              "title": "National Board Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts in Music (AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/music/index",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Curriculum",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Found. Quant. Reason.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Disc. Quan & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "106C",
+              "title": "History of African-American Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "270C",
+              "title": "Computer Applications to Music I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "210C",
+              "title": "Directed Study (AA Seminar)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITAL",
+              "number": "114",
+              "title": "Italian Diction for Voice Major (2 credits) for Vocal; Keyboard/Vocal: (except Jazz or Gospel Music)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts in Music (AA) — Instrumental",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/music/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "135C",
+              "title": "Applied Major Instrument",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "116C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "100C",
+              "title": "Materials of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "102C",
+              "title": "Ear Training & Sight Singing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "106C",
+              "title": "History of African-American Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quan & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "135C",
+              "title": "Applied Major Instrument",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "116C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "101C",
+              "title": "Materials of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "103C",
+              "title": "Ear Training & Sight Singing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "235C",
+              "title": "Applied Major Instrument",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "216C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "200C",
+              "title": "Materials of Music III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "202C",
+              "title": "Ear Training & Sight Singing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "270C",
+              "title": "Computer Applications to Music I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "235C",
+              "title": "Applied Major Instrument",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "216C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "201C",
+              "title": "Materials of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "203C",
+              "title": "Ear Training & Sight Singing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "210C",
+              "title": "AA Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts in Music (AA) — Voice",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/music/index",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "125C",
+              "title": "Applied Major Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "116C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "100C",
+              "title": "Materials of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "102C",
+              "title": "Ear Training & Sight Singing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "106C",
+              "title": "History of African-American Music OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITAL",
+              "number": "114C",
+              "title": "Italian Diction for Voice Major I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "220C",
+              "title": "Discovery Quant & Econ Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "125C",
+              "title": "Applied Major Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "116C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "101C",
+              "title": "Materials of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "103C",
+              "title": "Ear Training & Sight Singing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "THIRD SEMESTER",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "225C",
+              "title": "Applied Major Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "216C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "200C",
+              "title": "Materials of Music III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "202C",
+              "title": "Ear Training & Sight Singing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "270C",
+              "title": "Computer Applications to Music I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "106C",
+              "title": "History of African American Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FOURTH SEMESTER",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "225C",
+              "title": "Applied Major Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "216C",
+              "title": "Applied Minor Keyboard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "201C",
+              "title": "Materials of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "203C",
+              "title": "Ear Training & Sight Singing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "210C",
+              "title": "AA Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Applied Science Nursing (AASN)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/nursing/index",
+      "total_credits": 70,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing in Arts & Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111C",
+              "title": "Anatomy and Physiology I Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113C",
+              "title": "Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112C",
+              "title": "Anatomy and Physiology II Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "114C",
+              "title": "Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "245C",
+              "title": "Clinical Microbiology Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "244C",
+              "title": "Clinical Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "URST",
+              "number": "105C",
+              "title": "Introduction to Social Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar (nursing section) 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST-YEAR 100 LEVEL NURSING COURSES",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "106C",
+              "title": "Medication Administration and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "115C",
+              "title": "Foundations of Nursing Theory/Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201C",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR 200 LEVEL NURSING COURSES",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "206C",
+              "title": "Medication Administration and Pharmacology II 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "210C",
+              "title": "Common Concepts of Adults II Theor/Practicum 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "215C",
+              "title": "Mental Health Nursing Theory/Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing Certificate Program",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/nursing/practical-nursing-certificate-program",
+      "total_credits": 47,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "120C",
+              "title": "Foundation Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing in Arts & Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111C",
+              "title": "Anatomy and Physiology I -Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113C",
+              "title": "Anatomy and Physiology I –Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112C",
+              "title": "Anatomy and Physiology II Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "114C",
+              "title": "Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "ASSOCIATE OF SCIENCE DEGREE IN PUBLIC HEALTH AND IT (AS-PHIT)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/public-health-and-it/index",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSEM",
+              "number": "101C",
+              "title": "First Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "110C",
+              "title": "Foundation Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111C",
+              "title": "Anatomy & Physiology I – Lecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "113C",
+              "title": "Anatomy & Physiology I – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "101C",
+              "title": "Introduction to Public Health and Info Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116C",
+              "title": "Finite Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundations Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "102C",
+              "title": "Pathology and Pharmacology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112C",
+              "title": "Anatomy Physiology II – Lecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "114C",
+              "title": "Anatomy Physiology II – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "103C",
+              "title": "Healthcare Informatics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "104C",
+              "title": "Healthcare Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHIT",
+              "number": "110C",
+              "title": "International Classification of Diseases (ICD)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "131C",
+              "title": "Comp. Networking Fundamentals – Lecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "132C",
+              "title": "Comp. Networking Fundamentals – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "110C",
+              "title": "Intro to Programming – Lecture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "111C",
+              "title": "Intro to Programming – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "115C",
+              "title": "Foundations of Computing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "130C",
+              "title": "Foundation Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IGED",
+              "number": "210C",
+              "title": "Discovery Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "231C",
+              "title": "Computer Science I – Lecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "APCT",
+              "number": "233C",
+              "title": "Computer Science I – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "231C",
+              "title": "Wireless Local Area Networks – Lecture",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMOP",
+              "number": "232C",
+              "title": "Wireless Local Area Networks – Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIT",
+              "number": "111C",
+              "title": "Legal & Ethical Aspects of Healthcare",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://www.udc.edu/cc/programs-majors/respiratory-therapy/index",
+      "total_credits": 72,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR - SPRING SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "172C",
+              "title": "Principles and Practice of Respiratory Therapy II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "274C",
+              "title": "Acid-Base and Hemodynamic Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "271C",
+              "title": "Respiratory Therapy Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "250C",
+              "title": "Introduction to Mechanical Ventilation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR- SUMMER SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IGED",
+              "number": "111C",
+              "title": "Foundation Writing in the Natural & Social Sciences (May be",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR- FALL SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "270C",
+              "title": "Critical Care and Ventilator Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "273C",
+              "title": "Cardiopulmonary Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "276C",
+              "title": "Respiratory Disease Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "280C",
+              "title": "Respiratory Therapy Seminar I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "269C",
+              "title": "Neonatal/Pediatric Respiratory Therapy",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR- SPRING SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "277C",
+              "title": "Adjunctive Respiratory Therapies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "278C",
+              "title": "Respiratory Therapy Clinical Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "290C",
+              "title": "Respiratory Therapy Seminar II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "245C",
+              "title": "Clinical Microbiology Lecture (May be taken",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "244C",
+              "title": "Clinical Microbiology Lab (May be taken anytime)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/dc/config.ts
+++ b/lib/states/dc/config.ts
@@ -74,7 +74,11 @@ const dcConfig: StateConfig = {
     courses: [{ scripts: ["scripts/dc/scrape-banner.ts"], runner: "http" }],
     // manual-only: transfers — DC has no in-state CC→4yr articulation pipeline; see `transferSupported` comment above.
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — Acalog program scraper not yet wired up for this state.
+    // UDC-CC has no Acalog/CourseLeaf/Coursedog catalog — programs come from
+    // per-program curriculum PDFs on docs.udc.edu, discovered via the
+    // udc.edu/cc accordion. pdftotext (poppler) is installed by the cron
+    // workflow for the PDF scrapers.
+    programs: [{ scripts: ["scripts/dc/scrape-programs.ts"], runner: "http" }],
   },
   documentedCeilings: {
     transfers:

--- a/scripts/dc/scrape-programs.ts
+++ b/scripts/dc/scrape-programs.ts
@@ -1,0 +1,399 @@
+/**
+ * scrape-programs.ts — degree/program requirements for DC (UDC Community
+ * College, slug `udc-cc`).
+ *
+ * UDC-CC has no Acalog/CourseLeaf/Coursedog catalog (udc.smartcatalogiq.com
+ * is an empty Sitecore shell, catalog.udc.edu doesn't resolve). Programs are
+ * listed as an accordion on https://www.udc.edu/cc/ with one page per
+ * program, and each page links a per-program curriculum PDF on
+ * docs.udc.edu/academics/ (e.g. AS-Business-Administration.pdf). The PDFs
+ * are clean column-layout tables:
+ *
+ *   FIRST SEMESTER
+ *     Course #   Course Title                Credits  Semester  Grade  Prerequisites
+ *     FSEM-101C  First Year Seminar            1
+ *     ...
+ *                       Total Credit Hours:   16
+ *
+ * A "Developmental Education Courses" table precedes the curriculum on
+ * some PDFs; its credits "do not count towards degree completion" (their
+ * words), so it is skipped.
+ *
+ * PDF quirks handled:
+ *   - prefix typos vs the SIS (BMGT-104C in the PDF, BGMT 104C in Banner) —
+ *     corrected against the prefix vocabulary built from data/dc/courses/
+ *   - wrapped rows where the credits cell lands on a continuation line —
+ *     credits become null rather than garbage
+ *   - prerequisite-column course codes — only the line-leading code is taken
+ *
+ * Requires: pdftotext (poppler) on PATH. brew install poppler /
+ * apt-get install poppler-utils. (Same requirement as
+ * scripts/va/scrape-vhcc-pdf-programs.ts.)
+ *
+ * Usage:
+ *   npx tsx scripts/dc/scrape-programs.ts
+ *   npx tsx scripts/dc/scrape-programs.ts --keep-text   # keep /tmp text dumps
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import * as cheerio from "cheerio";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequirementGroup,
+} from "../../lib/types";
+
+const BASE = "https://www.udc.edu/cc/";
+const COLLEGE_SLUG = "udc-cc";
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const KEEP_TEXT = process.argv.includes("--keep-text");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function fetchText(url: string): Promise<string> {
+  const resp = await fetch(url, { headers: { "User-Agent": UA } });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`);
+  return resp.text();
+}
+
+// ---------------------------------------------------------------------------
+// Prefix vocabulary — corrects PDF typos (BMGT → BGMT) against the SIS
+// ---------------------------------------------------------------------------
+
+function loadPrefixVocab(): Set<string> {
+  const vocab = new Set<string>();
+  const coursesDir = path.join(process.cwd(), "data", "dc", "courses", COLLEGE_SLUG);
+  if (!fs.existsSync(coursesDir)) return vocab;
+  for (const f of fs.readdirSync(coursesDir).filter((f) => f.endsWith(".json"))) {
+    try {
+      const sections = JSON.parse(fs.readFileSync(path.join(coursesDir, f), "utf-8"));
+      if (!Array.isArray(sections)) continue;
+      for (const s of sections) {
+        if (typeof s?.course_prefix === "string") vocab.add(s.course_prefix);
+      }
+    } catch {
+      /* skip unreadable term file */
+    }
+  }
+  return vocab;
+}
+
+/**
+ * If `prefix` isn't in the SIS vocabulary but a single adjacent-letter
+ * transposition of it is, return the corrected prefix. Conservative: only
+ * one transposition, only when the result is unambiguous.
+ */
+function correctPrefix(prefix: string, vocab: Set<string>): string {
+  if (vocab.size === 0 || vocab.has(prefix)) return prefix;
+  const candidates = new Set<string>();
+  for (let i = 0; i < prefix.length - 1; i++) {
+    const swapped =
+      prefix.slice(0, i) + prefix[i + 1] + prefix[i] + prefix.slice(i + 2);
+    if (vocab.has(swapped)) candidates.add(swapped);
+  }
+  return candidates.size === 1 ? [...candidates][0] : prefix;
+}
+
+// ---------------------------------------------------------------------------
+// Program discovery from the /cc/ accordion
+// ---------------------------------------------------------------------------
+
+interface DiscoveredProgram {
+  pageUrl: string;
+  pdfUrl: string;
+}
+
+async function discoverProgramPdfs(): Promise<DiscoveredProgram[]> {
+  console.log(`Fetching program index ${BASE} ...`);
+  const html = await fetchText(BASE);
+  const $ = cheerio.load(html);
+  const pageUrls = new Set<string>();
+  $("a[href*='programs-majors']").each((_, el) => {
+    const href = $(el).attr("href") || "";
+    if (!href || href.includes("#")) return;
+    const abs = new URL(href, BASE).href;
+    pageUrls.add(abs);
+  });
+  console.log(`  ${pageUrls.size} program pages found`);
+
+  const out: DiscoveredProgram[] = [];
+  const seenPdfs = new Set<string>();
+  for (const pageUrl of [...pageUrls].sort()) {
+    await sleep(400);
+    let pageHtml: string;
+    try {
+      pageHtml = await fetchText(pageUrl);
+    } catch (e) {
+      console.error(`  ✗ ${pageUrl}: ${(e as Error).message}`);
+      continue;
+    }
+    const $$ = cheerio.load(pageHtml);
+    // Curriculum PDFs live under docs.udc.edu/{academics,cc,pos}/ with
+    // filenames like AS-Business-Administration.pdf,
+    // Computer-Science-AS-Program-of-Study-*.pdf, aasn-program-of-study.pdf.
+    // Pages also link handbooks / outcome-data / flyers — exclude those.
+    $$("a[href*='docs.udc.edu']").each((_, el) => {
+      const href = $$(el).attr("href") || "";
+      if (!/\.pdf$/i.test(href.split("?")[0])) return;
+      const name = decodeURIComponent(href.split("/").pop() || "");
+      if (/handbook|^data-|flyer|brochure|application|checklist|faq/i.test(name)) return;
+      if (!/program.?of.?study|\bpos\b|^A\.?A\.?S?|^AS-|^AA-|certificate|curriculum|\/pos\//i.test(`${name} ${href}`)) return;
+      const abs = new URL(href, pageUrl).href;
+      if (seenPdfs.has(abs)) return;
+      seenPdfs.add(abs);
+      out.push({ pageUrl, pdfUrl: abs });
+    });
+  }
+  console.log(`  ${out.length} curriculum PDFs discovered`);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// PDF parsing
+// ---------------------------------------------------------------------------
+
+function humanize(primary: string, fallbackSlug: string): string {
+  const clean = (s: string) =>
+    s
+      .replace(/program.?of.?study|\bpos\b|curriculum|revised|layout/gi, " ")
+      .replace(/[0-9._%-]+/g, " ")
+      .trim()
+      .replace(/\s+/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  const fromFile = clean(primary);
+  return fromFile.length >= 4 ? fromFile : clean(fallbackSlug.replace(/-/g, " "));
+}
+
+function credentialFromTitle(title: string, pdfUrl: string): ProgramCredential {
+  const t = `${title} ${path.basename(pdfUrl)}`;
+  if (/associate.{0,8}applied\s+science|\bA\.?A\.?S\b/i.test(t)) return "AAS";
+  if (/associate.{0,8}science|\bA\.?S\b\.?/i.test(t)) return "AS";
+  if (/associate.{0,8}arts|\bA\.?A\b\.?/i.test(t)) return "AA";
+  if (/certificate/i.test(t)) return "certificate";
+  return "other";
+}
+
+// Optional "1st Semester" lead handles the nursing-POS layout where the
+// semester label shares the line with the first course of the block.
+// Prefix/number separator is hyphen OR whitespace runs — the PHIT layout
+// puts "FSEM            101C" in two wide columns.
+const COURSE_ROW =
+  /^\s*(?:\d(?:st|nd|rd|th)\s+Semester\s+)?([A-Z]{2,5})(?:-|\s+)([0-9]{2,3}[A-Z]?)\b\s+(.+?)(?:\s{2,}(\d{1,2})(?:\s|$))?\s*$/;
+// Three heading shapes: "FIRST SEMESTER" sequence tables, standalone
+// ordinals ("1st Semester"), and ALL-CAPS requirement blocks ("GENERAL
+// EDUCATION REQUIREMENTS", "FIRST-YEAR 100 LEVEL NURSING COURSES") whose
+// line may carry trailing column headers.
+const GROUP_HEADING = /^\s*((?:FIRST|SECOND|THIRD|FOURTH|FIFTH|SIXTH|SUMMER|FALL|SPRING)\s+(?:SEMESTER|SESSION|YEAR)[A-Z\s\-()]*)\s*$/i;
+const GROUP_HEADING_ORDINAL = /^\s*(\d(?:st|nd|rd|th)\s+Semester)\s*$/i;
+const GROUP_HEADING_CAPS = /^\s*([A-Z][A-Z0-9\s\-&/]{8,}?(?:REQUIREMENTS|COURSES))(?:\s{2,}.*)?\s*$/;
+const GROUP_TOTAL = /Total\s+Credit\s+Hours:?\s+(\d{1,3})/i;
+const GROUP_TOTAL_SUFFIX = /^\s*Total\s+.{3,60}?\s+(\d{1,3})\s+Credit\s+Hours\s*$/i;
+const GROUP_TOTAL_PLAIN = /^\s*Total\s+Credits\s+(\d{1,3})\s*$/i;
+const PROGRAM_TOTAL = /Total\s+Credit\s+Hours?\s+for\s+.*?:\s*(\d{1,3})/i;
+const PROGRAM_TOTAL_CAPS = /^\s*TOTAL\s+SEMESTER\s+HOURS\s+(\d{1,3})\s*$/im;
+const DEVELOPMENTAL = /Developmental\s+Education\s+Courses/i;
+
+function parsePdf(
+  pdfUrl: string,
+  pageUrl: string,
+  vocab: Set<string>,
+): ProgramRequirement | null {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "udc-pdf-"));
+  const pdfPath = path.join(tmp, "program.pdf");
+  const txtPath = path.join(tmp, "program.txt");
+  try {
+    execFileSync("curl", ["-s", "-L", "--max-time", "30", "-A", UA, "-o", pdfPath, pdfUrl]);
+    execFileSync("pdftotext", ["-layout", pdfPath, txtPath]);
+  } catch (e) {
+    console.error(`  ✗ download/pdftotext failed for ${pdfUrl}: ${(e as Error).message}`);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    return null;
+  }
+  const text = fs.readFileSync(txtPath, "utf-8");
+  if (KEEP_TEXT) {
+    fs.copyFileSync(txtPath, `/tmp/udc-${path.basename(pdfUrl, ".pdf")}.txt`);
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+
+  const lines = text.split("\n");
+
+  // Title: first line mentioning a credential; else a humanized filename
+  // ("2025.26-mortuary-science-pos" → "Mortuary Science"), never the
+  // university letterhead line.
+  const credentialLine = lines.find(
+    (l) => /associate|certificate|diploma/i.test(l) && l.trim().length > 10,
+  );
+  const title = credentialLine
+    ? credentialLine.trim().replace(/\s{2,}/g, " ")
+    : humanize(
+        decodeURIComponent(path.basename(pdfUrl, ".pdf")),
+        // Cryptic filenames (PN-Program-of-Study → "PN") fall back to the
+        // program page's URL slug, which is always descriptive.
+        pageUrl.replace(/\/index$/, "").split("/").filter(Boolean).pop() || "",
+      );
+
+  const groups: RequirementGroup[] = [];
+  let current: RequirementGroup | null = null;
+  let inDevelopmental = false;
+  let totalCredits: number | null = null;
+
+  for (const line of lines) {
+    if (DEVELOPMENTAL.test(line)) {
+      inDevelopmental = true;
+      continue;
+    }
+    const heading =
+      line.match(GROUP_HEADING) ||
+      line.match(GROUP_HEADING_ORDINAL) ||
+      line.match(GROUP_HEADING_CAPS);
+    if (heading && !/^\s*TOTAL\b/i.test(line)) {
+      inDevelopmental = false;
+      if (current && current.courses.length > 0) groups.push(current);
+      current = {
+        name: heading[1].trim().replace(/\s{2,}/g, " "),
+        credits_required: null,
+        choose_n: null,
+        courses: [],
+      };
+      continue;
+    }
+    const programTotal = line.match(PROGRAM_TOTAL) || line.match(PROGRAM_TOTAL_CAPS);
+    if (programTotal) {
+      totalCredits = parseInt(programTotal[1], 10);
+      continue;
+    }
+    const groupTotal =
+      line.match(GROUP_TOTAL) ||
+      line.match(GROUP_TOTAL_SUFFIX) ||
+      line.match(GROUP_TOTAL_PLAIN);
+    if (groupTotal && current) {
+      current.credits_required = parseInt(groupTotal[1], 10);
+      groups.push(current);
+      current = null;
+      continue;
+    }
+    if (inDevelopmental) continue;
+    if (/^\s*Course\s*#/i.test(line)) {
+      // Some PDFs start a table without a semester heading — open an
+      // implicit group so their rows aren't dropped.
+      if (!current) {
+        current = { name: "Curriculum", credits_required: null, choose_n: null, courses: [] };
+      }
+      continue;
+    }
+    if (!current) continue;
+    const row = line.match(COURSE_ROW);
+    if (!row) continue;
+    const [, rawPrefix, number, rawTitle, credits] = row;
+    const prefix = correctPrefix(rawPrefix, vocab);
+    // The title cell can swallow the prerequisites column on wrapped rows —
+    // cut it at 2+ consecutive spaces if any survived the regex.
+    const courseTitle = rawTitle.split(/\s{2,}/)[0].trim();
+    current.courses.push({
+      prefix,
+      number,
+      title: courseTitle,
+      credits: credits ? parseInt(credits, 10) : null,
+      or_alternatives: [],
+    });
+  }
+  if (current && current.courses.length > 0) groups.push(current);
+
+  if (groups.length === 0) {
+    console.log(`  – no curriculum tables in ${path.basename(pdfUrl)} (skipped)`);
+    return null;
+  }
+
+  return {
+    title,
+    credential: credentialFromTitle(title, pdfUrl),
+    program_code: null,
+    catalog_url: pageUrl,
+    total_credits: totalCredits,
+    gpa_minimum: null,
+    description: null,
+    requirement_groups: groups,
+    matched_program_slug: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("UDC-CC program scraper (PDF curricula)\n");
+  const vocab = loadPrefixVocab();
+  console.log(`Prefix vocabulary: ${vocab.size} prefixes from data/dc/courses/${COLLEGE_SLUG}/`);
+
+  const discovered = await discoverProgramPdfs();
+  if (discovered.length === 0) {
+    console.error("No curriculum PDFs discovered — leaving existing data untouched.");
+    process.exit(1);
+  }
+
+  const programs: ProgramRequirement[] = [];
+  const seenTitles = new Set<string>();
+  for (const d of discovered) {
+    await sleep(400);
+    console.log(`Parsing ${path.basename(d.pdfUrl)} ...`);
+    const program = parsePdf(d.pdfUrl, d.pageUrl, vocab);
+    if (program) {
+      // Concentration variants share a credential line (the three Music
+      // PDFs) — qualify duplicates from the filename so titles stay unique.
+      if (seenTitles.has(program.title)) {
+        const qualifier = decodeURIComponent(path.basename(d.pdfUrl, ".pdf"))
+          .replace(/[0-9._%-]+/g, " ")
+          .replace(/program of study|pos|curriculum|revised|layout/gi, " ")
+          .trim()
+          .split(/\s+/)
+          .slice(-1)[0];
+        if (qualifier) program.title = `${program.title} — ${qualifier}`;
+      }
+      seenTitles.add(program.title);
+      const courseCount = program.requirement_groups.reduce(
+        (n, g) => n + g.courses.length,
+        0,
+      );
+      console.log(
+        `  ✓ "${program.title}" (${program.credential}) — ${program.requirement_groups.length} groups, ${courseCount} courses, total ${program.total_credits ?? "?"} cr`,
+      );
+      programs.push(program);
+    }
+  }
+
+  if (programs.length === 0) {
+    console.error("Parsed 0 programs — leaving existing data untouched.");
+    process.exit(1);
+  }
+
+  const { matched, unmatched } = applyProgramMatching(programs);
+  console.log(`\nMatcher: ${matched} matched / ${unmatched} unmatched`);
+
+  const data: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: "",
+    catalog_url: BASE,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+
+  const outDir = path.join(process.cwd(), "data", "dc", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+  console.log(`✓ Wrote ${programs.length} programs → ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this changes

The Degree-Path Planner comes alive for Washington, DC. `/dc/college/udc-cc/programs` now lists 26 real UDC Community College programs — every associate degree on udc.edu/cc (Business Administration, Nursing AAS, Law Enforcement, Mortuary Science, four IT concentrations, three Music tracks, …) with semester-by-semester course sequences and credit totals. DC was one of 10 remaining states with zero program data.

## Technical story

UDC-CC has no templated catalog — `udc.smartcatalogiq.com` is an empty Sitecore shell and `catalog.udc.edu` doesn't resolve. The curricula live in per-program PDFs on `docs.udc.edu`, linked from the udc.edu/cc accordion. `scripts/dc/scrape-programs.ts` discovers the 25 program pages, filters their PDF links to actual curricula (excluding handbooks/flyers/outcome reports), and parses them with `pdftotext -layout` — the same poppler dependency the cron workflow already installs for other states' PDF scrapers.

The PDFs span a decade of layout styles; the parser handles all three generations found: classic `FIRST SEMESTER` sequence tables, ALL-CAPS requirement blocks with inline `1st Semester` row labels (the nursing POS), and wide-column ordinal-heading tables (PHIT). PDF prefix typos are corrected against the SIS vocabulary built from `data/dc/courses/` — the Business PDF says `BMGT-104C`, Banner says `BGMT 104C`.

## Validation

- 26 of 27 discovered PDFs parse (only `Program-of-Study-Aviation-Maintenance-Technology.pdf` resists — different structure, left for a follow-up).
- All 26 programs are plannable (≥5 real courses each); **83% of 524 course references join to scraped sections** — the unaligned tail is retired course codes in decade-old PDFs (Law Enforcement is dated 2015) plus courses not offered in currently scraped terms.
- Filename `udc-cc.json` matches `institutions.json` `college_slug` exactly (the slug-align gotcha from #964/#966).
- `programs` scraper declared in `StateConfig.scrapers` → picked up by the cron matrix; `npm run check:scrapers` passes; `tsc --noEmit` clean.
- Dev check: `/dc/college/udc-cc/programs` server-renders the new programs. The plan page is Supabase-fed, so the end-to-end planner check happens on prod after merge + import.

Part of the DC+CO zero-program goal; the CO PR (SmartCatalogIQ template) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)