### PR TITLE
search: subject-aware keyword union + distance-ranked results with zip

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -168,6 +168,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   // apply the filters on first load. Previously only `q` was read and the
   // rest defaulted to empty, which silently dropped every other filter.
   const initialZip = searchParams.get("zip") || "";
+  const initialRadius = searchParams.get("radius") || "";
   const initialMode = searchParams.get("mode") || "";
   const initialDays = (searchParams.get("days") || "")
     .split(",")
@@ -179,9 +180,15 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
 
   const [query, setQuery] = useState(initialQuery);
   const [zip, setZip] = useState(initialZip);
+  // Radius (miles around the zip) as a select value: "" = any distance.
+  const [radius, setRadius] = useState(initialRadius);
   const [mode, setMode] = useState(initialMode);
   const [days, setDays] = useState<string[]>(initialDays);
   const [timeOfDay, setTimeOfDay] = useState(initialTimeOfDay);
+  // The query the last search actually ran with (vs `query`, which tracks
+  // every keystroke). Drives the URL write-back so typing doesn't churn the
+  // address bar.
+  const [submittedQuery, setSubmittedQuery] = useState(initialQuery);
 
   // Bookmark state
   const [bookmarkedCourses, setBookmarkedCourses] = useState<Set<string>>(new Set());
@@ -300,6 +307,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setError("");
     setHasSearched(true);
     setDisplayLimit(10);
+    setSubmittedQuery(searchQuery.trim());
     // Reset previous answer card before either fetch resolves so a stale card
     // never lingers under a new query. Skipped on a filter-only re-search
     // (keepAnswer): the query is unchanged, so resetting would just flash the
@@ -430,6 +438,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     try {
       const params = new URLSearchParams({ q: searchQ, limit: "50" });
       if (zip) params.set("zip", zip);
+      if (zip && radius) params.set("radius", radius);
       if (effectiveMode) params.set("mode", effectiveMode);
       if (effectiveDays.length > 0) params.set("days", effectiveDays.join(","));
       if (effectiveTimeOfDay) params.set("timeOfDay", effectiveTimeOfDay);
@@ -465,7 +474,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       setResults(null);
     }
     setLoading(false);
-  }, [state, zip, mode, days, timeOfDay, transferTo]);
+  }, [state, zip, radius, mode, days, timeOfDay, transferTo]);
 
   async function handleSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -473,6 +482,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       state,
       query: query.trim().slice(0, 80),
       has_zip: !!zip,
+      radius: radius || "any",
       mode: mode || "any",
       days: days.length > 0 ? days.join("") : "any",
       time_of_day: timeOfDay || "any",
@@ -539,7 +549,31 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       400
     );
     return () => clearTimeout(t);
