### PR TITLE
fix: green the Test workflow (lint + test mock) and the seat-watch cron (secret name)

### DIFF
--- a/.github/workflows/seat-watch.yml
+++ b/.github/workflows/seat-watch.yml
@@ -38,7 +38,7 @@ jobs:
       # The script defaults DRY_RUN to true if unset. workflow_dispatch
       # input takes precedence; otherwise the repo secret controls it.
       SEAT_WATCH_DRY_RUN: ${{ inputs.dry_run || secrets.SEAT_WATCH_DRY_RUN || 'true' }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       SEAT_WATCH_TOKEN_SECRET: ${{ secrets.SEAT_WATCH_TOKEN_SECRET }}

--- a/lib/__tests__/courses-titles-for-subject.test.ts
+++ b/lib/__tests__/courses-titles-for-subject.test.ts
@@ -16,6 +16,7 @@ const { fromMock, eqMock, rangeMock, supabaseClient } = vi.hoisted(() => {
   type Chain = {
     select: () => Chain;
     eq: (col: string, val: unknown) => Chain;
+    order: (col: string, opts?: unknown) => Chain;
     range: (start: number, end: number) => Promise<{ data: unknown[] | null; error: unknown }>;
   };
   const chain: Chain = {
@@ -24,6 +25,7 @@ const { fromMock, eqMock, rangeMock, supabaseClient } = vi.hoisted(() => {
       eqMock(col, val);
       return chain;
     },
+    order: () => chain,
     range: (start, _end) => rangeMock(start),
   };
   const fromMock = vi.fn(() => chain);

--- a/scripts/ca/scrape-ccsf.ts
+++ b/scripts/ca/scrape-ccsf.ts
@@ -48,6 +48,7 @@
  */
 
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -180,7 +181,7 @@ interface MeetingInfo {
  */
 function parseMeeting(
   $: cheerio.CheerioAPI,
-  cell: cheerio.Cheerio<any>,
+  cell: cheerio.Cheerio<AnyNode>,
   year: number
 ): MeetingInfo {
   const firstLi = cell.find("li").first();
@@ -222,7 +223,7 @@ function parseMeeting(
 }
 
 /** Derive mode from the modality icon's title attribute in the row. */
-function parseMode(tdNothing: cheerio.Cheerio<any>, campus: string): Mode {
+function parseMode(tdNothing: cheerio.Cheerio<AnyNode>, campus: string): Mode {
   const title = (tdNothing.find("[title]").attr("title") ?? "").toLowerCase();
   if (title.includes("online")) {
     return title.includes("hybrid") ? "hybrid" : "online";
@@ -234,7 +235,7 @@ function parseMode(tdNothing: cheerio.Cheerio<any>, campus: string): Mode {
   return "in-person";
 }
 
-function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<any>): string | null {
+function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<AnyNode>): string | null {
   const names: string[] = [];
   cell
     .find(".field--name-field-name a, .field--name-field-name")
@@ -250,7 +251,7 @@ function parseInstructor($: cheerio.CheerioAPI, cell: cheerio.Cheerio<any>): str
   return names.join("; ");
 }
 
-function tdText($: cheerio.CheerioAPI, $tr: cheerio.Cheerio<any>, cls: string): string {
+function tdText($: cheerio.CheerioAPI, $tr: cheerio.Cheerio<AnyNode>, cls: string): string {
   return cleanText($tr.find(`td.views-field-${cls} .td-container`).first().text());
 }
 
@@ -267,7 +268,7 @@ function parsePage(html: string, term: string, year: number): CourseSection[] {
     const prefix = tdText($, $tr, "field-subject-code");
     const number = tdText($, $tr, "field-course-id");
     const section = tdText($, $tr, "field-section");
-    let title = tdText($, $tr, "title");
+    const title = tdText($, $tr, "title");
 
     // Units cell contains a "Units" label div followed by the number.
     const unitsRaw = tdText($, $tr, "field-units").replace(/units/i, "").trim();

--- a/scripts/ca/scrape-imperial.ts
+++ b/scripts/ca/scrape-imperial.ts
@@ -142,18 +142,29 @@ async function fetchHtml(url: string): Promise<string> {
   return res.text();
 }
 
+// Loose shapes for the Livewire serverMemo.data blob (only the fields we read).
+interface TermRaw {
+  term_code?: unknown;
+  term_name?: unknown;
+}
+interface LivewireData {
+  data?: Record<string, IvcSection>;
+  meetings?: Record<string, IvcMeeting[]>;
+  searchForm?: { terms?: TermRaw[] } | null;
+}
+
 /** Pull the Livewire serverMemo.data object out of a page's wire:initial-data blob. */
-function extractLivewireData(html: string): any {
+function extractLivewireData(html: string): LivewireData {
   const m = html.match(/wire:initial-data="([^"]*)"/);
   if (!m) throw new Error('wire:initial-data attribute not found in page');
   const decoded = decodeHtmlEntities(m[1]);
-  let obj: any;
+  let obj: unknown;
   try {
     obj = JSON.parse(decoded);
   } catch (e) {
     throw new Error(`failed to JSON.parse wire:initial-data: ${(e as Error).message}`);
   }
-  const data = obj?.serverMemo?.data;
+  const data = (obj as { serverMemo?: { data?: LivewireData } })?.serverMemo?.data;
   if (!data) throw new Error('serverMemo.data missing from Livewire blob');
   return data;
 }
@@ -211,8 +222,8 @@ function isCreditTermCode(code: string, name: string): boolean {
 }
 
 /** Read available CREDIT term options from the searchForm in the root page blob. */
-function readTermOptions(rootData: any): TermOption[] {
-  const terms: any[] = rootData?.searchForm?.terms ?? [];
+function readTermOptions(rootData: LivewireData): TermOption[] {
+  const terms: TermRaw[] = rootData?.searchForm?.terms ?? [];
   const out: TermOption[] = [];
   for (const t of terms) {
     const code = String(t.term_code);
@@ -235,7 +246,7 @@ function formatTime(raw: string): string {
   if (!raw) return '';
   const m = raw.match(/^(\d{1,2}):(\d{2})/);
   if (!m) return '';
-  let h = Number.parseInt(m[1], 10);
+  const h = Number.parseInt(m[1], 10);
   const min = m[2];
   if (h === 0 && min === '00') return ''; // 00:00:00 sentinel = no real time (async/online)
   const ampm = h >= 12 ? 'PM' : 'AM';

--- a/scripts/ca/scrape-socccd.ts
+++ b/scripts/ca/scrape-socccd.ts
@@ -121,9 +121,10 @@ async function bootstrapToken(tenantId: string, termTenantId: string): Promise<s
     redirect: "manual",
   });
   // Set-Cookie may be exposed via getSetCookie() (Node 20+) or the raw header.
+  const getSetCookie = (res.headers as { getSetCookie?: () => string[] }).getSetCookie;
   const cookies: string[] =
-    typeof (res.headers as any).getSetCookie === "function"
-      ? (res.headers as any).getSetCookie()
+    typeof getSetCookie === "function"
+      ? getSetCookie.call(res.headers)
       : res.headers.get("set-cookie")
         ? [res.headers.get("set-cookie") as string]
         : [];
@@ -240,7 +241,7 @@ function toMinutes(s: string): number | null {
 }
 
 function fmtTime(mins: number): string {
-  let h = Math.floor(mins / 60);
+  const h = Math.floor(mins / 60);
   const m = mins % 60;
   const ap = h >= 12 ? "PM" : "AM";
   let hr = h % 12;
@@ -309,7 +310,28 @@ function parseSeats(text: string | null | undefined): number | null {
  *   - some online + some in-person rows → "hybrid"
  *   - otherwise → "in-person"
  */
-function classifyMode(schedules: any[]): string {
+// Loose shapes for the SmartSchedule JSON (only the fields we read).
+interface ScheduleRow {
+  day?: string | null;
+  time?: string | null;
+  instructionMethod?: string | null;
+  location?: { isLocationOnline?: boolean; displayName?: string } | null;
+  instructor?: { instructorName?: string } | null;
+}
+
+interface RawSection {
+  courseDisplayCode?: string;
+  classSchedules?: ScheduleRow[];
+  totalSeatCountText?: string;
+  availableSeatCountText?: string;
+  units?: number | string;
+  sectionTenantDefinedId?: string | number;
+  sectionDisplayCode?: string | number;
+  sectionKey?: number;
+  courseKey?: number;
+}
+
+function classifyMode(schedules: ScheduleRow[]): string {
   if (!schedules || schedules.length === 0) return "online";
   const rows = schedules.map((cs) => {
     const online = !!(cs.location && cs.location.isLocationOnline) || /online/i.test(cs.instructionMethod || "");
@@ -349,7 +371,7 @@ interface CourseMeta {
 }
 
 function buildSection(
-  raw: any,
+  raw: RawSection,
   course: CourseMeta | undefined,
   startDate: string,
   college: CollegeSpec,
@@ -359,7 +381,7 @@ function buildSection(
   const split = splitCourseCode(code);
   if (!split) return null;
 
-  const schedules: any[] = raw.classSchedules || [];
+  const schedules: ScheduleRow[] = raw.classSchedules || [];
   // Choose the primary meeting row for day/time/location/instructor: prefer a
   // row that actually has a day+time; fall back to the first row.
   const primary =
@@ -377,7 +399,7 @@ function buildSection(
   // Location: first non-online physical room, else "ONLINE", else first label.
   let location = "";
   const physical = schedules.find((cs) => cs.location && !cs.location.isLocationOnline && cs.location.displayName);
-  if (physical) location = physical.location.displayName;
+  if (physical?.location?.displayName) location = physical.location.displayName;
   else if (schedules.some((cs) => cs.location && cs.location.isLocationOnline)) location = "ONLINE";
   else if (primary?.location?.displayName) location = primary.location.displayName;
 
@@ -387,7 +409,7 @@ function buildSection(
   const seatsTotal = parseSeats(raw.totalSeatCountText);
   const seatsOpen = parseSeats(raw.availableSeatCountText);
 
-  const units = typeof raw.units === "number" ? raw.units : parseFloat(raw.units) || 0;
+  const units = typeof raw.units === "number" ? raw.units : parseFloat(String(raw.units ?? "")) || 0;
 
   return {
     college_code: college.slug,
@@ -466,7 +488,7 @@ async function scrapeCollegeTerm(
     }
     const data = await res.json();
     total = typeof data.totalSearchResultsCount === "number" ? data.totalSearchResultsCount : 0;
-    const pageSections: any[] = data.sections || [];
+    const pageSections: RawSection[] = data.sections || [];
 
     // Build courseKey → metadata and sectionKey → start_date maps for this page.
     const courseMeta = new Map<number, CourseMeta>();
@@ -488,8 +510,8 @@ async function scrapeCollegeTerm(
     for (const raw of pageSections) {
       const crn = String(raw.sectionTenantDefinedId || raw.sectionDisplayCode || "");
       if (crn && seenCrn.has(crn)) continue; // idempotent de-dupe across pages
-      const startDate = startDateByKey.get(raw.sectionKey) || "";
-      const sec = buildSection(raw, courseMeta.get(raw.courseKey), startDate, college, term.fileTerm);
+      const startDate = startDateByKey.get(raw.sectionKey ?? -1) || "";
+      const sec = buildSection(raw, courseMeta.get(raw.courseKey ?? -1), startDate, college, term.fileTerm);
       if (sec) {
         if (sec.crn) seenCrn.add(sec.crn);
         sections.push(sec);


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible on the site — this is CI/cron hygiene. But two things that were silently broken get fixed: the **Test workflow** (red on `main` for days, so every PR's checks were failing) goes green, and the **Seat-watch cron** (which emails students when a seat opens in a class they saved) starts running again instead of erroring on every scheduled run.

## What changed technically

Two unrelated root causes, found by reading the failing GitHub Actions logs:

### 1. Test workflow — `typecheck && lint && test:run`
- **lint** reported 17 errors (`no-explicit-any`, `prefer-const`) in three CA scrapers from the #1366 batch (`scrape-ccsf.ts`, `scrape-imperial.ts`, `scrape-socccd.ts`). Replaced the loose `any` with minimal interfaces describing the parsed JSON we actually read (SmartSchedule section/schedule rows; the IVC Livewire `serverMemo.data` blob) and `cheerio.Cheerio<AnyNode>` (importing `AnyNode` from `domhandler`, matching `scrape-losrios`/`scrape-cerritos`), plus a few `let`→`const`. **No behavior change** — same fields, same parsing.
- **test:run** then failed 7/7 in `lib/__tests__/courses-titles-for-subject.test.ts`: `getCourseTitlesForSubject()` gained an `.order("id")` call, but the test's Supabase query-builder mock chain never had `.order`, so it threw `.order is not a function`. Added a pass-through `order()` to the mock.

All three steps pass locally now: typecheck ✓, lint 0 errors (287 warnings, which don't fail CI), **878 tests pass**.

### 2. Seat-watch cron
Every scheduled run died at `Error: supabaseUrl is required.`. The workflow read `secrets.NEXT_PUBLIC_SUPABASE_URL`, but the repo's Supabase URL secret is named **`SUPABASE_URL`** — that's what the *working* `import-on-merge` workflow uses. Repointed it. The service-role key was already correctly named, so this is the one blocker that kept the Supabase client from initializing.

This unblocks the run; it stays in **DRY_RUN** (the default), i.e. it logs what it *would* send without emailing anyone. Turning on real sends is deliberately left as a separate, owner-gated step (it needs the remaining seat-watch secrets — `SEAT_WATCH_TOKEN_SECRET`, `RESEND_API_KEY`, `EMAIL_FROM` — set, plus a sample-verification pass so the first email a subscriber gets isn't wrong).

## Not in scope (but worth knowing)

The "Scheduled scrape (unified)" cron also shows red runs, but it is **not** systemically broken: a sampled failing run was **108 of 111 jobs green** — one flaky NY transfer scraper, an NJ aggregate step, and the health rollup. That's normal per-state scraper flakiness (the workflow is designed to preserve the successful matrix-job output), not a data outage.

## Test plan

- `npm run typecheck` ✓ · `npm run lint` → 0 errors ✓ · `npm run test:run` → 878 passed, 0 failed ✓ (the three steps the Test workflow runs)
- Post-merge: the Test check on the next PR should be green; the next Seat-watch scheduled run should complete (in DRY_RUN) instead of erroring at `supabaseUrl is required`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
