### PR TITLE
fix: stale program manifests hid working programs + gate empty-state nav links

### DIFF
--- a/app/[state]/layout.tsx
+++ b/app/[state]/layout.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation";
 import Header from "@/components/Header";
 import { hasPrereqsCoverage, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
+import { loadStateSummary } from "@/lib/state-summary";
+import { getQualifyingProgramSlugs } from "@/lib/programs";
 type Props = {
   children: React.ReactNode;
   params: Promise<{ state: string }>;
@@ -52,6 +54,16 @@ export default async function StateLayout({ children, params }: Props) {
   const baseUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
+  // Gate the Programs/Find-your-program nav links on whether the state has any
+  // qualifying program — otherwise those links land on a soft-404 (the pages
+  // notFound() with no qualifying programs). Use the same precomputed manifest
+  // the state home uses for its program chips so nav and chips always agree;
+  // fall back to the live check only when the manifest is absent.
+  const programSummary = loadStateSummary(state);
+  const programsAvailable = programSummary
+    ? programSummary.programSlugs.length > 0
+    : (await getQualifyingProgramSlugs(state).catch(() => [])).length > 0;
+
   return (
     <>
       <script
@@ -79,6 +91,7 @@ export default async function StateLayout({ children, params }: Props) {
         stateName={config.name}
         transferSupported={config.transferSupported}
         prereqsAvailable={hasPrereqsCoverage(state)}
+        programsAvailable={programsAvailable}
       />
 
       {/* Main content */}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,11 +19,13 @@ export default function Header({
   stateName,
   transferSupported = true,
   prereqsAvailable = false,
+  programsAvailable = true,
 }: {
   state: string;
   stateName?: string;
   transferSupported?: boolean;
   prereqsAvailable?: boolean;
+  programsAvailable?: boolean;
 }) {
   // `open` is the transient show/hide; `pinned` (persisted) keeps the sidebar
   // open across navigation on desktop. `isDesktop` gates pinning + push.
@@ -104,7 +106,7 @@ export default function Header({
     if (next) setOpen(true);
   };
 
-  const columns = buildNavColumns(state, { transferSupported, prereqsAvailable });
+  const columns = buildNavColumns(state, { transferSupported, prereqsAvailable, programsAvailable });
   const stateHome = `/${state}`;
   const isActive = (href: string) => isNavLinkActive(pathname, href, stateHome);
 

--- a/lib/nav/__tests__/sidebar.test.ts
+++ b/lib/nav/__tests__/sidebar.test.ts
@@ -10,7 +10,11 @@ import {
   type NavGating,
 } from "../sidebar";
 
-const ALL: NavGating = { transferSupported: true, prereqsAvailable: true };
+const ALL: NavGating = {
+  transferSupported: true,
+  prereqsAvailable: true,
+  programsAvailable: true,
+};
 
 // --- sidebarVisible -------------------------------------------------------
 
@@ -47,9 +51,20 @@ describe("showNavItem", () => {
     expect(showNavItem("/plan", { ...ALL, prereqsAvailable: true })).toBe(true);
   });
 
-  it("shows every other item regardless of gating", () => {
-    const none = { transferSupported: false, prereqsAvailable: false };
-    for (const p of ["", "/courses", "/colleges", "/choose", "/programs", "/about"]) {
+  it("hides /programs AND /choose when no qualifying programs exist", () => {
+    expect(showNavItem("/programs", { ...ALL, programsAvailable: false })).toBe(false);
+    expect(showNavItem("/choose", { ...ALL, programsAvailable: false })).toBe(false);
+    expect(showNavItem("/programs", { ...ALL, programsAvailable: true })).toBe(true);
+    expect(showNavItem("/choose", { ...ALL, programsAvailable: true })).toBe(true);
+  });
+
+  it("shows ungated items regardless of gating", () => {
+    const none: NavGating = {
+      transferSupported: false,
+      prereqsAvailable: false,
+      programsAvailable: false,
+    };
+    for (const p of ["", "/courses", "/colleges", "/about"]) {
       expect(showNavItem(p, none)).toBe(true);
     }
   });
@@ -93,16 +108,24 @@ describe("buildNavColumns", () => {
   });
 
   it("omits Transfer when transfers are unsupported", () => {
-    const plan = buildNavColumns("va", { transferSupported: false, prereqsAvailable: true })
+    const plan = buildNavColumns("va", { ...ALL, transferSupported: false })
       .find((c) => c.heading === "Plan your path")!;
     expect(plan.links.some((l) => l.href === "/va/transfer")).toBe(false);
     expect(plan.links.some((l) => l.href === "/va/schedule")).toBe(true);
   });
 
   it("omits Semester Planner when prereqs are unavailable", () => {
-    const plan = buildNavColumns("va", { transferSupported: true, prereqsAvailable: false })
+    const plan = buildNavColumns("va", { ...ALL, prereqsAvailable: false })
       .find((c) => c.heading === "Plan your path")!;
     expect(plan.links.some((l) => l.href === "/va/plan")).toBe(false);
+  });
+
+  it("drops the Programs & majors column when the state has no qualifying programs", () => {
+    const cols = buildNavColumns("wy", { ...ALL, programsAvailable: false });
+    expect(cols.some((c) => c.heading === "Programs & majors")).toBe(false);
+    const allHrefs = cols.flatMap((c) => c.links.map((l) => l.href));
+    expect(allHrefs).not.toContain("/wy/programs");
+    expect(allHrefs).not.toContain("/wy/choose");
   });
 });
 

--- a/lib/nav/sidebar.ts
+++ b/lib/nav/sidebar.ts
@@ -62,6 +62,14 @@ export const DESKTOP_MQ = "(min-width: 1024px)";
 export type NavGating = {
   transferSupported: boolean;
   prereqsAvailable: boolean;
+  /**
+   * Whether the state has at least one qualifying program. When false, both
+   * "/programs" and "/choose" notFound() (a state with no programs that clear
+   * the thin-content threshold), so we hide their nav links rather than link
+   * to a soft-404 — matching the state home, which already hides its program
+   * chips on the same signal.
+   */
+  programsAvailable: boolean;
 };
 
 /**
@@ -78,13 +86,16 @@ export function sidebarVisible(
 }
 
 /**
- * Hide /transfer where transfers aren't supported and /plan where prereqs
- * aren't available; every other item always shows.
+ * Hide /transfer where transfers aren't supported, /plan where prereqs aren't
+ * available, and /programs + /choose where the state has no qualifying
+ * programs (both notFound() there); every other item always shows.
  */
 export function showNavItem(path: string, g: NavGating): boolean {
   return (
     (path !== "/transfer" || g.transferSupported) &&
-    (path !== "/plan" || g.prereqsAvailable)
+    (path !== "/plan" || g.prereqsAvailable) &&
+    (path !== "/programs" || g.programsAvailable) &&
+    (path !== "/choose" || g.programsAvailable)
   );
 }
 
@@ -98,10 +109,13 @@ export function buildNavColumns(state: string, g: NavGating): NavColumn[] {
     label: i.label,
   });
   return [
+    // A task group whose every item is gated out (e.g. "Programs & majors" in a
+    // state with no qualifying programs) is dropped entirely — otherwise its
+    // heading renders with no links under it.
     ...NAV_GROUPS.map((grp) => ({
       heading: grp.heading,
       links: grp.items.filter((i) => showNavItem(i.path, g)).map(toLink),
-    })),
+    })).filter((col) => col.links.length > 0),
     {
       heading: "Guides",
       links: GUIDES_ITEMS.map((i) => ({ href: i.href, label: i.label })),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:css": "tailwindcss -i ./app/tailwind.source.css -o ./app/globals.css --watch",
     "dev:next": "next dev",
     "dev": "npm run build:css && concurrently --names \"css,next\" --prefix-colors \"cyan,green\" --kill-others-on-fail \"npm:dev:css\" \"npm:dev:next\"",
-    "build": "npm run build:css && npm run build:transfer-universities-cache && npm run build:course-availability-cache && npm run build:transfer-coverage-rollup && npm run build:transfer-dest-rollup && npm run build:term-counts-snapshot && npm run build:last-updated-snapshot && npm run build:section-counts-snapshot && npm run build:sitemap-data-snapshot && npm run build:starting-soon-snapshot && next build",
+    "build": "npm run build:css && npm run build:transfer-universities-cache && npm run build:course-availability-cache && npm run build:transfer-coverage-rollup && npm run build:transfer-dest-rollup && npm run build:term-counts-snapshot && npm run build:last-updated-snapshot && npm run build:section-counts-snapshot && npm run build:sitemap-data-snapshot && npm run build:starting-soon-snapshot && npm run build:state-summaries && next build",
     "build:term-counts-snapshot": "tsx scripts/build-term-counts-snapshot.ts",
     "build:last-updated-snapshot": "tsx scripts/build-last-updated-snapshot.ts",
     "build:section-counts-snapshot": "tsx scripts/build-section-counts-snapshot.ts",


### PR DESCRIPTION
## What changes for someone using the site

Two program-discovery bugs, both most visible to a student browsing majors:

1. **States that *have* programs were hiding them.** On a state home page, the "Browse by program" chips (Accounting, Nursing, Business…) come from a precomputed manifest. That manifest had gone stale, so several states showed **zero program chips even though their `/{state}/programs` page lists real programs** — e.g. Washington's home page showed no chips while `/wa/programs` has **15** (Mississippi: 0 vs **12**). After this change the home chips track the live data again.

2. **States with *no* programs linked to empty pages.** In the ~14 states with no qualifying programs, the sidebar still showed "Programs" and "Find your program" links that led to a bare "Compare 0 programs" shell. Those links (and the now-empty "Programs & majors" heading) are now hidden in those states — the same way "Transfer" hides where transfers aren't supported.

## What changed technically

**Root cause of #1:** `scripts/build-state-summaries.ts` regenerates `data/{state}/summary.json` (the home chips + online-callout manifest) from live data. Its own header says it "runs during the deploy build" — but it was **never added to the `npm run build` chain**, unlike every sibling snapshot builder (`section-counts`, `term-counts`, `starting-soon`, …). So the manifests froze at their last hand-committed values and drifted as course data grew. Fix: add `build:state-summaries` to the build chain, right before `next build`, so pages prerender against a freshly regenerated manifest each deploy. The script is resilient (per-state `try/catch`; a failed state degrades to "hidden", never aborts the build).

**Fix for #2:** add a `programsAvailable` flag to `NavGating` and gate `/programs` + `/choose` on it in `showNavItem` — mirroring the existing `/transfer` and `/plan` gates. The layout computes it from the **same manifest the home chips use** (`loadStateSummary`), with a live `getQualifyingProgramSlugs` fallback when the manifest is absent, so nav and home page never disagree. `buildNavColumns` now drops a task group whose every item is gated out, so a zero-program state doesn't render an orphan "Programs & majors" heading.

The 51 regenerated `summary.json` files are **intentionally not committed** — they're tracked-but-derived (like the other snapshot JSONs), and the newly-wired build step regenerates them at deploy.

## Test plan

- `npm run typecheck` ✓ · 23 sidebar unit tests pass (`lib/nav/__tests__/sidebar.test.ts`, incl. new cases for the program gate + empty-column drop)
- `build:state-summaries` run standalone: 51/51 manifests written; confirmed WA 0→15, MS 0→12 qualifying programs
- Dev render: `/ct` and `/de` (0 programs) hide the Programs/Choose nav links and the column heading; `/va` (14) keeps both
- Post-merge prod checks: after the deploy regenerates manifests, `/wa` home should show program chips (it shows none today); a zero-program state's sidebar (e.g. `/de`) should no longer list "Programs"/"Find your program"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
