### PR TITLE
seo: college pages — value-first reframe (drop legacy audit framing from metadata + hero)

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -58,19 +58,20 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
   return {
-    title: `${institution.name} — Courses & Transfer Info | Community College Path ${requireStateConfig(state).name}`,
-    description: `Find out how to audit courses at ${institution.name}. ${
-      institution.audit_policy.allowed
-        ? "Auditing is available."
-        : "Contact the college to confirm audit policies."
-    }`,
+    title: `${institution.name} — Courses, Programs & Transfer Info | Community College Path ${requireStateConfig(state).name}`,
+    // Value-first description. The old copy led with "Find out how to audit
+    // courses at X" — legacy AuditMap framing that buried the page's real value
+    // and signalled niche "audit" intent to search engines instead of the
+    // high-volume "courses / programs / transfer at {college}" queries students
+    // actually run. The page already surfaces all of this; only the lead changed.
+    description: `${institution.name}: browse course schedules and sections, compare programs, and check transfer-credit equivalencies — with tuition, graduation rates, and median graduate earnings. Free on Community College Path.`,
     alternates: { canonical: `/${state}/college/${id}` },
     openGraph: {
       images: [{
         url: `${baseUrl}/${state}/college/${id}/opengraph-image`,
         width: 1200,
         height: 630,
-        alt: `${institution.name} — courses, audit policy, and transfer info on Community College Path`,
+        alt: `${institution.name} — courses, programs, transfer info, and graduate outcomes on Community College Path`,
       }],
     },
   };
@@ -257,15 +258,8 @@ export default async function CollegeDetailPage(props: PageProps) {
     ],
   };
 
-  // Derive audit cost stat for hero card
+  // Senior-audit discount still drives the hero badge below.
   const sd = institution.audit_policy.eligibility.senior_discount;
-  const auditCostStat = sd.available
-    ? `Free ${sd.age_threshold ?? 60}+`
-    : institution.audit_policy.allowed === false
-    ? "N/A"
-    : institution.audit_policy.cost_note
-    ? institution.audit_policy.cost_note.slice(0, 14)
-    : "—";
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
@@ -355,7 +349,7 @@ export default async function CollegeDetailPage(props: PageProps) {
               { label: "Students", value: scorecard?.size ? scorecard.size.toLocaleString() : "—" },
               { label: "In-state/yr", value: scorecard?.cost?.tuitionInState != null ? formatDollar(scorecard.cost.tuitionInState) : "—" },
               { label: "Completion", value: scorecard?.completion?.completionRate150nt != null ? formatPercent(scorecard.completion.completionRate150nt) : "—" },
-              { label: "Audit cost", value: auditCostStat },
+              { label: "Grad earnings", value: scorecard?.earnings?.median10YrsAfterEntry != null ? formatDollar(scorecard.earnings.median10YrsAfterEntry) : "—" },
             ].map(({ label, value }) => (
               <div key={label} className="bg-white dark:bg-slate-800 px-3 py-4">
                 <p className="text-[10px] font-mono font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500">{label}</p>


### PR DESCRIPTION
## What changes for someone using the site

When a student searches Google for **"Northern Virginia Community College courses"** (or programs, or transfer credit), the result we show them now reads:

> **Northern Virginia Community College — Courses, Programs & Transfer Info**
> *Northern Virginia Community College: browse course schedules and sections, compare programs, and check transfer-credit equivalencies — with tuition, graduation rates, and median graduate earnings.*

Before, that same result read *"Find out how to **audit** courses at Northern Virginia Community College. Auditing is available."* — i.e. it advertised the niche use case of sitting in on a class, not the thing students actually came for. On the page itself, the 4th hero stat tile flips from **"Audit cost"** to **"Grad earnings"** (e.g. **$53,557** for NOVA, from the federal College Scorecard). The audit policy hasn't gone anywhere — it still has its own badge and its own dedicated section lower on the page.

## Why this matters (the SEO story)

This is the highest-confidence lever for recovering the May 2026 search-traffic drop. Decomposing Google Search Console by page template, **college-detail pages are 37% of the site's pre-collapse impressions**, and they were demoted from **average position 9.6 → 18.7** by the May 2026 Google core update. Crucially, all ~2,530 of those URLs are *still indexed and still getting impressions* — so this is a pure quality/relevance demotion, not a serving loss, and it's recoverable without scraping any new data.

The template's problem was that it led — in the `<title>`, the meta description, the OpenGraph alt text, and a hero stat tile — with legacy **"AuditMap"** framing. Auditing is a niche feature; leading with it (a) tells Google to rank the page for low-volume "audit" intent instead of the high-volume "courses / programs / transfer at {college}" queries, (b) buries the page's real value in the snippet (hurting click-through even when we do rank), and (c) is off-brand — CLAUDE.md explicitly mandates "Community College Path, not AuditMap." All the valuable content was already on the page; only the *lead* changed.

## What changed technically

One file: `app/[state]/college/[id]/page.tsx`.

| element | before | after |
|---|---|---|
| `<title>` | `… Courses & Transfer Info` | `… Courses, Programs & Transfer Info` |
| meta description | `Find out how to audit courses at X. Auditing is available.` | value-first (courses · programs · transfer · tuition · grad rates · earnings) |
| OG image alt | `… courses, audit policy, and transfer info` | `… courses, programs, transfer info, and graduate outcomes` |
| hero stat tile #4 | `Audit cost` (`auditCostStat`) | `Grad earnings` (`scorecard.earnings.median10YrsAfterEntry`, `formatDollar`) |

The unused `auditCostStat` derivation was removed; the `sd` (senior-discount) binding it shared is kept because the hero badge still uses it.

## Test plan

- `npm run typecheck` ✓ · `eslint` on the file (exit 0) ✓
- Verified on the **worktree** dev server (`/va/college/nova`): new value-first `<title>` + meta render in `<head>`; hero tiles are Students · In-state/yr · Completion · **Grad earnings $53,557**; **"Audit cost" absent**. (Layout markup unchanged — same `grid-cols-4` tile structure — so only copy + one tile's data source differ.)
- Post-merge: the meta/title change is an SEO signal that takes Google days–weeks to re-crawl and re-rank; the on-page tile is visible immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
