### PR TITLE
perf: subject pages near-504 in big states — drop the 13s live program aggregation (manifest)

### DIFF
--- a/app/[state]/programs/page.tsx
+++ b/app/[state]/programs/page.tsx
@@ -24,6 +24,7 @@ import {
   qualifies,
   getQualifyingProgramSlugs,
 } from "@/lib/programs";
+import { loadStateSummary } from "@/lib/state-summary";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 export const revalidate = 1209600; // 14 days
@@ -54,7 +55,11 @@ export async function generateMetadata(
   const { state } = await props.params;
   if (!isValidState(state)) return { title: "Not Found" };
   const config = requireStateConfig(state);
-  const slugs = await getQualifyingProgramSlugs(state);
+  // Manifest-first (the live getQualifyingProgramSlugs aggregates every program
+  // across colleges — ~13s for a big state, which can time out the ISR
+  // revalidation and leave this page frozen). Fallback to live when absent.
+  const slugs =
+    loadStateSummary(state)?.programSlugs ?? (await getQualifyingProgramSlugs(state));
 
   const title = `Programs at ${config.name} Community Colleges — Earnings, Transfer, and Course Comparison`;
   const description = `Compare ${slugs.length} program${slugs.length === 1 ? "" : "s"} across ${config.systemName} community colleges. Side-by-side awards-per-year, graduate earnings, and transfer details for popular majors at every CC in ${config.name}.`;

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -23,6 +23,7 @@ import { subjectName } from "@/lib/subjects";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import { getBestProgramForPrefix } from "@/lib/programs/registry";
 import { getQualifyingProgramSlugs } from "@/lib/programs";
+import { loadStateSummary } from "@/lib/state-summary";
 import SectionHeading from "@/components/SectionHeading";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
@@ -187,8 +188,13 @@ export default async function StateSubjectPage(props: PageProps) {
   // link so subject-page visitors discover the cross-college comparison
   // view with earnings data.
   const matchedProgram = getBestProgramForPrefix(prefix);
+  // Use the precomputed summary manifest (same source the state home + course
+  // page use) instead of the live getQualifyingProgramSlugs(), which loops every
+  // program × per-college section aggregation — ~13s for CA, pushing this page
+  // to ~12.6s (on the edge of Vercel's 15s 504). Manifest read is ~1ms; the
+  // live call stays only as a fallback when the manifest is absent.
   const qualifyingSlugs = matchedProgram
-    ? await getQualifyingProgramSlugs(state)
+    ? (loadStateSummary(state)?.programSlugs ?? (await getQualifyingProgramSlugs(state)))
     : [];
   const programLink =
     matchedProgram && qualifyingSlugs.includes(matchedProgram.slug)

--- a/app/sitemap/programs.xml/route.ts
+++ b/app/sitemap/programs.xml/route.ts
@@ -1,5 +1,6 @@
 import { getAllStates } from "@/lib/states/registry";
 import { getQualifyingProgramSlugs } from "@/lib/programs";
+import { loadStateSummary } from "@/lib/state-summary";
 import {
   toSitemapXml,
   siteOrigin,
@@ -15,7 +16,13 @@ export async function GET() {
 
   const results = await Promise.allSettled(
     getAllStates().map(async (state) => {
-      const slugs = await getQualifyingProgramSlugs(state.slug);
+      // Manifest-first: this force-dynamic sitemap is fetched by crawlers on
+      // every request, and the live getQualifyingProgramSlugs aggregates every
+      // program across colleges (~13s for a big state) — so the old code took
+      // ~13s per crawl. The precomputed manifest makes it instant.
+      const slugs =
+        loadStateSummary(state.slug)?.programSlugs ??
+        (await getQualifyingProgramSlugs(state.slug));
       const lastModified = getProgramLastUpdated(state.slug) ?? undefined;
       return slugs.map((slug) => ({
         url: `${url}/${state.slug}/program/${slug}`,


### PR DESCRIPTION
## What changes for someone using the site

Subject pages — the SEO hubs like `/ca/subject/engl` ("9,120 sections · 593 courses · 93 colleges") — are loading right at the edge of Vercel's 15-second timeout in the biggest states (**California 12.6 s**, Texas 8.2 s). They haven't 504'd *yet*, but as data grows they would, exactly the way the course pages did. After this change they load in about a second. Same fix also speeds up the program sitemap (which crawlers fetch) and the `/programs` page's background refresh.

## What changed technically

After #1444 fixed the course pages, I audited every other page that calls the same expensive function — `getQualifyingProgramSlugs(state)`, which loops every curated program × per-college section aggregation (~4–13 s for CA, and variable). Probing prod across big states found the **subject page** sitting at 12.6 s. Other routes were already fine (`/programs` body, `/program/[slug]` 1.7 s, `/plan`, `/schedule`, `/transfer` — cached or scoped; `/program/[slug]` only mentions the function in comments).

Three remaining live call sites now read the precomputed **`loadStateSummary().programSlugs`** manifest instead — the same source the state home and (since #1444) the course page already use, regenerated every deploy by `build-state-summaries` (wired into the build in #1410). The live call stays only as a fallback when the manifest is absent:

| page | before | after |
|---|---|---|
| `/[state]/subject/[prefix]` (data load) | ~5–13 s | ~0.5 s |
| `/sitemap/programs.xml` (force-dynamic, per crawl) | ~13 s | instant |
| `/[state]/programs` metadata (ISR revalidation) | 13 s | ~1 ms |

**Tradeoff (identical to #1444):** the manifest is a *subset* of live qualification, so a program that newly clears the threshold gets its "Part of {program}" cross-link one deploy late — never a broken link. Verified the manifest matches live for NY; CA/TX differ by exactly 1 only because the *local committed* `summary.json` is stale (prod's is regenerated at deploy).

## Test plan

- `npm run typecheck` ✓ · `npm run lint` (0 errors) ✓
- Timed the subject-page data load against prod: the live `getQualifyingProgramSlugs('ca')` (4–13 s) is replaced by a 0 ms manifest read; the only remaining cost is `loadCoursesBySubject` (~0.5 s)
- Manifest-vs-live correctness: identical for NY; CA/TX subset-different only due to local stale manifest (prod regenerates at deploy); subset means no broken links
- Post-merge: `/ca/subject/engl`, `/tx/subject/engl` should drop from ~8–13 s to ~1–2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
