### PR TITLE
fix: the REAL course-page 504 (getTransferInfo loaded 161K rows) + un-noindex 169 ranking pages

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -10,6 +10,7 @@ import { getTransferInfo, getUniversities } from "@/lib/transfer";
 import { subjectName } from "@/lib/subjects";
 import { getBestProgramForPrefix } from "@/lib/programs/registry";
 import { getQualifyingProgramSlugs } from "@/lib/programs";
+import { loadStateSummary } from "@/lib/state-summary";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import type { CourseSection } from "@/lib/types";
 import SectionHeading from "@/components/SectionHeading";
@@ -180,15 +181,16 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/course/${code}`;
 
-  // Thin-content guard. GSC audit (2026-05) found 26K of these "Discovered –
-  // not indexed". A course is thin unless it has either real breadth
-  // (≥3 sections at ≥2 colleges) or substantial breadth at one college
-  // (≥5 sections). The previous rule (`<3 && colleges===1`) was too narrow:
-  // a course with 2 sections at 2 colleges, or 4 sections at one college,
-  // would slip through as "indexable" with very little unique content.
-  const isThin =
-    sections.length < 3 ||
-    (collegeCount < 2 && sections.length < 5);
+  // Thin-content guard. The prior rule (noindex unless ≥3 sections, or ≥5 at a
+  // single college) was too aggressive: a GSC audit (2026-06) found it had
+  // noindexed 169 course pages that were actively ranking and earning clicks
+  // before they were suppressed on 2026-05-11. A course offered at even one or
+  // two sections is still a real, searchable course with unique content here
+  // (its live sections + transfer verdicts + prereq chain + related courses),
+  // and Google already declines to index the genuinely-empty long tail on its
+  // own. So we now noindex only the absolute-thinnest case — a single section
+  // at a single college — and index everything with more substance.
+  const isThin = sections.length < 2 && collegeCount < 2;
 
   return {
     title: pageTitle,
@@ -373,8 +375,13 @@ export default async function CoursePage(props: PageProps) {
   // course-detail visitor can step up to the program comparison view
   // with earnings + per-college data.
   const matchedProgram = getBestProgramForPrefix(prefix);
+  // Use the precomputed summary manifest (the same source the state home uses
+  // for its program chips) instead of the live getQualifyingProgramSlugs(),
+  // which loops every program × per-college section aggregation — ~13s for a
+  // big state like CA, the second-largest contributor to this page's 504s.
+  // The manifest read is ~1ms; fall back to the live check only if it's absent.
   const qualifyingSlugs = matchedProgram
-    ? await getQualifyingProgramSlugs(state)
+    ? (loadStateSummary(state)?.programSlugs ?? (await getQualifyingProgramSlugs(state)))
     : [];
   const programLink =
     matchedProgram && qualifyingSlugs.includes(matchedProgram.slug)

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -358,10 +358,32 @@ export async function getTransferInfo(
   number: string,
   state: string
 ): Promise<TransferMapping[]> {
-  const mappings = await loadTransferMappings(state);
-  return mappings.filter(
-    (m) => m.cc_prefix === prefix && m.cc_number === number
-  );
+  // Scoped query on the idx_transfers_state_course (state, cc_prefix, cc_number)
+  // index — returns the handful of rows for THIS course directly. The old code
+  // called loadTransferMappings(state), which paginates the WHOLE state's
+  // transfer set into memory and filters in JS; for a big state that is
+  // catastrophic on a cold cache (CA = 161K rows ≈ 100s on a Vercel lambda),
+  // and it was the dominant cause of the /[state]/course/* 504 timeouts.
+  return cached(`transfer-course:${state}:${prefix}:${number}`, async () => {
+    const { data, error } = await supabase
+      .from("transfers")
+      .select(
+        "cc_prefix, cc_number, cc_course, cc_title, cc_credits, university, university_name, univ_course, univ_title, univ_credits, notes, no_credit, is_elective"
+      )
+      .eq("state", state)
+      .eq("cc_prefix", prefix)
+      .eq("cc_number", number);
+    if (error) {
+      console.error("getTransferInfo error:", error.message);
+      // Fall back to the (slow) full-state load only on a query error, so a
+      // transient Supabase issue degrades to correct-but-slow, never wrong.
+      const mappings = await loadTransferMappings(state);
+      return mappings.filter(
+        (m) => m.cc_prefix === prefix && m.cc_number === number
+      );
+    }
+    return (data || []) as TransferMapping[];
+  });
 }
 
 /**


### PR DESCRIPTION
## What changes for someone using the site

Course-detail pages in the biggest states (California, Texas, New York…) **still time out** with a raw `FUNCTION_INVOCATION_TIMEOUT` — I confirmed it live: `/ca/course/engl-001a` takes 15 s and 504s right now, even though the earlier fix (#1406) is deployed. After this change those pages load in **~1 second**, and a batch of real course pages that were wrongly hidden from Google get un-hidden.

This is the bigger half of the SEO recovery: per the GSC audit, **~525 previously-ranking course pages are currently unreachable (504) and ~169 more were noindexed by mistake** — together about 13,400 impressions/week.

## What changed technically

#1406 fixed *one* slow path (the page was pulling a whole subject's sections). But the page still 504'd, so I timed every data call it makes for a CA course against prod Supabase. Two calls #1406 never touched dwarfed everything:

| call | before | after |
|---|---|---|
| `getTransferInfo('ca','ENGL','001A')` | **102,990 ms** | scoped query, ~ms |
| `getQualifyingProgramSlugs('ca')` | **13,133 ms** | manifest read, ~1 ms |
| (whole course-page data load) | **~116 s** | **1.1 s** |

1. **`getTransferInfo`** loaded the *entire* state transfer set — CA is **161,680 rows** — into memory and filtered in JS to find the ~handful for one course. An index for exactly this already exists (`idx_transfers_state_course` on `(state, cc_prefix, cc_number)`), so it now issues a scoped query that uses it. Verified **row-for-row identical** to the old filter on 5 sampled courses; falls back to the full load only on a query error, so a transient DB hiccup degrades to correct-but-slow, never wrong.

2. **`getQualifyingProgramSlugs`** (loops every program × per-college section aggregation) was being called live just to decide whether to show one "Part of {program}" link. Swapped for the precomputed `loadStateSummary().programSlugs` manifest — the same source the state home uses — with the live call as a fallback.

3. **Noindex relaxation.** The prior thin-content rule noindexed any course with `<3 sections`. The 2026-06 GSC audit found this had suppressed **169 course pages that were actively ranking and earning clicks** until 2026-05-11. A course with even 1–2 sections is a real, searchable page here (live schedule + transfer verdicts + prereq chain + related courses), and Google already declines to index the genuinely-empty long tail on its own. Now only the absolute-thinnest case (a single section at a single college) is noindexed.

## Test plan

- `npm run typecheck` ✓ · `npm run lint` (0 errors) ✓ · 51 transfer unit tests pass
- Timed the full CA course-page data load against prod: **116 s → 1.1 s**
- Correctness: scoped `getTransferInfo` returns identical rows to the old full-load+filter on 5 sampled CA courses; ENGL 001A's 0-mapping result confirmed genuine (not a format bug)
- Local render: `/ca/course/engl-001a` and `/ca/course/math-001` both return **200** (were 504); engl-001a's `<meta name="robots">` is correctly `index, follow`
- Post-merge: `/ca/course/engl-001a`, `/tx/course/engl-1301`, `/ny/course/eng-101` should return 200 within ~1 s (they 504 today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