-  }, [mode, days, timeOfDay, zip]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mode, days, timeOfDay, zip, radius]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Persist the active search + filters in the URL (replaceState — no
+  // navigation, no scroll reset) so refresh and share keep the narrowed state.
+  // Keyed on submittedQuery (the last query actually searched), not `query`,
+  // so typing doesn't churn the address bar. Skipped mid-zip-edit and before
+  // any search so the pristine landing URL stays clean.
+  useEffect(() => {
+    if (!hasSearched) return;
+    if (zip !== "" && zip.length !== 5) return;
+    const params = new URLSearchParams();
+    if (submittedQuery.trim()) params.set("q", submittedQuery.trim());
+    if (zip) params.set("zip", zip);
+    if (zip && radius) params.set("radius", radius);
+    if (mode) params.set("mode", mode);
+    if (days.length > 0) params.set("days", days.join(","));
+    if (timeOfDay) params.set("timeOfDay", timeOfDay);
+    if (transferTo) params.set("transfersTo", transferTo);
+    const qs = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      qs ? `${window.location.pathname}?${qs}` : window.location.pathname
+    );
+  }, [hasSearched, submittedQuery, zip, radius, mode, days, timeOfDay, transferTo]);
 
   function toggleExpand(courseKey: string, slug: string) {
     const id = `${courseKey}::${slug}`;
@@ -636,6 +670,26 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
 
           {/* Filters row */}
           <div className="flex flex-wrap items-end gap-3">
+            {/* Distance cap — only meaningful once a full zip is entered, so it
+                appears alongside the other filters at that point. Mirrors the
+                /{state}/results radius options. */}
+            {zip.length === 5 && (
+              <div className="min-w-[130px]">
+                <label className="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1">
+                  Within
+                </label>
+                <select
+                  value={radius}
+                  onChange={(e) => setRadius(e.target.value)}
+                  className="w-full rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 dark:text-slate-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-200"
+                >
+                  <option value="">Any distance</option>
+                  <option value="10">10 miles</option>
+                  <option value="25">25 miles</option>
+                  <option value="50">50 miles</option>
+                </select>
+              </div>
+            )}
             <div className="min-w-[120px]">
               <label className="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1">Mode</label>
               <select
@@ -803,6 +857,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
               already restates what we understood, so we don't repeat it. */}
           {results.courses.length === 0 && (() => {
             const activeFilters: string[] = [];
+            if (zip.length === 5 && radius) activeFilters.push(`within ${radius} miles`);
             if (mode) activeFilters.push(mode === "in-person" ? "in-person" : mode);
             if (days.length > 0) activeFilters.push(`day (${days.join(", ")})`);
             if (timeOfDay) activeFilters.push(timeOfDay);

--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -222,13 +222,18 @@ export default async function CoursesPage({ params, searchParams }: Props) {
           todRaw === "morning" || todRaw === "afternoon" || todRaw === "evening"
             ? todRaw
             : undefined;
+        // Same optional radius clamp as /api/[state]/courses/search.
+        const radiusRaw = parseInt(firstParam(sp.radius)?.trim() || "", 10);
+        const radius = Number.isFinite(radiusRaw)
+          ? Math.max(1, Math.min(radiusRaw, 100))
+          : undefined;
         try {
           const currentTerm = await currentTermPromise;
           const r = await searchCoursesAcrossColleges(
             currentTerm,
             initialQuery,
             institutions,
-            { mode, days, timeOfDay, zip },
+            { mode, days, timeOfDay, zip, radius },
             50,
             0,
             state

--- a/app/api/[state]/courses/search/route.ts
+++ b/app/api/[state]/courses/search/route.ts
@@ -42,6 +42,12 @@ export async function GET(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: "Invalid timeOfDay value." }, { status: 400 });
   }
   const timeOfDay = timeOfDayRaw as "morning" | "afternoon" | "evening" | undefined;
+  // Optional ?radius= (miles around ?zip=), clamped like /api/[state]/search.
+  // No default: a zip alone ranks by distance without dropping far colleges.
+  const radiusRaw = parseInt(searchParams.get("radius") || "", 10);
+  const radius = Number.isFinite(radiusRaw)
+    ? Math.max(1, Math.min(radiusRaw, 100))
+    : undefined;
   const limit = Math.max(1, Math.min(parseInt(searchParams.get("limit") || "10", 10) || 10, 100));
   const offset = Math.max(0, parseInt(searchParams.get("offset") || "0", 10) || 0);
 
@@ -79,7 +85,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     term,
     q,
     institutions,
-    { mode, days, timeOfDay, zip },
+    { mode, days, timeOfDay, zip, radius },
     limit,
     offset,
     state

--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -1,7 +1,7 @@
 import type { CourseSection, Institution } from "./types";
 import { getZipCoordinates, calculateDistance } from "./geo";
 import { searchSections, getDistinctSubjects } from "./courses";
-import { subjectName } from "./subjects";
+import { subjectName, subjectPrefixesForName } from "./subjects";
 
 // ---------------------------------------------------------------------------
 // Cross-college search
@@ -75,8 +75,10 @@ export function parseQuery(q: string): {
 } {
   const trimmed = q.trim().toUpperCase();
 
-  // "ENG 111" or "ENG111"
-  const exactMatch = trimmed.match(/^([A-Z]{2,4})\s*(\d{3})$/);
+  // "ENG 111" or "ENG111" — also 4-digit numbering ("ENGL 1301", TX/FL).
+  // With only \d{3}, "ENGL 1301" fell through to the title-keyword path and
+  // returned the corequisite courses that MENTION it, not the course itself.
+  const exactMatch = trimmed.match(/^([A-Z]{2,4})\s*(\d{3,4})$/);
   if (exactMatch) {
     return { prefix: exactMatch[1], number: exactMatch[2], keyword: null };
   }
@@ -184,6 +186,8 @@ export async function searchCoursesAcrossColleges(
     days?: string[];
     timeOfDay?: "morning" | "afternoon" | "evening";
     zip?: string;
+    /** Optional cap in miles around `zip`; ignored without a resolvable zip. */
+    radius?: number;
   } = {},
   limit = 10,
   offset = 0,
@@ -196,22 +200,72 @@ export async function searchCoursesAcrossColleges(
   recovery?: SearchRecovery;
 }> {
   let { prefix, number, keyword } = parseQuery(query);
+
+  // Subject-aware keyword search. A keyword like "english" only title-matches
+  // colleges that literally word their titles that way — Houston CC titles
+  // ENGL 1301 "Composition I", so its sections never matched while Austin CC's
+  // "English…" titles did. Resolve the keyword as a subject NAME ("english" →
+  // ENG/ENGL/ENC via lib/subjects.ts) and UNION those prefixes' sections with
+  // the title matches, so per-college title wording can't hide a subject.
+  // Restricted to prefixes the state actually offers (getDistinctSubjects is
+  // cached) so unused prefixes never cost a query.
+  let subjectPrefixes: string[] = [];
+  if (keyword) {
+    const candidates = subjectPrefixesForName(keyword);
+    if (candidates.length > 0) {
+      const stateSubjects = new Set(await getDistinctSubjects(term, state));
+      subjectPrefixes = candidates.filter((p) => stateSubjects.has(p));
+    }
+  }
+  const subjectPrefixSet = new Set(subjectPrefixes);
+
   // Push the query predicate into Postgres instead of loading every section
   // for the term and filtering in JS (which 504'd on large states like CA,
   // ~188k rows). The JS filters below still run on this already-narrowed set,
   // so output is unchanged — just over 10s–1000s of rows.
-  let allCourses = await searchSections(term, state, { prefix, number, keyword });
+  let allCourses: CourseSection[];
+  if (subjectPrefixes.length > 0) {
+    const batches = await Promise.all([
+      searchSections(term, state, { prefix: null, number: null, keyword }),
+      ...subjectPrefixes.map((p) =>
+        searchSections(term, state, { prefix: p, number: null, keyword: null })
+      ),
+    ]);
+    // Dedupe across batches (a "English Composition" title row also arrives
+    // via its ENG prefix batch). The key includes the meeting fields because
+    // one CRN can have several meeting rows and CourseSection carries no row
+    // id — crn alone would collapse a lecture+lab pair into one row.
+    const seen = new Set<string>();
+    allCourses = [];
+    for (const rows of batches) {
+      for (const r of rows) {
+        const k = `${r.college_code}|${r.crn}|${r.course_prefix}${r.course_number}|${r.days}|${r.start_time}|${r.end_time}`;
+        if (!seen.has(k)) {
+          seen.add(k);
+          allCourses.push(r);
+        }
+      }
+    }
+  } else {
+    allCourses = await searchSections(term, state, { prefix, number, keyword });
+  }
 
   // Zero-result rescue for natural-language keyword phrases. A keyword like
   // "math courses without prerequisite" matches no course TITLE verbatim, so the
   // server-side search returns nothing (this also happens when the /ask
   // classifier leaves `keyword` null and the client searches the raw sentence).
-  // Strip filler words and re-query on the remaining subject token(s). Because a
-  // short subject word re-parses as a PREFIX (e.g. "math" → MATH), this recovers
-  // the whole subject, not just title matches. Only runs when the normal search
-  // found nothing, so it can never change a query that already returns results.
-  if (allCourses.length === 0 && keyword) {
-    const tokens = meaningfulKeywordTokens(keyword);
+  // Strip filler words and re-query on the remaining subject token(s). Only runs
+  // when the normal search found nothing, so it can never change a query that
+  // already returns results.
+  //
+  // Also fires for a bare-PREFIX parse that found nothing: "math" parses as
+  // prefix MATH, but a state that numbers its math courses MAT (NC) has no MATH
+  // rows — the subject-name match below ("mathematics".includes("math")) then
+  // recovers the state's real prefix instead of dead-ending at 0 results.
+  const rescueKeyword =
+    keyword ?? (prefix && !number ? query.trim().toLowerCase() : null);
+  if (allCourses.length === 0 && rescueKeyword) {
+    const tokens = meaningfulKeywordTokens(rescueKeyword);
     if (tokens.length > 0) {
       // Resolve each token to THIS state's actual subject prefixes via subject
       // names — so "math" → MTH (VA) / MAT (NC) / MATH (CT,TX), not a literal
@@ -263,6 +317,35 @@ export async function searchCoursesAcrossColleges(
     if (zipInfo) userCoords = { lat: zipInfo.lat, lng: zipInfo.lng };
   }
 
+  // Per-college distance to the user's zip (nearest campus), computed once and
+  // shared by the radius filter, the per-college display value, and the course
+  // ordering so the three can never disagree.
+  const collegeDistance = new Map<string, number>();
+  if (userCoords) {
+    for (const inst of institutions) {
+      if (inst.campuses.length === 0) continue;
+      const d = Math.min(
+        ...inst.campuses.map((c) =>
+          calculateDistance(userCoords!.lat, userCoords!.lng, c.lat, c.lng)
+        )
+      );
+      collegeDistance.set(inst.college_slug, Math.round(d * 10) / 10);
+    }
+  }
+
+  // Optional radius cap (miles around the zip). Scopes the section universe
+  // BEFORE the query/mode/days/timeOfDay steps — like `term` does — so the
+  // empty-state recovery counts never suggest sections at colleges outside the
+  // radius. Colleges with no campus coordinates are kept: we can't show a
+  // distance for them, but we also can't prove they're far.
+  const radius = filters.radius;
+  if (userCoords && radius && radius > 0) {
+    allCourses = allCourses.filter((s) => {
+      const d = collegeDistance.get(s.college_code);
+      return d === undefined || d <= radius;
+    });
+  }
+
   // Non-query filters (mode/days/time) — shared by the main pass and the
   // zero-result keyword rescue below so they stay in sync.
   const passesFilters = (s: CourseSection): boolean => {
@@ -279,7 +362,16 @@ export async function searchCoursesAcrossColleges(
   const queryMatched = allCourses.filter((s) => {
     if (prefix && s.course_prefix !== prefix) return false;
     if (number && s.course_number !== number) return false;
-    if (keyword && !s.course_title.toLowerCase().includes(keyword)) return false;
+    // A section matches a keyword by title OR by belonging to a subject prefix
+    // the keyword resolved to — without the prefix clause this re-filter would
+    // strip the subject-union rows whose titles don't contain the keyword
+    // (the entire point of the union).
+    if (
+      keyword &&
+      !s.course_title.toLowerCase().includes(keyword) &&
+      !subjectPrefixSet.has(s.course_prefix)
+    )
+      return false;
     return true;
   });
 
@@ -336,16 +428,8 @@ export async function searchCoursesAcrossColleges(
       allCollegeSlugs.add(slug);
       const inst = instMap.get(slug);
 
-      let distance: number | null = null;
-      if (userCoords && inst && inst.campuses.length > 0) {
-        // Use nearest campus
-        distance = Math.min(
-          ...inst.campuses.map((c) =>
-            calculateDistance(userCoords!.lat, userCoords!.lng, c.lat, c.lng)
-          )
-        );
-        distance = Math.round(distance * 10) / 10;
-      }
+      // Nearest-campus distance, precomputed once per college above.
+      const distance: number | null = collegeDistance.get(slug) ?? null;
 
       colleges.push({
         slug,
@@ -380,8 +464,20 @@ export async function searchCoursesAcrossColleges(
     });
   }
 
-  // Sort course groups: most sections first (most available)
-  courseGroups.sort((a, b) => b.totalSections - a.totalSections);
+  // Sort course groups: with a zip, nearest offering college first (each
+  // group's colleges are already distance-sorted, so colleges[0] is its
+  // nearest), availability breaking ties — so a Houston student sees Houston
+  // CC's courses before Austin CC's. Without a zip: most sections first,
+  // unchanged.
+  if (userCoords) {
+    const nearest = (g: CourseGroup) =>
+      g.colleges[0]?.distance ?? Number.POSITIVE_INFINITY;
+    courseGroups.sort(
+      (a, b) => nearest(a) - nearest(b) || b.totalSections - a.totalSections
+    );
+  } else {
+    courseGroups.sort((a, b) => b.totalSections - a.totalSections);
+  }
 
   const totalCourses = courseGroups.length;
   const totalSections = matched.length;


### PR DESCRIPTION
## What changes for someone using the site

A Houston student typing **"english"** with zip **77002** into Find a Course used to see ENGL 1301 only at Austin CC ("146.2 mi"), NE Texas CC, and Wharton — Houston Community College's 173 ENGL sections never appeared, because HCC titles the course "Composition I" and the search only matched titles. Now:

- **"english" finds every ENGL/ENG course statewide** regardless of how each college words its titles — the keyword is also resolved as a subject name and those prefixes' sections are unioned in. Same for "psychology", "biology", etc., in every state.
- **With a zip, the nearest college that offers the course comes first.** The 77002 student now sees Houston CC at 1.6 mi at the top of every English group instead of Austin CC.
- **A new "Within N miles" select** (10/25/50, default Any) appears once a zip is entered, mirroring the `/{state}/results` radius flow.
- **Filters survive refresh and sharing**: q/zip/radius/mode/days/timeOfDay/transfersTo are written back to the URL as you change them.
- Two adjacent dead-ends fixed: **"ENGL 1301" now returns ENGL 1301 itself** (4-digit course numbers — TX/FL — previously fell to title-keyword and returned the *corequisite* courses that mention it), and **"math" in NC** (MAT-prefix state) returns 41 math courses instead of 0.

## Technical notes

- `lib/courses-search.ts` does the work: `subjectPrefixesForName(keyword)` (existing machinery in `lib/subjects.ts`, fully state-agnostic) is intersected with the state's actual `getDistinctSubjects` (cached) and the per-prefix `searchSections` queries run in parallel with the title-ILIKE query, deduped on college+crn+meeting fields. The post-fetch keyword re-filter accepts subject-prefix membership so union rows aren't stripped.
- Per-college distance is computed once into a map shared by the radius filter, the displayed distance, and the group ordering, so the three can't disagree. The radius cap scopes the section universe *before* the mode/days/time filters, so the empty-state "drop this filter" recovery counts never include out-of-radius colleges.
- The zero-result rescue now also fires for bare-prefix parses ("math" → prefix MATH → 0 rows in an MAT state), recovering via the existing subject-name match.
- No-zip behavior is unchanged (most-sections-first ordering, verified identical against prod for `tx?q=english` group ordering and `ENG 111` in VA).

## Known gaps

- `searchSections` keeps its pre-existing 5,000-section cap per query; a very broad prefix (TX ENGL ≈ 5k+) can still truncate the tail by row id. The union makes this *more* complete than before (each prefix gets its own capped query), not less.
- Subject resolution covers the names/aliases in `SUBJECT_NAMES` — a keyword that isn't a recognized subject name behaves exactly as before (title match + existing rescue).

## Test plan

- [x] `/api/tx/courses/search?q=english&zip=77002` — Houston CC first in every group (1.6 mi), 173 HCC ENGL sections present (matches HCC's catalog count)
- [x] `q=english` no-zip — ordering identical to prod (sections-first, no distances)
- [x] `q=ENGL 1301` — returns ENGL 1301 (3,881 sections); `q=ENG 111` (VA, 3-digit) unchanged
- [x] `&radius=10` → only HCC; UI select + URL write-back verified with Playwright against the worktree dev server (screenshot reviewed)
- [x] `/api/nc/courses/search?q=math` → 41 MAT courses (prod: 0); `q=biology` → BIO union works; latency ~1.4s cold, cached after
- [x] `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)