### PR TITLE
ask: answer card works in every state — fix silent classifier outage; homepage cards follow your selected state

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -272,6 +272,10 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   const [answer, setAnswer] = useState<Answer | null>(null);
   const [secondaryAnswer, setSecondaryAnswer] = useState<Answer | null>(null);
   const [classification, setClassification] = useState<ClassificationSummary | null>(null);
+  // True when /ask 5xxed (classifier outage) or the fetch itself failed. Shown
+  // as a small note so a broken classifier is visible instead of silently
+  // degrading every natural-language question to keyword soup.
+  const [askUnavailable, setAskUnavailable] = useState(false);
 
   // Fetch transfer lookup data on mount (small, cached 24h)
   useEffect(() => {
@@ -309,6 +313,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       setSecondaryAnswer(null);
       setClassification(null);
     }
+    setAskUnavailable(false);
 
     const trimmed = searchQuery.trim();
     // The user query may be natural language ("Computer Science classes on
@@ -410,9 +415,15 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
             if (!llmTransferTo && sec.university) llmTransferTo = sec.university;
           }
         }
+      } else if (askRes.status >= 500) {
+        // Classifier outage (all providers down, missing key, quota). The
+        // course search below still runs on the raw query — but say so, or a
+        // natural-language question silently turns into keyword soup.
+        setAskUnavailable(true);
       }
     } catch {
-      /* silent — no answer card, fall through to raw-query search below */
+      // Network failure reaching /ask — same degradation as a 5xx.
+      setAskUnavailable(true);
     }
 
     // Sync LLM-extracted filters into UI state when the user hasn't set
@@ -490,13 +501,17 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       // duplicate the query — and fetch only the natural-language answer card so
       // the deep link still matches the interactive search experience.
       fetch(`/api/${state}/ask?q=${encodeURIComponent(initialQuery)}`)
-        .then((r) => (r.ok ? r.json() : null))
+        .then((r) => {
+          if (r.ok) return r.json();
+          if (r.status >= 500) setAskUnavailable(true);
+          return null;
+        })
         .then((d) => {
           if (d?.answer) setAnswer(d.answer);
           if (d?.secondaryAnswer) setSecondaryAnswer(d.secondaryAnswer);
           if (d?.classification) setClassification(d.classification);
         })
-        .catch(() => {});
+        .catch(() => setAskUnavailable(true));
       return;
     }
     // No server-rendered results (no keyword match, or a natural-language query
@@ -724,6 +739,18 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
           transfer to GMU?", renders just its typed answer body — passing
           classification={null} naturally suppresses the duplicate summary
           UI on the second card. */}
