### PR TITLE
fix: planner save stuck on Saving with no error feedback

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
+++ b/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
@@ -36,7 +36,10 @@ const PILL_BASE =
 export default function PlanClient({ plan, transferHref }: Props) {
   const [uni, setUni] = useState<string>(plan.universities[0]?.slug ?? "__all__");
   const [view, setView] = useState<"requirements" | "sequence">("requirements");
-  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [saveStatus, setSaveStatus] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
   const { user, openLoginModal } = useAuth();
 
   const allCourses = useMemo(
@@ -169,30 +172,48 @@ export default function PlanClient({ plan, transferHref }: Props) {
           type="button"
           onClick={async () => {
             if (!user) { openLoginModal(); return; }
-            if (saveStatus !== "idle") return;
+            if (saveStatus !== "idle" && saveStatus !== "error") return;
             setSaveStatus("saving");
+            setSaveError(null);
             try {
               const supabase = createClient();
               const targetCourses = plan.groups
                 .flatMap((g) => g.courses)
                 .map((c) => c.code);
-              await supabase.from("saved_plans").insert({
+              const insertPromise = supabase.from("saved_plans").insert({
                 user_id: user.id,
                 state: plan.state,
                 name: `${plan.program.title} — ${plan.collegeName}`,
                 target_courses: targetCourses,
                 plan_data: { groups: plan.groups },
               });
+              const timeoutPromise = new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error("Save timed out")), 10_000),
+              );
+              const { error } = await Promise.race([insertPromise, timeoutPromise]);
+              if (error) throw error;
               setSaveStatus("saved");
               setTimeout(() => setSaveStatus("idle"), 3000);
-            } catch {
-              setSaveStatus("idle");
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              const isAuth = /jwt|auth|token|permission|row-level/i.test(msg);
+              console.error("Plan save failed:", msg);
+              setSaveError(
+                isAuth
+                  ? "Your session expired — please sign in again."
+                  : "Couldn't save your plan. Please try again.",
+              );
+              setSaveStatus("error");
+              if (isAuth) openLoginModal();
             }
           }}
+          disabled={saveStatus === "saving" || saveStatus === "saved"}
           className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
             saveStatus === "saved"
               ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-              : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
+              : saveStatus === "error"
+                ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
+                : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
           }`}
         >
           {saveStatus === "saved" ? (
@@ -202,15 +223,29 @@ export default function PlanClient({ plan, transferHref }: Props) {
               </svg>
               Saved
             </>
+          ) : saveStatus === "saving" ? (
+            "Saving…"
+          ) : saveStatus === "error" ? (
+            <>
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+              </svg>
+              Try again
+            </>
           ) : (
             <>
               <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
               </svg>
-              {user ? (saveStatus === "saving" ? "Saving…" : "Save this plan") : "Sign in to save"}
+              {user ? "Save this plan" : "Sign in to save"}
             </>
           )}
         </button>
+        {saveError && (
+          <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+            {saveError}
+          </p>
+        )}
       </div>
 
       {view === "sequence" && plan.sequence ? (

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -510,9 +510,10 @@ export default function SemesterPlanner({
   // Save-plan state — mirrors ScheduleResults exactly: idle → saving → saved,
   // reverts after 3s. Auth gating via openLoginModal() if not signed in.
   const { user, openLoginModal } = useAuth();
-  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
-    "idle",
-  );
+  const [saveStatus, setSaveStatus] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Seat-availability data for every course in the current plan. Fetched
   // from /api/{state}/sections-for-courses whenever the set of course codes
@@ -749,21 +750,24 @@ export default function SemesterPlanner({
                   return;
                 }
                 setSaveStatus("saving");
+                setSaveError(null);
                 try {
                   const supabase = createClient();
-                  // Default name = comma-joined target codes, or fall back to
-                  // initialName when this is a "Duplicate to edit" flow.
                   const fallback = targets.length > 0
                     ? targets.join(", ")
                     : "My Plan";
                   const name = initialName?.trim() || fallback;
-                  const { error } = await supabase.from("saved_plans").insert({
+                  const insertPromise = supabase.from("saved_plans").insert({
                     user_id: user.id,
                     state,
                     name,
                     target_courses: targets,
                     plan_data: { semesters },
                   });
+                  const timeoutPromise = new Promise<never>((_, reject) =>
+                    setTimeout(() => reject(new Error("Save timed out")), 10_000),
+                  );
+                  const { error } = await Promise.race([insertPromise, timeoutPromise]);
                   if (error) throw error;
                   setSaveStatus("saved");
                   track("plan_save", {
@@ -773,15 +777,26 @@ export default function SemesterPlanner({
                     semesters: totalSemesters,
                   });
                   setTimeout(() => setSaveStatus("idle"), 3000);
-                } catch {
-                  setSaveStatus("idle");
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : String(err);
+                  const isAuth = /jwt|auth|token|permission|row-level/i.test(msg);
+                  console.error("Plan save failed:", msg);
+                  setSaveError(
+                    isAuth
+                      ? "Your session expired — please sign in again."
+                      : "Couldn't save your plan. Please try again.",
+                  );
+                  setSaveStatus("error");
+                  if (isAuth) openLoginModal();
                 }
               }}
               disabled={saveStatus === "saving" || saveStatus === "saved"}
               className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
                 saveStatus === "saved"
                   ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
-                  : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
+                  : saveStatus === "error"
+                    ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
+                    : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700"
               }`}
             >
               {saveStatus === "saved" ? (
@@ -793,6 +808,13 @@ export default function SemesterPlanner({
                 </>
               ) : saveStatus === "saving" ? (
                 "Saving..."
+              ) : saveStatus === "error" ? (
+                <>
+                  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+                  </svg>
+                  Try again
+                </>
               ) : (
                 <>
                   <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
@@ -802,6 +824,11 @@ export default function SemesterPlanner({
                 </>
               )}
             </button>
+            {saveError && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                {saveError}
+              </p>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## What changes for someone using the site

The "Save plan" button on the semester planner and program plan pages was broken — clicking it showed "Saving..." indefinitely with no feedback, or silently failed and reset to "Save plan" with no error message. The `saved_plans` table has zero rows, confirming saves have never worked in production.

Now: if the save fails (expired session, network timeout, database error), users see a red "Try again" button with a specific message — either "Your session expired — please sign in again" (which auto-opens the login modal) or "Couldn't save your plan. Please try again." The save also has a 10-second timeout so it never hangs forever.

## Technical changes

**Root causes fixed:**
- `SemesterPlanner.tsx` caught errors silently (`catch { setSaveStatus("idle") }`) — no feedback, no console log
- `PlanClient.tsx` never even destructured `{ error }` from the Supabase insert — it always showed "Saved" even when the insert failed
- Neither handler had a timeout, so a hanging Supabase client (e.g. during token refresh with an expired session) meant "Saving..." forever

**Both handlers now:**
- Race the insert against a 10s `Promise` timeout
- Add `"error"` to the `saveStatus` union type
- Show red error state button ("Try again") + inline error text
- Detect auth-related errors via regex and prompt re-login
- Log to `console.error` for debugging

| File | Change |
|---|---|
| `components/SemesterPlanner.tsx` | +error state, +timeout, +error display, +auth detection |
| `app/[state]/college/[id]/program/[slug]/PlanClient.tsx` | Same + fix missing `{ error }` destructuring from insert |

## Test plan

- [ ] Sign in on prod, go to `/ks/plan`, add MATH 0120, click Save — should succeed or show clear error
- [ ] Open browser console — on failure, should see `Plan save failed: <reason>`
- [ ] With expired session: should see "Your session expired" + login modal
- [ ] Save on a program plan page (e.g. any `/college/.../program/...` route) — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)