### PR TITLE
seo: fix sitemap lastModified + tighten crawl budget for recovery

### DIFF
--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -79,6 +79,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const description = `Browse ${filtered.length} ${subject} sections (${uniqueCourses} courses) at ${institution.name} for ${termLabel(resolvedTerm)}.${onlineCount > 0 ? ` ${onlineCount} available online.` : ""} View schedules, instructors, and prerequisites.`;
 
   const canonical = `/${state}/college/${id}/courses/${rawPrefix}`;
+  const isThin = filtered.length < 5;
   return {
     title,
     description,
@@ -90,6 +91,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       ...config.branding.metaKeywords,
     ],
     alternates: { canonical },
+    ...(isThin && { robots: { index: false, follow: true } }),
     openGraph: {
       title,
       description,

--- a/app/sitemap/college-subjects.xml/route.ts
+++ b/app/sitemap/college-subjects.xml/route.ts
@@ -1,6 +1,7 @@
 import { getAllStates } from "@/lib/states/registry";
 import { loadInstitutions } from "@/lib/institutions";
 import { getCurrentTerm } from "@/lib/terms";
+import { getCollegeLastUpdated } from "@/lib/data-freshness";
 import {
   toSitemapXml,
   siteOrigin,
@@ -23,7 +24,7 @@ import snapshotJson from "@/data/sitemap-college-subjects.json";
 const SUBJECT_SNAPSHOT: Record<string, Array<{ prefix: string; count: number }>> =
   (snapshotJson as unknown as Record<string, Array<{ prefix: string; count: number }>>) ?? {};
 
-const MIN_SECTIONS_FOR_INDEXED_URL = 3;
+const MIN_SECTIONS_FOR_INDEXED_URL = 5;
 
 export const dynamic = "force-dynamic";
 
@@ -53,7 +54,8 @@ export async function GET() {
           url: `${url}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
           changeFrequency: "weekly",
           priority: 0.5,
-          lastModified: new Date(),
+          lastModified:
+            getCollegeLastUpdated(state.slug, inst.college_slug) ?? undefined,
         });
       }
     }

--- a/app/sitemap/core.xml/route.ts
+++ b/app/sitemap/core.xml/route.ts
@@ -1,6 +1,10 @@
 import { getAllStates } from "@/lib/states/registry";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
 import {
+  getCourseLastUpdated,
+  getTransferLastUpdated,
+} from "@/lib/data-freshness";
+import {
   toSitemapXml,
   siteOrigin,
   xmlResponse,
@@ -11,29 +15,28 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const url = siteOrigin();
-  const now = new Date();
   const entries: SitemapEntry[] = [
-    { url, changeFrequency: "daily", priority: 1, lastModified: now },
-    { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
+    { url, changeFrequency: "daily", priority: 1 },
+    { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9 },
   ];
 
   const states = getAllStates();
 
   for (const state of states) {
     const s = state.slug;
+    const courseFreshness = getCourseLastUpdated(s) ?? undefined;
     entries.push(
-      { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1, lastModified: now },
-      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.85, lastModified: now },
-      { url: `${url}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
-      // /starting-soon is noindex (client-rendered tool page) — omit from sitemap
-      { url: `${url}/${s}/about`, changeFrequency: "yearly", priority: 0.5, lastModified: now }
+      { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1, lastModified: courseFreshness },
+      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.85, lastModified: courseFreshness },
+      { url: `${url}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: courseFreshness },
+      { url: `${url}/${s}/about`, changeFrequency: "yearly", priority: 0.5 }
     );
     if (state.transferSupported) {
       entries.push({
         url: `${url}/${s}/transfer`,
         changeFrequency: "weekly",
         priority: 0.9,
-        lastModified: now,
+        lastModified: getTransferLastUpdated(s) ?? undefined,
       });
     }
   }


### PR DESCRIPTION
## What changes for site visitors

Nothing visible — this is infrastructure that helps Google re-index the site faster after the May 2026 traffic collapse. The site is recovering (average position improved from ~25 to ~13 over the last 2 weeks), and these changes concentrate Google's crawl budget on pages with real content depth instead of spreading it thin across 80K URLs.

## What changes technically

Three fixes to accelerate SEO recovery:

**1. Fix `lastModified` in `core.xml` and `college-subjects.xml` sitemaps**
Both were using `new Date()` for every URL — telling Google "everything just changed" on every crawl. Google ignores lastmod when it's always set to now. Now uses real file-mtime dates via `getCourseLastUpdated()` / `getCollegeLastUpdated()` / `getTransferLastUpdated()` so Google can prioritize recently-updated pages.

**2. Raise college-subjects sitemap threshold from 3→5 sections**
Cuts ~10K thin pages from the sitemap (~31K→~20K URLs). These pages had too few sections to provide meaningful value and were diluting crawl budget during recovery. The site has 79K sitemap URLs with 0 showing as indexed in GSC — concentrating on higher-quality pages should help.

**3. Add noindex guard to thin college-subject pages**
Pages with <5 sections now get `robots: { index: false, follow: true }`, matching the existing pattern on course pages. Prevents Google from indexing thin pages even if it crawls them directly.

## GSC data context (Jun 20, 2026)
- 79,642 URLs submitted via sitemap, 0 indexed per GSC
- ~15 clicks/day, ~420 impressions/day (recovering from ~80% traffic drop)
- Average position improved from ~25 (late May) to ~13 (Jun 15-18)
- 72% of current clicks are on instructor pages (which are already noindex — legacy indexed pages fading out)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes — all sitemap routes compile
- [ ] After merge: verify `curl communitycollegepath.com/sitemap/core.xml` shows real dates, not today's date
- [ ] After merge: verify `curl communitycollegepath.com/sitemap/college-subjects.xml | grep -c '<loc>'` decreased

🤖 Generated with [Claude Code](https://claude.com/claude-code)