+      {/* Classifier outage: the question couldn't be interpreted, but keyword
+          search still ran. Without this note the failure is invisible — the
+          user just sees worse results and assumes the site can't answer. */}
+      {askUnavailable && !loading && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 p-3 mb-4" role="status">
+          <p className="text-sm text-amber-800 dark:text-amber-300">
+            We couldn&apos;t interpret your question right now, so these are
+            plain keyword matches. Try again in a minute for a direct answer.
+          </p>
+        </div>
+      )}
+
       {answer && (
         <AnswerCard
           answer={answer}

--- a/app/api/[state]/ask/route.ts
+++ b/app/api/[state]/ask/route.ts
@@ -79,14 +79,26 @@ export async function GET(request: NextRequest, context: RouteContext) {
   try {
     classification = await classifyQuery(q, state);
   } catch (err) {
-    // Anthropic outage, missing key, billing issue, network error, etc.
-    // Log server-side, return 503 so the UI knows to skip the answer card.
-    console.error("[ask] classifier failed:", err);
+    // Provider outage, missing key, billing issue, network error, etc.
+    // chainAll() aggregates every provider's failure into one message, so this
+    // names the broken provider instead of just the last fallback in line.
+    // Structured line first (grep `ask.classifier_failed` in Vercel logs),
+    // human-readable error second.
+    const cause = err instanceof Error ? err.message : "unknown";
+    console.error(
+      JSON.stringify({
+        event: "ask.classifier_failed",
+        state,
+        queryLength: q.length,
+        cause: cause.slice(0, 600),
+      }),
+    );
     return NextResponse.json(
       {
         error: "Classifier service unavailable.",
+        code: "classifier_unavailable",
         // Surface the high-level cause without leaking stack details.
-        cause: err instanceof Error ? err.message : "unknown",
+        cause,
       },
       { status: 503 },
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { getAllStates, statesCoveredLabel, coveredStateCount } from "@/lib/state
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 import CourseSearchHero from "@/components/CourseSearchHero";
+import HomeFeatureCards from "@/components/HomeFeatureCards";
 import USMap from "@/components/USMap";
 import AccountPromo from "@/components/auth/AccountPromo";
 
@@ -161,95 +162,10 @@ export default async function LandingPage() {
           <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-8">
             what you can do
           </div>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {[
-              {
-                num: "01",
-                title: "Search any course",
-                body: "One search across every college in your state — by code, subject, or what you're trying to learn.",
-                href: "/colleges",
-                cta: "Start searching",
-                icon: (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                  />
-                ),
-              },
-              {
-                num: "02",
-                title: "Check what transfers",
-                body: "Pick your CC and your target university. See which courses count, which don't, and what they map to.",
-                href: geoState ? `/${geoState}/transfer` : "/colleges",
-                cta: "Look up transfers",
-                icon: (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
-                  />
-                ),
-              },
-              {
-                num: "03",
-                title: "Build a schedule",
-                body: "Drag classes onto a weekly grid, see conflicts immediately, and export when you're ready to register.",
-                href: geoState ? `/${geoState}/schedule` : "/colleges",
-                cta: "Open the planner",
-                icon: (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
-                  />
-                ),
-              },
-              {
-                num: "04",
-                title: "Plan a degree",
-                body: "Pick a program, choose your transfer target, and see every required course — which ones count there, and what's open now.",
-                href: geoState ? `/${geoState}/colleges` : "/colleges",
-                cta: "Start planning",
-                icon: (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5"
-                  />
-                ),
-              },
-            ].map((card) => (
-              <Link
-                key={card.num}
-                href={card.href}
-                className="group rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-md transition-all"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="w-11 h-11 rounded-xl bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300 flex items-center justify-center">
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
-                      {card.icon}
-                    </svg>
-                  </div>
-                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
-                    {card.num}
-                  </span>
-                </div>
-                <h3 className="mt-5 text-lg font-semibold text-slate-900 dark:text-slate-100">
-                  {card.title}
-                </h3>
-                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
-                  {card.body}
-                </p>
-                <span className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 group-hover:gap-2 transition-all">
-                  {card.cta}
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-                  </svg>
-                </span>
-              </Link>
-            ))}
-          </div>
+          <HomeFeatureCards
+            geoState={geoState}
+            stateSlugs={states.map((s) => s.slug)}
+          />
         </div>
       </section>
 

--- a/components/CourseSearchHero.tsx
+++ b/components/CourseSearchHero.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { statesCoveredLabel } from "@/lib/states/registry";
+import { readStoredState, storeSelectedState } from "./state-selection";
 
 const PLACEHOLDER_QUERIES = [
   "ENG 111",
@@ -66,8 +67,6 @@ function useTypewriter(phrases: string[], active: boolean) {
 
 type StateOption = { slug: string; name: string; abbr: string };
 
-const LS_KEY = "ccp:lastState";
-
 export default function CourseSearchHero({
   states,
   geoState,
@@ -95,8 +94,8 @@ export default function CourseSearchHero({
   // localStorage is only available client-side, so this hydration must
   // happen in an effect after mount.
   useEffect(() => {
-    const stored = typeof window !== "undefined" ? localStorage.getItem(LS_KEY) : null;
-    if (stored && states.some((s) => s.slug === stored)) {
+    const stored = readStoredState(states.map((s) => s.slug));
+    if (stored) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedState(stored);
 
@@ -144,7 +143,11 @@ export default function CourseSearchHero({
   const pickState = (slug: string) => {
     setSelectedState(slug);
     setIsAuto(false);
-    localStorage.setItem(LS_KEY, slug);
+    // Persists the choice AND broadcasts it so the feature cards below the
+    // hero retarget to the new state immediately. The typed query lives in
+    // this component's state, so switching state never discards it — submit
+    // still routes to /{selectedState}/courses?q=<query>.
+    storeSelectedState(slug);
     setPickerOpen(false);
     setNeedsState(false);
   };

--- a/components/HomeFeatureCards.tsx
+++ b/components/HomeFeatureCards.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  STATE_CHANGE_EVENT,
+  readStoredState,
+} from "./state-selection";
+
+// The homepage's four "what you can do" cards. Client component so the card
+// destinations follow the hero's selected state chip: manual choice (stored by
+// the hero) > geo-IP guess (server prop) > the national /colleges index.
+// Server HTML renders with geoState, then the mount effect swaps in a stored
+// manual choice and the event listener tracks live chip switches.
+
+type Card = {
+  num: string;
+  title: string;
+  body: string;
+  /** Path under /{state} when a state is known, e.g. "courses". */
+  statePath: string;
+  cta: string;
+  icon: React.ReactNode;
+};
+
+const CARDS: Card[] = [
+  {
+    num: "01",
+    title: "Search any course",
+    body: "One search across every college in your state — by code, subject, or what you're trying to learn.",
+    statePath: "courses",
+    cta: "Start searching",
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      />
+    ),
+  },
+  {
+    num: "02",
+    title: "Check what transfers",
+    body: "Pick your CC and your target university. See which courses count, which don't, and what they map to.",
+    statePath: "transfer",
+    cta: "Look up transfers",
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+      />
+    ),
+  },
+  {
+    num: "03",
+    title: "Build a schedule",
+    body: "Drag classes onto a weekly grid, see conflicts immediately, and export when you're ready to register.",
+    statePath: "schedule",
+    cta: "Open the planner",
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
+      />
+    ),
+  },
+  {
+    num: "04",
+    title: "Plan a degree",
+    body: "Pick a program, choose your transfer target, and see every required course — which ones count there, and what's open now.",
+    statePath: "colleges",
+    cta: "Start planning",
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5"
+      />
+    ),
+  },
+];
+
+export default function HomeFeatureCards({
+  geoState,
+  stateSlugs,
+}: {
+  geoState: string | null;
+  stateSlugs: string[];
+}) {
+  const [selectedState, setSelectedState] = useState<string | null>(geoState);
+
+  useEffect(() => {
+    const stored = readStoredState(stateSlugs);
+    if (stored) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedState(stored);
+    }
+    const onChange = (e: Event) => {
+      const slug = (e as CustomEvent<string>).detail;
+      if (stateSlugs.includes(slug)) setSelectedState(slug);
+    };
+    window.addEventListener(STATE_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(STATE_CHANGE_EVENT, onChange);
+  }, [stateSlugs]);
+
+  return (
+    <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {CARDS.map((card) => (
+        <Link
+          key={card.num}
+          href={selectedState ? `/${selectedState}/${card.statePath}` : "/colleges"}
+          className="group rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-md transition-all"
+        >
+          <div className="flex items-center justify-between">
+            <div className="w-11 h-11 rounded-xl bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300 flex items-center justify-center">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
+                {card.icon}
+              </svg>
+            </div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
+              {card.num}
+            </span>
+          </div>
+          <h3 className="mt-5 text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {card.title}
+          </h3>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+            {card.body}
+          </p>
+          <span className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 group-hover:gap-2 transition-all">
+            {card.cta}
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+            </svg>
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/state-selection.ts
+++ b/components/state-selection.ts
@@ -1,0 +1,24 @@
+// The homepage's single source of truth for "which state is the user in".
+//
+// The hero's state chip writes here; anything else on the page that builds
+// state-scoped links (the four feature cards) subscribes via the custom event
+// so a chip switch retargets them immediately — no reload, no prop drilling
+// through the server component.
+//
+// Priority order for consumers: stored manual choice > geo-IP guess > none.
+
+export const STATE_LS_KEY = "ccp:lastState";
+export const STATE_CHANGE_EVENT = "ccp:state-change";
+
+/** Read the user's last manually-chosen state, if it's still a valid slug. */
+export function readStoredState(validSlugs: readonly string[]): string | null {
+  if (typeof window === "undefined") return null;
+  const stored = localStorage.getItem(STATE_LS_KEY);
+  return stored && validSlugs.includes(stored) ? stored : null;
+}
+
+/** Persist a manual state choice and notify same-page subscribers. */
+export function storeSelectedState(slug: string): void {
+  localStorage.setItem(STATE_LS_KEY, slug);
+  window.dispatchEvent(new CustomEvent(STATE_CHANGE_EVENT, { detail: slug }));
+}

--- a/lib/search-intent/__tests__/classify.test.ts
+++ b/lib/search-intent/__tests__/classify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { classifierWith } from "../classify";
+import { bareCourseCodeShortcut, classifierWith } from "../classify";
 import { hashQuery, memoryCache, normalizeQuery, nullCache } from "../cache";
 import type { Classifier } from "../types";
 
@@ -132,5 +132,55 @@ describe("classifierWith", () => {
     await classifier("hello", "va");
     await classifier("hello", "va");
     expect(llm).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("bareCourseCodeShortcut", () => {
+  it("matches bare course codes in common spellings", () => {
+    for (const q of ["ENG 111", "eng111", "BIO-256", "MATH 151A", "  cs 50  ", "CRTV 121F"]) {
+      const result = bareCourseCodeShortcut(q);
+      expect(result, q).not.toBeNull();
+      expect(result!.intent.type).toBe("course");
+    }
+  });
+
+  it("extracts an uppercased prefix + number", () => {
+    const result = bareCourseCodeShortcut("eng-111");
+    expect(result!.intent).toEqual({
+      type: "course",
+      keyword: null,
+      filters: { course: { prefix: "ENG", number: "111" } },
+    });
+  });
+
+  it("returns an empty studentSummary so the UI renders no card", () => {
+    expect(bareCourseCodeShortcut("ENG 111")!.studentSummary).toBe("");
+  });
+
+  it("does NOT match natural-language or filtered queries", () => {
+    for (const q of [
+      "does ENG 111 transfer to GMU?",
+      "ENG 111 online",
+      "biology",
+      "intro psychology",
+      "prereqs for BIO 256",
+      "free college if I'm 65+",
+      "summer 2026",
+    ]) {
+      expect(bareCourseCodeShortcut(q), q).toBeNull();
+    }
+  });
+
+  it("classifierWith never touches cache or LLM for a bare code", async () => {
+    const llm: Classifier = vi.fn();
+    const cacheGet = vi.fn();
+    const classifier = classifierWith({
+      cache: { get: cacheGet, put: vi.fn() },
+      llm,
+    });
+    const result = await classifier("ENG 111", "nc");
+    expect(result.intent.type).toBe("course");
+    expect(llm).not.toHaveBeenCalled();
+    expect(cacheGet).not.toHaveBeenCalled();
   });
 });

--- a/lib/search-intent/classify.ts
+++ b/lib/search-intent/classify.ts
@@ -109,9 +109,36 @@ function buildProvider(spec: string | undefined): { llm: Classifier; modelVersio
   }
 }
 
-/** Chain N classifiers: try each in order, falling to the next on any throw. */
-export function chainAll(classifiers: Classifier[]): Classifier {
-  return classifiers.reduce((primary, next) => chain(primary, next));
+/**
+ * Chain N classifiers: try each in order, falling to the next on any throw.
+ *
+ * When EVERY provider fails, the thrown error's message lists each provider's
+ * failure (labelled by `labels[i]` — pass the modelVersions). Before this, only
+ * the LAST provider's error survived to the route's 503 `cause`, which made
+ * outages look like the wrong provider was broken: a dead Groq key surfaced as
+ * "Cloudflare neurons exhausted" because Cloudflare was merely the last
+ * fallback in line (2026-06-12 incident — /ask was down in every state).
+ */
+export function chainAll(classifiers: Classifier[], labels?: string[]): Classifier {
+  if (classifiers.length === 1) return classifiers[0];
+  return async (query, state) => {
+    const failures: string[] = [];
+    for (let i = 0; i < classifiers.length; i++) {
+      try {
+        return await classifiers[i](query, state);
+      } catch (err) {
+        const label = labels?.[i] ?? `provider ${i + 1}/${classifiers.length}`;
+        const msg = err instanceof Error ? err.message : String(err);
+        failures.push(`[${label}] ${msg}`);
+        if (i < classifiers.length - 1) {
+          console.warn(
+            `[classifier] ${label} failed (${msg.slice(0, 160)}); trying next provider`,
+          );
+        }
+      }
+    }
+    throw new Error(`all ${classifiers.length} classifier providers failed: ${failures.join(" | ")}`);
+  };
 }
 
 /**
@@ -143,9 +170,47 @@ function providerDefault(): { llm: Classifier; modelVersion: string } | null {
     .filter((p) => p.modelVersion !== primary.modelVersion);
 
   if (fallbacks.length === 0) return primary;
+  const providers = [primary, ...fallbacks];
   return {
-    llm: chainAll([primary, ...fallbacks].map((p) => p.llm)),
+    llm: chainAll(
+      providers.map((p) => p.llm),
+      providers.map((p) => p.modelVersion),
+    ),
     modelVersion: primary.modelVersion,
+  };
+}
+
+// "ENG 111", "eng-111", "MATH 151A" — subject prefix + number, nothing else.
+const BARE_COURSE_CODE = /^([a-z]{2,5})[\s-]*(\d{2,4}[a-z]{0,2})$/i;
+
+/**
+ * Skip the LLM entirely for bare course-code queries. The classifier would
+ * return a course intent whose only payload is the code itself — which the
+ * keyword search already parses natively — and the answer layer maps course
+ * intents to a no-answer. So the LLM call buys nothing, yet it's the most
+ * common query shape AND the one bots burn quota with: every crawled
+ * /{state}/courses?q=ENG+111 deep link fires /ask with a distinct code,
+ * bypassing the Supabase cache. Groq's free tier is ~45 classify calls/day
+ * (200k tokens ÷ ~4.4k per call); a catalog crawl exhausts it before breakfast
+ * (2026-06-12: both Groq pools + Cloudflare's neurons were drained, so /ask
+ * 503'd in every state). Empty studentSummary = the UI renders no card.
+ */
+export function bareCourseCodeShortcut(query: string): ClassifiedIntent | null {
+  const m = query.trim().match(BARE_COURSE_CODE);
+  if (!m) return null;
+  return {
+    intent: {
+      type: "course",
+      keyword: null,
+      filters: { course: { prefix: m[1].toUpperCase(), number: m[2].toUpperCase() } },
+    },
+    secondaryIntent: null,
+    confidence: 1,
+    reasoning: "bare course code — regex shortcut, no LLM call",
+    studentSummary: "",
+    clarifyingQuestion: null,
+    sourceCollege: null,
+    suggestedFollowups: [],
   };
 }
 
@@ -160,6 +225,9 @@ export function classifierWith(opts: ClassifierWithOptions = {}): Classifier {
   const modelVersion = opts.modelVersion ?? provider?.modelVersion ?? CLASSIFIER_MODEL;
 
   return async (query: string, state: string): Promise<ClassifiedIntent> => {
+    // Cheapest first: bare course codes never need the LLM or the cache.
+    const shortcut = bareCourseCodeShortcut(query);
+    if (shortcut) return shortcut;
     const cached = await cache.get(query, state, modelVersion);
     if (cached) return cached;
     const fresh = await llm(query, state);


### PR DESCRIPTION
## What changes for someone using the site

**Asking a question now works in every state, not just Virginia** — and when it can't, the site says so. Typing "Does intro psychology transfer to UNC Charlotte?" on /nc/courses was silently falling back to keyword soup; the same question on /va/courses showed a 💭 answer card. The card was never state-gated: the classifier service was down for **all** states (free-tier LLM quota exhausted), and VA only looked alive because its common questions were already in the classification cache. With this PR, when the classifier is unavailable the search page shows a small amber note — "We couldn't interpret your question right now, so these are plain keyword matches" — instead of pretending nothing happened, and the quota burn that caused the outage is largely eliminated (see below).

**The homepage's four feature cards now follow the state you picked in the hero.** Switch the chip to North Carolina and "Check what transfers" points at /nc/transfer, the planner at /nc/schedule, etc. — previously they were pinned to your geo-IP state even after you switched. The typed query survives the switch (it already did — verified) and search lands on /nc/courses?q=….

## Root cause (diagnosed live on prod)

`curl https://communitycollegepath.com/api/nc/ask?q=…` → HTTP 503: Cloudflare Workers AI "daily free allocation of 10,000 neurons" exhausted. Same for VA. Digging further with the new aggregated error, all three chain providers were down at once:

- `groq:openai/gpt-oss-120b` — 429, tokens-per-day limit 200,000, used 196,966
- `groq:openai/gpt-oss-20b` — 429, same 200k TPD pool exhausted
- `cf:llama-3.3-70b` — daily neurons exhausted

Each classify call costs ~4.4k tokens, so the free tier is **~45 questions/day per Groq model**. The main burn: every crawled `/{state}/courses?q=ENG+111` deep link fires a distinct, uncacheable classify call.

## Technical changes

| Area | Change |
|---|---|
| `lib/search-intent/classify.ts` | `chainAll()` now collects **every** provider's error into the thrown message (labelled by modelVersion). Before, only the last fallback's error survived — a dead Groq key surfaced as "Cloudflare neurons exhausted". |
| `lib/search-intent/classify.ts` | `bareCourseCodeShortcut()`: queries shaped like a bare course code ("ENG 111", "bio-256", "MATH 151A") skip the LLM *and* the cache. The classifier's output for these is a no-card course intent that the keyword search already parses natively, so the call bought nothing. Kills the crawler quota burn. State-agnostic, registry untouched. |
| `app/api/[state]/ask/route.ts` | 503s now log a structured `ask.classifier_failed` JSON event (state, query length, full aggregated cause) and return `code: "classifier_unavailable"`. |
| `app/[state]/courses/CourseSearchClient.tsx` | New `askUnavailable` state: /ask 5xx or network failure renders the amber note instead of silently dropping the card. Wired into both call sites (interactive search + ?q= deep links). |
| `components/HomeFeatureCards.tsx` (new) | The four "what you can do" cards, extracted from `app/page.tsx` into a client component. Destination priority: stored manual choice > geo-IP > `/colleges`. |
| `components/state-selection.ts` (new) | Shared localStorage key + custom event so the hero chip and the cards stay in sync without prop drilling. `CourseSearchHero` now writes through it. |

**Prod env fixed separately on Vercel (prod + preview), takes effect with this deploy:** `CLASSIFIER_PROVIDER=groq`, `CLASSIFIER_FALLBACK=groq:openai/gpt-oss-20b,cloudflare`, fresh verified `GROQ_API_KEY`. The old values were unreadable (sensitive), so whether they drifted is unknowable — they're now known-good.

## Known gap — capacity is a billing decision

Even with three quota pools chained (~90-100 LLM questions/day + Cloudflare overflow), heavy traffic can still exhaust the free tiers; the graceful note + structured logs make that visible now instead of silent. The real fix is a paid tier (Groq Dev Tier is the cheapest jump). Until then the bare-code bypass should keep organic load well inside the free budget.

## Test plan

- [x] 18 chain/route tests + 5 new shortcut tests + full search-intent suite: 201 passed
- [x] `tsc --noEmit` clean, `npm run lint` 0 errors, `npm run build` exit 0
- [x] Dev: `/api/{va,nc}/ask?q=ENG 111` → 200 in ~11 ms, no LLM call
- [x] Dev: NC natural-language repro → amber note renders above keyword results (screenshot in session)
- [x] Data path: `lookupAnswers` with transfer intents returns real answers in **nc (PSY 150→UNCC: yes)**, in (PSYC 101→Purdue: yes), tx (no-credit verdict), va
- [x] Playwright: type query → switch chip to NC → query preserved, all 4 cards retarget to /nc/*, search lands on /nc/courses?q=…, choice persists across reload
- [ ] Post-merge prod: NC question renders an answer card once quota frees (Cloudflare resets 00:00 UTC; Groq rolls over ~24 h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)