### PR TITLE
tx: every course row now links the college's own registration site (was tacc.org) + CRN explainer

### DIFF
--- a/app/[state]/college/[id]/CollegeDetailClient.tsx
+++ b/app/[state]/college/[id]/CollegeDetailClient.tsx
@@ -73,6 +73,7 @@ export default function CollegeDetailClient({
         courses={courses}
         collegeSlug={collegeSlug}
         systemName={systemName}
+        collegeName={institution.name}
         courseListingUrl={courseListingUrl}
         onAuditClick={(course) => {
           setSelectedCourse(course);

--- a/app/[state]/college/[id]/CollegeTermSection.tsx
+++ b/app/[state]/college/[id]/CollegeTermSection.tsx
@@ -143,7 +143,7 @@ export default function CollegeTermSection({
               rel="noopener noreferrer"
               className="underline"
             >
-              {systemName} course site
+              {institution.name} course site
             </a>{" "}
             for the latest listings.
           </p>
@@ -221,7 +221,7 @@ export default function CollegeTermSection({
                 rel="noopener noreferrer"
                 className="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 ml-1"
               >
-                {systemName} ↗
+                View at {institution.name} ↗
               </a>
             </div>
           )}
@@ -249,7 +249,7 @@ export default function CollegeTermSection({
               rel="noopener noreferrer"
               className="text-teal-600 hover:underline text-sm"
             >
-              {`Check ${systemName} course site directly →`}
+              {`Check the ${institution.name} course site directly →`}
             </a>
           </div>
         ) : (

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -998,7 +998,7 @@ function CollegeBlock({
               rel="noopener noreferrer"
               className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-300 hover:underline"
             >
-              View on {config.systemName} &rarr;
+              View at {college.name} ↗
             </a>
           )}
         </div>

--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -1042,7 +1042,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                                   rel="noopener noreferrer"
                                   className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-300 hover:underline"
                                 >
-                                  {`View on ${systemName} →`}
+                                  {`View at ${college.name} ↗`}
                                 </a>
                               </div>
                             </div>

--- a/components/CourseTable.tsx
+++ b/components/CourseTable.tsx
@@ -18,6 +18,8 @@ interface CourseTableProps {
   collegeSlug: string;
   courseListingUrl?: string;
   systemName?: string;
+  /** College display name for the external-link label ("View at {college}"). */
+  collegeName?: string;
   onAuditClick?: (course: CourseSection) => void;
   pinnedCRNs?: Set<string>;
   onTogglePin?: (crn: string) => void;
@@ -253,6 +255,7 @@ interface CourseRowProps {
   collegeSlug: string;
   courseListingUrl?: string;
   systemName?: string;
+  collegeName?: string;
   onAuditClick?: (course: CourseSection) => void;
   pinnedCRNs?: Set<string>;
   onTogglePin?: (crn: string) => void;
@@ -260,7 +263,7 @@ interface CourseRowProps {
   state?: string;
 }
 
-function CourseRow({ course, collegeSlug, courseListingUrl, systemName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state }: CourseRowProps) {
+function CourseRow({ course, collegeSlug, courseListingUrl, systemName, collegeName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state }: CourseRowProps) {
   const style = MODE_STYLES[course.mode];
   const status = getCourseStatus(course.start_date);
   const statusStyle = STATUS_STYLES[status];
@@ -362,7 +365,7 @@ function CourseRow({ course, collegeSlug, courseListingUrl, systemName, onAuditC
             rel="noopener noreferrer"
             className="text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline dark:text-slate-400 dark:hover:text-slate-300"
           >
-            {systemName} &rarr;
+            View at {collegeName ?? systemName} ↗
           </a>
         </div>
       </td>
@@ -370,7 +373,7 @@ function CourseRow({ course, collegeSlug, courseListingUrl, systemName, onAuditC
   );
 }
 
-export default function CourseTable({ courses, collegeSlug, courseListingUrl, systemName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state, groupBySubject, defaultStatusFilter = "", defaultModeFilter = "" }: CourseTableProps) {
+export default function CourseTable({ courses, collegeSlug, courseListingUrl, systemName, collegeName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state, groupBySubject, defaultStatusFilter = "", defaultModeFilter = "" }: CourseTableProps) {
   const [subjectFilter, setSubjectFilter] = useState("");
   const [dayFilters, setDayFilters] = useState<string[]>([]);
   const [modeFilter, setModeFilter] = useState(defaultModeFilter);
@@ -498,7 +501,14 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
             <table className="w-full text-left text-sm">
               <thead className="border-b border-gray-200 bg-gray-50 text-xs uppercase tracking-wider text-gray-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400">
                 <tr>
-                  <th className="whitespace-nowrap px-3 py-3 font-medium">CRN</th>
+                  <th className="whitespace-nowrap px-3 py-3 font-medium">
+                    <abbr
+                      title="Course Reference Number — the code you give the college when you register for this exact section"
+                      className="cursor-help no-underline border-b border-dotted border-gray-400 dark:border-slate-500"
+                    >
+                      CRN
+                    </abbr>
+                  </th>
                   <th className="whitespace-nowrap px-3 py-3 font-medium">Course</th>
                   <th className="px-3 py-3 font-medium w-full">Title</th>
                   <th className="whitespace-nowrap px-3 py-3 font-medium">Schedule</th>
@@ -523,7 +533,7 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
                           <span className="ml-3 text-xs text-gray-400 dark:text-slate-500">{group.length} {group.length === 1 ? "section" : "sections"}</span>
                         </td>
                       </tr>,
-                      ...group.map((course) => <CourseRow key={`${course.crn}-${course.course_prefix}${course.course_number}-${course.days}-${course.start_time}`} course={course} collegeSlug={collegeSlug} courseListingUrl={courseListingUrl} systemName={systemName} onAuditClick={onAuditClick} pinnedCRNs={pinnedCRNs} onTogglePin={onTogglePin} transferLookup={transferLookup} state={state} />),
+                      ...group.map((course) => <CourseRow key={`${course.crn}-${course.course_prefix}${course.course_number}-${course.days}-${course.start_time}`} course={course} collegeSlug={collegeSlug} courseListingUrl={courseListingUrl} systemName={systemName} collegeName={collegeName} onAuditClick={onAuditClick} pinnedCRNs={pinnedCRNs} onTogglePin={onTogglePin} transferLookup={transferLookup} state={state} />),
                     ];
                   });
                 })() : filtered.map((course) => (
@@ -533,6 +543,7 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
                     collegeSlug={collegeSlug}
                     courseListingUrl={courseListingUrl}
                     systemName={systemName}
+                    collegeName={collegeName}
                     onAuditClick={onAuditClick}
                     pinnedCRNs={pinnedCRNs}
                     onTogglePin={onTogglePin}
@@ -597,7 +608,7 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
                     </span>
                   </div>
                   <div className="grid grid-cols-2 gap-y-1 text-xs text-gray-500 dark:text-slate-400">
-                    <span className="truncate">CRN: <span className="font-mono text-gray-700 dark:text-slate-300">{course.crn}</span></span>
+                    <span className="truncate" title="Course Reference Number — the code you give the college when you register for this exact section">CRN: <span className="font-mono text-gray-700 dark:text-slate-300">{course.crn}</span></span>
                     <span>Campus: <span className="text-gray-700 dark:text-slate-300">{course.campus || "---"}</span></span>
                     <span className="col-span-2">
                       Schedule: <span className="text-gray-700 dark:text-slate-300">{formatSchedule(course)}</span>
@@ -640,7 +651,7 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
                       rel="noopener noreferrer"
                       className="text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline dark:text-slate-400 dark:hover:text-slate-300"
                     >
-                      View on {systemName} &rarr;
+                      View at {collegeName ?? systemName} ↗
                     </a>
                   </div>
                 </div>

--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -1,5 +1,123 @@
 import type { StateConfig } from "../registry";
 
+// Texas has no statewide SIS — every district runs its own class search. These
+// are per-college public class-search / registration entry points, harvested
+// from the working scrapers in scripts/tx/ and each probed 2026-06-12 (HTTP 200
+// for curl with a browser UA, or verified rendering in real headless Chromium
+// where a bot wall blocks curl — noted inline).
+//
+// Five Alamo Colleges share one public Banner SSB instance (same host the
+// scraper uses; the student-facing aces.alamo.edu portal is login-walled).
+const ALAMO_CLASS_SEARCH =
+  "https://lum010.alamo.edu:8010/StudentRegistrationSsb/ssb/classSearch/classSearch";
+// Howard College + SW College for the Deaf share one Concourse instance.
+// The root redirects to /login but /search is public.
+const HOWARD_CLASS_SEARCH = "https://howardcollege.campusconcourse.com/search";
+
+const REGISTRATION_URLS: Record<string, string> = {
+  // hccs.edu's own "class searcher" link — auto-establishes a PeopleSoft guest
+  // session in the browser and lands on Class Search (curl sees ?cmd=login
+  // because the guest auto-login is JS; verified in headless Chromium).
+  "houston-community-college": "https://www.hccs.edu/class-searcher/",
+  "san-antonio-college": ALAMO_CLASS_SEARCH,
+  "st-philips-college": ALAMO_CLASS_SEARCH,
+  "palo-alto-college": ALAMO_CLASS_SEARCH,
+  "northwest-vista-college": ALAMO_CLASS_SEARCH,
+  "northeast-lakeview-college": ALAMO_CLASS_SEARCH,
+  // Colleague Self-Service guest course search (same hosts the scrapers use).
+  "amarillo-college": "https://acselfservice.actx.edu/Student/Courses",
+  "odessa-college": "https://sserv.odessa.edu/Student/Courses",
+  "college-of-the-mainland": "https://selfserve.com.edu/Student/Courses",
+  "mclennan-community-college": "https://mymcc.mclennan.edu/Student/Courses",
+  "alvin-community-college":
+    "https://self-service.alvincollege.edu/Student/Courses",
+  "vernon-college":
+    "https://vernon-ss.colleague.elluciancloud.com/Student/Courses",
+  "del-mar-college": "https://colss-prod.ec.delmar.edu/Student/Courses",
+  // Public, but Cloudflare Bot Management 403s curl — renders fine in a real
+  // browser ("Search for Courses and Course Sections", verified in Chromium).
+  "central-texas-college": "https://student.ctcd.org/Student/Courses",
+  // Jenzabar ICS public course-search portlets.
+  "kilgore-college":
+    "https://accesskc.kilgore.edu/ICS/Current_Students/Academics/AddDrop_Courses.jnz",
+  "panola-college":
+    "https://pctportal.jenzabarcloud.com/ICS/Admin/Shared_Features/Everyone.jnz?portlet=Student_Registration&screen=StudentRegistrationPortlet_CourseSearchView&screenType=next",
+  "paris-junior-college":
+    "https://mypjc.parisjc.edu/ICS/Portal_Homepage.jnz?portlet=AddDrop_Courses&screen=Advanced+Course+Search&screenType=next",
+  "north-central-texas-college":
+    "https://my.nctc.edu/ICS/Academics/Academics_Homepage.jnz?portlet=AddDrop_Courses&screen=Advanced+Course+Search&screenType=next",
+  "texarkana-college":
+    "https://my.texarkanacollege.edu/ICS/Home.jnz?portlet=Course_Search&screen=Advanced+Course+Search&screenType=next",
+  "midland-college":
+    "https://mymcportal.midland.edu/ICS/Course_Search.jnz?portlet=Course_Search&screen=Advanced+Course+Search&screenType=next",
+  "northeast-texas-community-college": "https://myeagle.ntcc.edu/ICS/Find_Courses/",
+  // Banner SSB 9 class search.
+  "victoria-college":
+    "https://xe-stu.victoriacollege.edu/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  "laredo-college":
+    "https://reg-prod.laredo.elluciancloud.com:8103/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  "wharton-county-junior-college":
+    "https://reg-prod.wcjc.elluciancloud.com:8103/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  "san-jacinto-community-college":
+    "https://reg-prod.ec.sanjac.edu/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  "lamar-institute-of-technology":
+    "https://reg-prod.litsaas.elluciancloud.com:8103/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  // Banner 8 dynamic schedule.
+  "tyler-junior-college": "https://ssbprod.tjc.edu:8100/prod/bwckschd.p_disp_dyn_sched",
+  // Bespoke public schedule apps (same endpoints the scrapers read).
+  "austin-community-college-district": "https://www6.austincc.edu/schedule/",
+  "collin-county-community-college-district": "https://collin-coursebook.web.app/",
+  "dallas-college": "https://schedule.dallascollege.edu/",
+  "grayson-college": "https://planner.grayson.edu/Planner/CourseSearch",
+  "brazosport-college":
+    "https://mybcnext.brazosport.edu/CMCPortal/Common/CourseSchedule.aspx",
+  "cisco-college": "https://admin.cisco.edu/cc4/web_course_avail.html",
+  "clarendon-college": "https://ci.clarendoncollege.edu/",
+  "lone-star-college-system": "https://campus.lonestar.edu/classsearch.htm",
+  "howard-college": HOWARD_CLASS_SEARCH,
+  "southwest-college-for-the-deaf": HOWARD_CLASS_SEARCH,
+  // Per-term PDF schedules live on this page.
+  "frank-phillips-college": "https://fpctx.edu/student-resources/",
+  // Public schedule app; its search POST is Turnstile-walled for bots
+  // (documentedCeilings) but the page renders fine for humans (verified in
+  // Chromium: "TVCC Schedule Of Classes").
+  "trinity-valley-community-college": "https://webapps.tvcc.edu/ClassSched2/",
+};
+
+// Honest fallback for colleges with no public class search (login-walled SIS —
+// see documentedCeilings — or no scraper yet): the college's own homepage,
+// from data/tx/scorecard schoolUrl. Never tacc.org per college — TACC is a
+// trade association, useless to a student trying to register.
+const COLLEGE_HOMEPAGES: Record<string, string> = {
+  "angelina-college": "https://www.angelina.edu/",
+  "blinn-college-district": "https://www.blinn.edu/",
+  "coastal-bend-college": "https://www.coastalbend.edu/",
+  "el-paso-community-college": "https://www.epcc.edu/",
+  "galveston-college": "https://www.gc.edu/",
+  "hill-college": "https://www.hillcollege.edu/",
+  "lamar-state-college-orange": "https://www.lsco.edu/",
+  "lamar-state-college-port-arthur": "https://www.lamarpa.edu/",
+  "lee-college": "https://www.lee.edu/",
+  "navarro-college": "https://www.navarrocollege.edu/",
+  "ranger-college": "https://www.rangercollege.edu/",
+  "south-plains-college": "https://www.southplainscollege.edu/",
+  "south-texas-college": "https://www.southtexascollege.edu/",
+  // Canonical domain; the whole swtjc.edu web presence was timing out at probe
+  // time (2026-06-12) — kept anyway since it's still the college's only site.
+  "southwest-texas-junior-college": "https://www.swtjc.edu/",
+  "tarrant-county-college-district": "https://www.tccd.edu/",
+  "temple-college": "https://www.templejc.edu/",
+  "texas-southmost-college": "https://www.tsc.edu/",
+  "texas-state-technical-college": "https://www.tstc.edu/",
+  "weatherford-college": "https://www.wc.edu/",
+  "western-texas-college": "https://www.wtc.edu/",
+};
+
+const collegeUrl = (collegeSlug: string): string =>
+  REGISTRATION_URLS[collegeSlug] ??
+  COLLEGE_HOMEPAGES[collegeSlug] ??
+  "https://www.tacc.org/";
+
 const txConfig: StateConfig = {
   slug: "tx",
   name: "Texas",
@@ -34,11 +152,10 @@ const txConfig: StateConfig = {
   defaultZip: "77002",
   defaultZipCity: "Houston",
 
-  courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    "https://www.tacc.org/",
+  courseDiscoveryUrl: (collegeSlug: string, _prefix: string, _number: string) =>
+    collegeUrl(collegeSlug),
 
-  collegeCoursesUrl: (_collegeSlug: string) =>
-    "https://www.tacc.org/",
+  collegeCoursesUrl: (collegeSlug: string) => collegeUrl(collegeSlug),
 
   branding: {
     siteName: "Community College Path Texas",


### PR DESCRIPTION
## What changes for someone using the site

Every TX course row now links to the college's own registration site. On /tx/college/houston-community-college, the link on each of the 170 ENGL rows used to say "Texas Community Colleges →" and go to https://www.tacc.org/ — a trade-association homepage where a student holding CRN 17325 could do nothing. It now says **"View at Houston Community College ↗"** and opens HCC's real class search (hccs.edu/class-searcher/, which auto-opens a guest PeopleSoft Class Search session). The header chip, the stale-data banner, the per-course page, and the statewide course search get the same treatment.

The **CRN** column header now explains itself: hovering shows "Course Reference Number — the code you give the college when you register for this exact section" (an `<abbr>` with a dotted underline; same title on the mobile cards).

## Technical

- `lib/states/tx/config.ts` gets a GA-style per-college lookup: **39 colleges** with a verified public class-search/registration URL (`REGISTRATION_URLS`) and **20 honest homepage fallbacks** (`COLLEGE_HOMEPAGES`) for colleges whose SIS is login-walled (see `documentedCeilings`) or has no scraper. `courseDiscoveryUrl()`/`collegeCoursesUrl()` resolve registration URL → homepage → tacc.org (now unreachable in practice: every college is in one of the two maps).
- URLs were harvested from the working `scripts/tx/` scrapers and **every one probed 2026-06-12**: 200 via curl with a browser UA, or — for HCC, Central Texas (Cloudflare), and Trinity Valley (Turnstile) — verified rendering in real headless Chromium, since their bot walls 403 curl but pass humans. Howard's Concourse root redirects to /login, so its public `/search` path is used. One upgrade beyond the scrapers: Lamar Institute of Technology's Banner SSB host from the fingerprint baseline.
- `components/CourseTable.tsx` gains an optional `collegeName` prop (fed from `institution.name` in `CollegeDetailClient`); the row label is "View at {college}" with `systemName` as fallback. This improves **all states** — GA rows now read "View at Atlanta Technical College ↗" while still hitting the same Banner URL.

## Known gaps

- Southwest Texas Junior College's entire web presence (homepage + SIS) was timing out at probe time; its canonical swtjc.edu is kept as the fallback anyway.
- The 20 fallback colleges land on the college homepage, not a class search — that's the documented ceiling (login-walled Colleague/Jenzabar/PeopleSoft), not a deferral.

## Test plan

- [x] `tsc --noEmit` clean; `npm run build` passes
- [x] Dev (Playwright): HCC, San Antonio (Alamo shared Banner), Tyler JC (Banner 8), Austin CC, Blinn (homepage fallback) — per-row + chip links correct, CRN abbr present
- [x] GA regression: /ga/college/atlanta-tech still links its Banner class search
- [ ] Post-merge: click the prod HCC link on /tx/college/houston-community-college

🤖 Generated with [Claude Code](https://claude.com/claude-code)