### PR TITLE
bootstrap-state: stop seeding example.edu in new-state configs; flag empty URLs in url-health check

### DIFF
--- a/scripts/lib/bootstrap-state.ts
+++ b/scripts/lib/bootstrap-state.ts
@@ -278,11 +278,18 @@ ${seniorWaiverBlock}
   defaultZip: ${JSON.stringify(defaultZip)},
   defaultZipCity: ${JSON.stringify(defaultZipCity)},
 
+  // TODO: replace with a per-college class-search lookup (see lib/states/tx/config.ts
+  // for the REGISTRATION_URLS + COLLEGE_HOMEPAGES + collegeUrl() helper template).
+  // The empty-string default is intentional — \`example.edu\` is a reserved
+  // non-existent domain, so seeding it sent every course row to a dead link
+  // until the human curator noticed (PR #1481). check-config-urls.ts flags
+  // empty/non-URL returns so the rolling URL-health issue catches this before
+  // a state ships data.
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    ${JSON.stringify(systemUrl || "https://www.example.edu/")},
+    ${JSON.stringify(systemUrl)},
 
   collegeCoursesUrl: (_collegeSlug: string) =>
-    ${JSON.stringify(systemUrl || "https://www.example.edu/")},
+    ${JSON.stringify(systemUrl)},
 
   branding: {
     siteName: ${JSON.stringify(`Community College Path ${fullName}`)},

--- a/scripts/lib/check-config-urls.ts
+++ b/scripts/lib/check-config-urls.ts
@@ -84,13 +84,24 @@ function collectUrlsToCheck(): Array<{ state: string; field: string; url: string
     }
     // Sample courseDiscoveryUrl / collegeCoursesUrl with one college's data.
     // We aren't trying to validate every college — just that the URL-shape
-    // generator still produces a URL the source site recognizes.
+    // generator still produces a URL the source site recognizes. Empty
+    // strings and non-http(s) returns are pushed under a synthetic
+    // BOOTSTRAP_STUB_URL so probe() surfaces them as bootstrap leftovers —
+    // auto-add-state seeds the helpers with "" when no per-college lookup
+    // exists yet, and that needs to fail the URL-health check before the
+    // state ships data (not be silently skipped).
     const sample = pickSampleCollege(cfg.slug);
     if (sample && sample.slug) {
       try {
         const url = cfg.courseDiscoveryUrl(sample.slug, "ENG", "101");
         if (url && /^https?:\/\//i.test(url)) {
           out.push({ state: cfg.slug, field: "courseDiscoveryUrl(sample)", url });
+        } else {
+          out.push({
+            state: cfg.slug,
+            field: "courseDiscoveryUrl(sample)",
+            url: BOOTSTRAP_STUB_URL,
+          });
         }
       } catch {
         // Some states throw if the slug isn't recognized — skip.
@@ -99,6 +110,12 @@ function collectUrlsToCheck(): Array<{ state: string; field: string; url: string
         const url = cfg.collegeCoursesUrl(sample.slug);
         if (url && /^https?:\/\//i.test(url)) {
           out.push({ state: cfg.slug, field: "collegeCoursesUrl(sample)", url });
+        } else {
+          out.push({
+            state: cfg.slug,
+            field: "collegeCoursesUrl(sample)",
+            url: BOOTSTRAP_STUB_URL,
+          });
         }
       } catch {
         // Same — skip if slug not recognized.
@@ -115,10 +132,15 @@ function collectUrlsToCheck(): Array<{ state: string; field: string; url: string
 // Placeholder URLs left over from auto-add-state bootstrap that weren't
 // curated. example.edu / example.com both legitimately resolve (returning
 // 200), so probe() can't detect these — we filter them out separately and
-// mark them as failed regardless of HTTP status.
+// mark them as failed regardless of HTTP status. BOOTSTRAP_STUB_URL is a
+// synthetic sentinel collectUrlsToCheck() emits when a state's
+// courseDiscoveryUrl/collegeCoursesUrl returns "" or a non-http(s) value
+// (the new bootstrap default — see scripts/lib/bootstrap-state.ts).
 const PLACEHOLDER_HOSTS = ["example.edu", "example.com", "example.org"];
+const BOOTSTRAP_STUB_URL = "https://bootstrap-stub.invalid/";
 
 function isPlaceholder(url: string): boolean {
+  if (url === BOOTSTRAP_STUB_URL) return true;
   try {
     const host = new URL(url).hostname.toLowerCase();
     return PLACEHOLDER_HOSTS.some((p) => host === p || host.endsWith("." + p));
@@ -129,7 +151,11 @@ function isPlaceholder(url: string): boolean {
 
 async function probe(url: string): Promise<{ status: number | null; ok: boolean; error?: string }> {
   if (isPlaceholder(url)) {
-    return { status: null, ok: false, error: "placeholder URL (auto-add-state bootstrap leftover)" };
+    const why =
+      url === BOOTSTRAP_STUB_URL
+        ? "empty / non-http(s) URL (auto-add-state bootstrap leftover — wire courseDiscoveryUrl/collegeCoursesUrl to a real per-college lookup)"
+        : "placeholder URL (auto-add-state bootstrap leftover)";
+    return { status: null, ok: false, error: why };
   }
   const controller = new AbortController();
   const t = setTimeout(() => controller.abort(), timeoutMs);


### PR DESCRIPTION
## What changes for someone using the site

Users see nothing new on the live site today. This is a process / safety fix that prevents the next-bootstrapped state from shipping with the same dead-link bug PR #1481 just cleaned up across AR/AZ/KS/MT/NM/SD.

## What changes on the technical front

Two small edits, both in `scripts/lib/`:

1. **`bootstrap-state.ts`**: the template emitter now writes `courseDiscoveryUrl: (...) => "",` and `collegeCoursesUrl: (...) => "",` for a brand-new state — not `"https://www.example.edu/"`. A TODO comment above both points the human curator at `lib/states/tx/config.ts` as the canonical per-college lookup template (REGISTRATION_URLS + COLLEGE_HOMEPAGES + collegeUrl() helper). Empty string is fine for an unshipped state — no real users hit it yet — and is the same shape `az` and the five other states had until PR #1481 wired in real lookups.

2. **`check-config-urls.ts`**: extends the rolling URL-health check to flag empty / non-http(s) returns from those helpers via a synthetic `BOOTSTRAP_STUB_URL = "https://bootstrap-stub.invalid/"` sentinel. Previously the collector did `if (url && /^https?:\/\//) push` — silently skipping empty returns. Now empty returns get pushed under the sentinel, `isPlaceholder()` recognizes it, and `probe()` reports `"empty / non-http(s) URL (auto-add-state bootstrap leftover — wire courseDiscoveryUrl/collegeCoursesUrl to a real per-college lookup)"`. The cron-driven URL-health rolling issue picks this up.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run check:registry` + `check:scrapers` pass
- [x] Rendered bootstrap output for a fake slug `zz` — confirmed the two helpers emit `""`, not `example.edu`
- [x] Ran `check-config-urls.ts` against the live 51-state registry → **0** `bootstrap-stub.invalid` flags. The new flagging path is dormant for all existing states (none currently emit empty after #1481) and only fires for unfinished fresh bootstraps — no false alarms.

## Related

- Builds on PR #1481 (replaced `example.edu` with real per-college URLs across AR/AZ/KS/MT/NM/SD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)