### PR TITLE
la/programs: add delgado + bossier (160+120); revert domcontentloaded regression

### DIFF
--- a/data/la/DEFERRED-programs.md
+++ b/data/la/DEFERRED-programs.md
@@ -1,25 +1,21 @@
 # LA programs — coverage & deferred colleges
 
 Programs are scraped for the LCTCS colleges with public, parseable catalogs.
-All four Acalog catalogs (Fletcher, SLCC, Delta, BRCC, Delgado, Bossier) sit
+All six Acalog catalogs (Fletcher, SLCC, Delta, BRCC, Delgado, Bossier) sit
 behind AWS WAF and are scraped through Playwright; a plain-fetch re-run would
 return HTTP 202 + empty and silently zero the data.
 
-Covered with data in this PR (`scripts/la/scrape-programs.ts`):
+Covered with data (`scripts/la/scrape-programs.ts`):
 
-- **Acalog (4):** fletcher (83), south-louisiana (48), louisiana-delta (145),
-  baton-rouge (60).
+- **Acalog (6):** fletcher (83), south-louisiana (48), louisiana-delta (145),
+  baton-rouge (60), bossier-parish (160), delgado (120).
 - **CourseLeaf (1):** nunez (92, `/programs/`).
 
-Wired + verified, data populates on the next scheduled run:
-
-- **delgado** (Acalog, catalog.dcc.edu, catoid 60 — 197 programs discoverable)
-  and **bossier-parish** (Acalog, catalog.bpcc.edu, catoid 19 — 160 programs
-  discoverable). Both are wired with working configs; search-discovery confirms
-  the program counts. Their detail-page scrape did not complete in the
-  disk-pressured dev environment (renderer stalls), but runs cleanly on the
-  scheduled `runner: playwright` CI job. Re-run `scripts/la/scrape-programs.ts`
-  on a clean runner to commit their data files.
+> Bossier and Delgado were the two largest WAF catalogs. Their detail-page
+> scrape only completes when `playwrightFetch` uses `waitUntil: "networkidle"`
+> (so the WAF JS-challenge solves before the HTML is read) **and** the box has
+> disk headroom — under disk pressure the headless renderer crashes mid-fetch.
+> See memory `feedback_disk_pressure_crashes_playwright`.
 
 ## Deferred (5)
 

--- a/data/la/programs/bossier-parish-community-college.json
+++ b/data/la/programs/bossier-parish-community-college.json
@@ -1,0 +1,20742 @@
+{
+  "college_slug": "bossier-parish-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.bpcc.edu",
+  "scraped_at": "2026-06-21T05:14:37.672Z",
+  "programs": [
+    {
+      "title": "Accounting Office Specialist, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4794",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 18 Credit Hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Retail Federation NRF Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "110",
+              "title": "Records and Information Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "218",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "112",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting Technology: Account Clerk, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "210",
+              "title": "Personal Income Tax",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "218",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "108",
+              "title": "Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: BOOKKEEPING",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Acting, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4731",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "153",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "154",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "156",
+              "title": "Voice for the Stage",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Assistant, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4795",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 18 Credit Hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Retail Federation NRF Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "110",
+              "title": "Records and Information Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "112",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "144",
+              "title": "Advanced MS Word",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Emergency Medical Technician, CTC (Bossier, Natchitoches, and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4799",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "150",
+              "title": "Advanced EMT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "151",
+              "title": "Advanced EMT Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NREMT Emergency Medical Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing and Mechatronics, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4697",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: CERTIFIED PRODUCTION TECHNOLOGY",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMFG",
+              "number": "110",
+              "title": "Manufacturing Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "143",
+              "title": "Introductory Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "260",
+              "title": "Mechatronics Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISAF",
+              "number": "210",
+              "title": "Industrial Safety and OSHA Standards",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Welding Technology, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "201",
+              "title": "Welding Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "203",
+              "title": "Advanced Shield Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "207",
+              "title": "Adv Flx Cor &amp; Gas Met Arc Wel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "205",
+              "title": "Advanced Gas Tungsten Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "209",
+              "title": "Adv Pipe Welding &amp; Fitting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "110",
+              "title": "Manufacturing Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "101",
+              "title": "Introduction to the Exploration and Production of Oil and Gas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "151",
+              "title": "Power Transmission Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Helper I, CTC (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4760",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "115",
+              "title": "HACR Safety, Health &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "116",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "117",
+              "title": "Principles of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "118",
+              "title": "Principles of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Helper II, CTS (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4761",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "115",
+              "title": "HACR Safety, Health &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "116",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "117",
+              "title": "Principles of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "118",
+              "title": "Principles of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "121",
+              "title": "HACR Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "122",
+              "title": "HACR Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "123",
+              "title": "HACR Electric Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "124",
+              "title": "Applied Electricity &amp; Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Technician, TD (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4751",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "115",
+              "title": "HACR Safety, Health &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "116",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "117",
+              "title": "Principles of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "118",
+              "title": "Principles of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: A/C AND REFRIGERATION HELPER I *IBC: EPA section 608 type 1, 2, 3 or Universal (HVAC Excellence)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "121",
+              "title": "HACR Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "122",
+              "title": "HACR Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "123",
+              "title": "HACR Electric Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "124",
+              "title": "Applied Electricity &amp; Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE of TECHNICAL STUDIES: A/C AND REFRIGERATION HELPER II *IBC: Electrical- Employment Ready (HACR 124) 47020131",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "141",
+              "title": "Domestic Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "142",
+              "title": "Room Air Conditioners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "256",
+              "title": "Residential Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: DOMESTIC AIR CONDITIONING AND REFIRGERATION *IBC: Heat Pumps - Employment Ready",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "251",
+              "title": "Residential Central Air Conditioning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "252",
+              "title": "Residential Central Air Conditioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "253",
+              "title": "Residential System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "254",
+              "title": "Residential Heating I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "255",
+              "title": "Residential Heating II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Electric Heat - Employment Ready* *IBC: Gas Heat - Employment Ready**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ARC Welder FCAW, CTS (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4776",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "112",
+              "title": "FCAW Bsc FILT Wld/Bsc Groove W",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "124",
+              "title": "FCAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ARC Welder GMAW, CTS (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4775",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "116",
+              "title": "GMAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "122",
+              "title": "GMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ARC Welder GTAW, CTS (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4774",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "114",
+              "title": "GTAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "120",
+              "title": "GTAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ARC Welder SMAW, CTS (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4777",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "108",
+              "title": "SMAW V-Groove BU/Gouge",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "110",
+              "title": "SMAW V-Groove Open",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "SMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Audio Technology, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4720",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "225",
+              "title": "Audio Production in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "107",
+              "title": "Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "111",
+              "title": "Engineering for Comm Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "290",
+              "title": "Pro Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Management, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4635",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "212",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "213",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "215",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "217",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Bookkeeping, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4636",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "210",
+              "title": "Personal Income Tax",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "218",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4628",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "108",
+              "title": "Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy/MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "212",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3***",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3***",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "215",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3***",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Applications, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4792",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "144",
+              "title": "Advanced MS Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Associate, CTC",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4787",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Retail Federation NRF Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "108",
+              "title": "Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Course Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Entrepreneurship, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4609",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "214",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "216",
+              "title": "Small Business Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "208",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "215",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "250",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Office Technology, Accounting Concentration, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4767",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "110",
+              "title": "Records and Information Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "218",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "112",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Office Technology- General Office Concentration, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4768",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "110",
+              "title": "Records and Information Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "144",
+              "title": "Advanced MS Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "112",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "115",
+              "title": "Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Certified Nurse Assistant",
+      "credential": "other",
+      "program_code": "CNA",
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4743",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Certified Production Technician, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4708",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Professional Medical Coder",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4745",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cisco Certified Network Associate, CTC",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4709",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 4 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "255",
+              "title": "CCNA I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 8 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "256",
+              "title": "CCNA II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "257",
+              "title": "CCNA III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4756",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+ or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "255",
+              "title": "CCNA I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "263",
+              "title": "Cloud+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "264",
+              "title": "Advanced Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Vehicle Operation",
+      "credential": "other",
+      "program_code": "CVO",
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4741",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Media, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4647",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved COMM Course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved COMM Course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved COMM Course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved COMM Course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Media, Graphic Design/Computer Animation Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "120",
+              "title": "Digital Media Survey",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Digital Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "248",
+              "title": "Visual Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Fundamentals of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "236",
+              "title": "3D Modeling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "219",
+              "title": "Applied Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "251",
+              "title": "3D Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Compositing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "239",
+              "title": "Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "150",
+              "title": "Video Production Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "223",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "246",
+              "title": "Introduction to 2D Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communications Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Communication Media, Mass Communication Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4606",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "120",
+              "title": "Digital Media Survey",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "150",
+              "title": "Video Production Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "212",
+              "title": "Announcing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "213",
+              "title": "Voice and Diction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Live Video Productions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "130",
+              "title": "Film Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Scriptwriting for Film and Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "256",
+              "title": "Multimedia Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Science Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3***",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "281",
+              "title": "Documentary Filmmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Media, Multimedia Concentration (Non-Prescriptive), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4641",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "120",
+              "title": "Digital Media Survey",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Digital Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours:3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Media, Photography Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4640",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "120",
+              "title": "Digital Media Survey",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Digital Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Compositing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "267",
+              "title": "Photography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "163",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "171",
+              "title": "The Business of Visual Artistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "270",
+              "title": "Commercial Photography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Media, Sound and Music Recording Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4638",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "120",
+              "title": "Digital Media Survey",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Digital Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "111",
+              "title": "Engineering for Comm Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "225",
+              "title": "Audio Production in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective​ Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "107",
+              "title": "Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "105",
+              "title": "Survey of Music Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "108",
+              "title": "Marketing of Recorded Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "290",
+              "title": "Pro Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "294",
+              "title": "Studio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Animation, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4721",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "236",
+              "title": "3D Modeling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "239",
+              "title": "Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "246",
+              "title": "Introduction to 2D Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "251",
+              "title": "3D Animation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4687",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "108",
+              "title": "Introduction to Management Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA A+ Core 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA A+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "118",
+              "title": "Help Desk Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: COMPUTER REPAIR ♦ CAREER AND TECHNICAL CERTIFICATE: HELP DESK",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "274",
+              "title": "Data Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Data+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "282",
+              "title": "Information Technology Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Project +",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective - Level 200 Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "290",
+              "title": "System Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Approved Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Repair, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4711",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Corrections, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4624",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "211",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "172",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "274",
+              "title": "Local Adult Detention Facilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "271",
+              "title": "Correctional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "296",
+              "title": "Introduction to Jurisprudence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "276",
+              "title": "Probation, Parole, and Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "232",
+              "title": "Police Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "278",
+              "title": "Management of Correctional Facilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Cosmetology, TD (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4754",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "111",
+              "title": "Intro to Decontam &amp; Infection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "112",
+              "title": "Properties-Skin, Scalp, Hair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "113",
+              "title": "Shampoo, Rinse, &amp; Condition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: SHAMPOO ASSISTANT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "121",
+              "title": "Cells, Anatomy. &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "123",
+              "title": "Wet Hair Styling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "122",
+              "title": "Manicuring and Pedicuring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "141",
+              "title": "CHemical Hair Relaxing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "142",
+              "title": "Thermal Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "143",
+              "title": "Hair Coloring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "131",
+              "title": "Hair Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "251",
+              "title": "Facial, Massage, Makeup",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "252",
+              "title": "Artistry of Artificial Hair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "253",
+              "title": "Electricity and Light Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "254",
+              "title": "Salon Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "132",
+              "title": "Permanent Waving",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Costume Design, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4730",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "120",
+              "title": "Makeup for Stage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "220",
+              "title": "Costume Construction Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "221",
+              "title": "Costume Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice Investigation, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "202",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "204",
+              "title": "Accident Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "240",
+              "title": "Narcotics and Dangerous Drugs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "294",
+              "title": "Medicolegal Death Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "290",
+              "title": "Homeland Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "295",
+              "title": "Criminalistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "250",
+              "title": "Police Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4610",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Louisiana POST Council Credits Applied to Criminal Justice Degree",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "202",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "250",
+              "title": "Police Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "292",
+              "title": "Police-Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Psychology Elective (except PSYC 210) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Sociology Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice, Medicolegal Death Investigation Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Louisiana POST Council Credits Applied to Criminal Justice Degree",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "202",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "250",
+              "title": "Police Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "292",
+              "title": "Police-Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Loss and Death",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Sociology Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "202",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "295",
+              "title": "Criminalistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "105",
+              "title": "Medical Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦TECHNICAL DIPLOMA: MEDICOLEGAL DEATH INVESTIGATION (MDI)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "204",
+              "title": "Accident Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "294",
+              "title": "Medicolegal Death Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4623",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PSYC Elective (except PSYC 210 ) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4736",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: National Restaurant Association/ServSafe Manager",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: National Restaurant Association/ManageFirst; Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Mathematics of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Food Preparation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "125",
+              "title": "Basic Skills Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "130",
+              "title": "The Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: National Restaurant Association/ManageFirst; Hospitality Human Resources Mgmt. and Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Food Preparation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Dining Room Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ManageFirst: Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "170",
+              "title": "Supervisory Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ManageFirst: Hospitality and Restaurant Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "180",
+              "title": "Culinary Arts Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: CULINARY ARTS Upon completion of a certificate, the students can earn (CFC) Certified Fundamentals Cook / Accrediting Board (ACF) American Culinary Federation upon completion of 1 year in the industry.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "235",
+              "title": "Purchasing and Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Controlling Foodservice Cost",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "200",
+              "title": "Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "217",
+              "title": "Human Relations and Supervisory Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ TECHNICAL DIPLOMA: CULINARY ARTS Upon successful completion of four Core Credential exams and one Foundation exam you will earn/ (MFP) ManageFirst Professional/ Accrediting Board (NRA) National Restaurant Association.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Or BADM 113",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=5060",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association?ServSafe Manager",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ManageFirst; Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Mathematics of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Food Preparation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "125",
+              "title": "Basic Skills Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "130",
+              "title": "The Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ManageFirst; Hospitality Human Resources Mgmt and Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4632",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ServSafe Manager",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Mathematics of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Food Preparation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "125",
+              "title": "Basic Skills Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "130",
+              "title": "The Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Hospitality Human Resources Mgmt and Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Food Preparation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Dining Room Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "170",
+              "title": "Supervisory Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Hospitality and Restaurant Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "180",
+              "title": "Culinary Arts Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4737",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ServSafe Manager",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "110",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Mathematics of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "120",
+              "title": "Food Preparation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "125",
+              "title": "Basic Skills Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "130",
+              "title": "The Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Hospitality and Resources Mgmt and Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Food Preparation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "150",
+              "title": "Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Dining Room Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "170",
+              "title": "Supervisory Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Hospitality and Restaurant Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "180",
+              "title": "Culinary Arts Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: CULINARY ARTS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Upon Graduation of a certificate, the students can earn (CFC) Certified Fundamentals Cook / Accrediting Board (ACF) American Culinary Federation upon completion of 1 year in the industry.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "235",
+              "title": "Purchasing and Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Restaurant Association/ ManageFirst: Controlling Foodservice Cost",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "200",
+              "title": "Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "217",
+              "title": "Human Relations and Supervisory Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ TECHNICAL DIPLOMA: CULINARY ARTS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Upon successful completion of four Core Credential exams and one Foundation exam you will earn/ (MFP) ManageFirst Professional/ Accrediting Board (NRA) National Restaurant Association.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Customer Service Representative, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4780",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Retail Federation NRF Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Customer Service Specialist, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4769",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "102",
+              "title": "Customer Service Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: National Retail Federation NRF Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "105",
+              "title": "General Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "110",
+              "title": "Records and Information Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: IC3 Digital Literacy MOS Associate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4692",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "104",
+              "title": "Introduction to Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA A+ Core 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA A+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "172",
+              "title": "Linux Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "255",
+              "title": "CCNA I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CTEC Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "279",
+              "title": "Information Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective-Level 200 only Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: CompTIA Security+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "299",
+              "title": "CTEC Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Analytics, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4788",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Freshman Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "108",
+              "title": "Introduction to Management Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "270",
+              "title": "Relational Database Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Data Systems+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "274",
+              "title": "Data Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Data+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4763",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 13 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "200",
+              "title": "Introduction to Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "201",
+              "title": "Physics and Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "202",
+              "title": "Abdominal Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "203",
+              "title": "Gynecologic Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "204L",
+              "title": "Learning Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "205",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Psychology Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 9 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "210",
+              "title": "Physics and Instrmentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "211",
+              "title": "Abdominal Sonography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "212",
+              "title": "Obestetric Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "213",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 4 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "216",
+              "title": "Physics and Instrumenation III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "209",
+              "title": "Sonography Sectional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 10 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "217",
+              "title": "Abdominal Sonography III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "219",
+              "title": "Adv. OB/GYN Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "218",
+              "title": "Clinical Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "220",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3​",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Photography, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4724",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "163",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "171",
+              "title": "The Business of Visual Artistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Compositing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "267",
+              "title": "Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "270",
+              "title": "Commercial Photography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Directing, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4729",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "153",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "255",
+              "title": "Directing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "256",
+              "title": "Directing Styles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Domestic Air Condition and Refrigeration, CTS (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4762",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "115",
+              "title": "HACR Safety, Health &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "116",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "117",
+              "title": "Principles of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "118",
+              "title": "Principles of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "121",
+              "title": "HACR Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "122",
+              "title": "HACR Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "123",
+              "title": "HACR Electric Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "124",
+              "title": "Applied Electricity &amp; Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 4 Credit Hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "141",
+              "title": "Domestic Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "142",
+              "title": "Room Air Conditioners",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ECG/Telemetry Technician, CTC (Bossier and Natchitoches Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4684",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "112",
+              "title": "Basic ECG",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NHCA Electrocardiogram Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician Helper, CTC (Sabine Valley Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4804",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester (Fall): 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦IBC: Electrician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "103",
+              "title": "Residential Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "132",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician Technology, TD (Sabine Valley Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4753",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester (Fall): 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course has an embedded industry-based credential (IBC) in Electronics I from PrecisionExams/YouScience.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "103",
+              "title": "Residential Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "132",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "104",
+              "title": "Electrical Raceways",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "208",
+              "title": "Intermediate Programmable Logic Controllers (PLCs) and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "230",
+              "title": "Generators &amp; Transformer OPS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "260",
+              "title": "Mechatronics Level I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OGPT",
+              "number": "102",
+              "title": "Introduction to Process Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "280",
+              "title": "Industrial Technology Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "282",
+              "title": "Industrial Engineering Technology Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician, CTC (Bossier, Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4685",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "100",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "100L",
+              "title": "EMT Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NREMT Emergency Medical Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Services, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4700",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "145",
+              "title": "Industrial Mechanical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "146",
+              "title": "Industrial Mechanical Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISAF",
+              "number": "210",
+              "title": "Industrial Safety and OSHA Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "245",
+              "title": "Pumps and Pump Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "102",
+              "title": "Fundamentals of Electricity and Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "260",
+              "title": "Mechatronics Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Graphics, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4701",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "143",
+              "title": "Introductory Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Technology Technical Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "144",
+              "title": "Intermediate Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "171",
+              "title": "Building Information Modeling I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Technology Technical Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4616",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGR",
+              "number": "100",
+              "title": "Engineering Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "250",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "105",
+              "title": "Elements of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGR",
+              "number": "101",
+              "title": "Engineering Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "251",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Engineering and Science I (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "252",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "220",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "201",
+              "title": "Mechanics of Engineering Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics for Engineering and Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGR",
+              "number": "222",
+              "title": "Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "221",
+              "title": "Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "299",
+              "title": "Engineering Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective Credit Hours: 3 * or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "161",
+              "title": "Solid Works 3D",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Appreciation Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Fiber Optics Technician Certifications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4784",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fiber Optics Technology, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4785",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "125",
+              "title": "Fiber Optics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Certified Premises Cabling Technician *IBC: Certified Fiber Optic Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "126",
+              "title": "Fiber Optics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Certified Fiber Optic Splicing Specialist *IBC: Certified Fiber Optic Testing Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "127",
+              "title": "Fiber Optics III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC:Certified Fiber Optic Outside Plant Specialist *IBC:Certified Fiber Optic Fiber to the Home Specialist",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4653",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "130",
+              "title": "Film Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Scriptwriting for Film and Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "280",
+              "title": "Digital Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "281",
+              "title": "Documentary Filmmaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4734",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "100",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "110",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "120",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "130",
+              "title": "Principles of Fire and Emergency Services and Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "140",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "150",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "200",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "210",
+              "title": "Fire &amp; Emerg. Serv. Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "220",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "230",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "240",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: FIRE SCIENCE * IBC: FDSOA Health and Safety Officer Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credit Hours: 3 Must be approved by Program Director",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "250",
+              "title": "Hazardous Materials Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "260",
+              "title": "Fire Investigation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "270",
+              "title": "Fire Investigation II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4735",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "100",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "110",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "120",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "130",
+              "title": "Principles of Fire and Emergency Services and Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "140",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "150",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "200",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "210",
+              "title": "Fire &amp; Emerg. Serv. Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "220",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "230",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "240",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: FDSOA Health and Safety Officer Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Safety Certification",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4746",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education Courses",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4714",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fine Arts - 3 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "120",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "121",
+              "title": "Jazz Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "240",
+              "title": "American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics/Analytical Reasoning",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra and Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "114",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "250",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "251",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "252",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "254",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "201",
+              "title": "Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "202",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPHY",
+              "number": "101",
+              "title": "Physical Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPHY",
+              "number": "102",
+              "title": "Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPHY",
+              "number": "105",
+              "title": "Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "206",
+              "title": "Adolescent Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "210",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Loss and Death",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "290",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "201",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "202",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "203",
+              "title": "Marriage and Family Living",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "204",
+              "title": "Sociology of Deviance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "207",
+              "title": "Race, Class and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "290",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "201",
+              "title": "Major British Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "250",
+              "title": "Introduction to Women’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "251",
+              "title": "Introduction to World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "252",
+              "title": "Introduction to Folklore and Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "255",
+              "title": "Introduction to Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "256",
+              "title": "Introduction to Poetry and Drama",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Introduction to African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "103",
+              "title": "World Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "104",
+              "title": "World Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "202",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Foreign Language Sequences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FREN",
+              "number": "101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "102",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMAN",
+              "number": "201",
+              "title": "Prehistoric-Medieval Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMAN",
+              "number": "202",
+              "title": "Renaissance - Modern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMAN",
+              "number": "203",
+              "title": "Film and Culture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "All Courses Considered as Humanities Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "201",
+              "title": "Major British Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "250",
+              "title": "Introduction to Women’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "251",
+              "title": "Introduction to World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "252",
+              "title": "Introduction to Folklore and Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "255",
+              "title": "Introduction to Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "256",
+              "title": "Introduction to Poetry and Drama",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "257",
+              "title": "Introduction to African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "102",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "201",
+              "title": "Intermediate French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "103",
+              "title": "World Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "104",
+              "title": "World Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "202",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "203",
+              "title": "Louisiana History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMAN",
+              "number": "201",
+              "title": "Prehistoric-Medieval Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMAN",
+              "number": "202",
+              "title": "Renaissance - Modern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMAN",
+              "number": "203",
+              "title": "Film and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLGN",
+              "number": "201",
+              "title": "New Testament Survey I: Interbiblical Period, Four Gospels",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLGN",
+              "number": "202",
+              "title": "New Testament Survey II: Acts to Revelations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLGN",
+              "number": "203",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "201",
+              "title": "Intermediate Spanish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological Sequences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "101",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "105",
+              "title": "Elements of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "106",
+              "title": "Elements of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical Sequences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "106",
+              "title": "Elemental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "201",
+              "title": "General Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Engineering and Science I (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics for Engineering and Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "101",
+              "title": "Foundations in Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "102",
+              "title": "Foundations in Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "101",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "105",
+              "title": "Elements of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "106",
+              "title": "Elements of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "107",
+              "title": "Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "203",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "206",
+              "title": "Principles of Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "244",
+              "title": "Introduction to Human Genetics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I (Non-Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "250",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "106",
+              "title": "Elemental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "107",
+              "title": "Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "110",
+              "title": "Astronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "111",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "201",
+              "title": "General Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "211",
+              "title": "Physics for Engineering and Science I (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "212",
+              "title": "Physics for Engineering and Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "101",
+              "title": "Foundations in Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "102",
+              "title": "Foundations in Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Science, Option in Allied Health, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4614",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MATH Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Science Elective Credit Hours: 4 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credits Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Science Elective Credits Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Science Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Science, Option in Natural Sciences, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4676",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101L",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102L",
+              "title": "Biology II Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credits Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Science Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Science Elective Credit Hours: 3 * or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies, AGS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4666",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYSE",
+              "number": "100",
+              "title": "First Year Student Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CTEC Elective Credit Hours 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies, CGS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4667",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "101",
+                  "title": "Applied Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Elective Credits Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credits Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Graphic Design, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4654",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "223",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Graphic Design, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4723",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "219",
+              "title": "Applied Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "223",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COMM Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COMM or ART Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Health Care Management, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4791",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "213",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "201",
+              "title": "Introduction to Healthcare Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "202",
+              "title": "Healthcare Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "205",
+              "title": "Risk and Insurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "203",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "250",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "290",
+              "title": "Healthcare Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "299",
+              "title": "Internship in Healthcare Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Health Care Management, Health Studies Concentration, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "201",
+              "title": "Introduction to Healthcare Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I (Non-Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "202",
+              "title": "Healthcare Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCM",
+              "number": "205",
+              "title": "Risk and Insurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "250",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCM",
+              "number": "203",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLGY",
+              "number": "201",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "226",
+              "title": "Perspectives on Aging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Health Care Management, Professional Practice Concentration, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4611",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "201",
+              "title": "Introduction to Healthcare Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I (Non-Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Physical Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "145",
+              "title": "Advanced MS Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "202",
+              "title": "Healthcare Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCM",
+              "number": "205",
+              "title": "Risk and Insurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "250",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "213",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCM",
+              "number": "203",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "290",
+              "title": "Healthcare Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "299",
+              "title": "Internship in Healthcare Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Health Information Security, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4702",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "279",
+              "title": "Information Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 8 Credit Hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "263",
+              "title": "Cloud+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Help Desk, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4718",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "118",
+              "title": "Help Desk Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "High School Equivalency",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4750",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Engineering Technology, Automation and Controls Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4690",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester (Fall): 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IBC: Electronics I from Precision Exams/YouScience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "143",
+              "title": "Introductory Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IBC: AutoCAD Certified User from Autodesk",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "161",
+              "title": "Solid Works 3D",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IBC: SolidWorks Certification from SolidWorks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "102",
+              "title": "Fundamentals of Electricity and Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "201",
+              "title": "General Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "202",
+              "title": "Intro to Microprocessors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "206",
+              "title": "Electronics Equipment and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "208",
+              "title": "Intermediate Programmable Logic Controllers (PLCs) and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective Credit Hours: 4** (Fall only)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "260",
+              "title": "Mechatronics Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: INSTRUMENTATION AND ELECTRONICS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "210",
+              "title": "Robotic Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective* Credit Hours: 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Engineering Technology, Engineering Graphics Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4691",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Electronics I - YouScience Precision Exams",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "143",
+              "title": "Introductory Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Autocad Certified User - Autodesk ♦ CAREER AND TECHNICAL CERTIFICATE: INDUSTRIAL TECHNICIAN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "110",
+              "title": "Manufacturing Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "144",
+              "title": "Intermediate Computer Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "171",
+              "title": "Building Information Modeling I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: ENGINEERING GRAPHICS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "158",
+              "title": "Computer Drafting Applications and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "161",
+              "title": "Solid Works 3D",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Certified Solidworks Associate - Solidworks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "210",
+              "title": "Computer Aided Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "201",
+              "title": "General Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Engineering Technology, Industrial Maintenance Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4717",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "202",
+              "title": "Introduction to Lean Manufacturing and Six Sigma",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: INDUSTRIAL TECHNICIAN *IBC: Youscience Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 18 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "151",
+              "title": "Power Transmission Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "101",
+              "title": "Survey of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "110",
+              "title": "Manufacturing Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: INDUSTRIAL MAINTENANCE",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "201",
+              "title": "General Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "161",
+              "title": "Solid Works 3D",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "210",
+              "title": "Computer Aided Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Technology Technical Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "203",
+              "title": "Advanced Shield Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Technology Technical Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 14 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Technology Technical Elective* Credit Hours: 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Manufacturing Technology, TD (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4759",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISAF",
+              "number": "101",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: CERTIFIED PRODUCTION TECHNOLOGY, MANUFACTURING FUNDAMENTALS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "145",
+              "title": "Industrial Mechanical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: INDUSTRIAL MANUFACTURING",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "149",
+              "title": "Fluid Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "200",
+              "title": "Intro to PLC’s",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "105",
+              "title": "Basic Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "203",
+              "title": "Intro to Ind Cont, Comp &amp; Equi",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "205",
+              "title": "Millwright",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "207",
+              "title": "Basic Machining",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Manufacturing, CTS (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4772",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISAF",
+              "number": "101",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "145",
+              "title": "Industrial Mechanical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Technician, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4786",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "​",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Security Professionals, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4705",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "200",
+              "title": "Network Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Security+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Instrumentation and Electronics, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4704",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "102",
+              "title": "Fundamentals of Electricity and Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "150",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "153",
+              "title": "Hydraulics/Fluid Dynamics with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "202",
+              "title": "Intro to Microprocessors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IET Technical Elective Credit Hours: 4*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Laboratory Assistant, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4615",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202L",
+              "title": "Microbiology Lab for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHSC",
+                  "number": "106",
+                  "title": "Elemental Chemistry"
+                }
+              ]
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "209",
+              "title": "Laboratory Testing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Lighting Design, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4728",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "113",
+              "title": "Lighting Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "213",
+              "title": "Special Problems in Stage Lighting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "214",
+              "title": "Scene Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "215",
+              "title": "Scene Painting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Linux, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4789",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "104",
+              "title": "Introduction to Scripting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "272",
+              "title": "Advanced Topics in Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "172",
+              "title": "Linux Server",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Biological Sciences Concentration, ASLT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4618",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101L",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "112",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "102L",
+              "title": "Biology II Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Concentration Elective Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Concentration Elective Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "250",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Concentration Elective Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral /Social Sciences Elective Credit Hours: 3 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Business Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4629",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Elective Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "114",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "206",
+              "title": "Introduction Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 7",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Elective (200-Level ) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science - Other Discipline Credit Hours: 3 5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Elective Credit Hours: 3 6",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 7",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities - Literature Course Credit Hours: 3 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Louisiana Transfer - Fine Arts Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4617",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 31",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 31",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Louisiana Transfer - Humanities Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4607",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 31",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 31",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Mass Communication Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4642",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "211",
+              "title": "Newswriting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Physical Sciences Concentration, ASLT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4679",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "250",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "101L",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101L",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "251",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102L",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science concentration Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Elective Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "252",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science concentration Elective Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Elective Credit Hours: 3 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral /Social Sciences Elective Credit Hours: 3 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Social Sciences Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4619",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence1 Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Sequence1 Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Fundamentals, CTC (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4771",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISAF",
+              "number": "101",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media for the Ministry, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4655",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Live Video Productions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "225",
+              "title": "Audio Production in Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, CTS (Bossier and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4755",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 26 Credit Hours",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "115",
+              "title": "Pharmacology for Allied Health Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "207",
+              "title": "Advanced Medical Language",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "201",
+              "title": "Medical Supplies and Patient Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "209",
+              "title": "Laboratory Testing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MOS",
+              "number": "107",
+              "title": "Medical Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "203",
+              "title": "Specialty Areas for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "210",
+              "title": "Medical Assistant Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NHA Certified Clinical Medical Assistant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, TD (Bossier and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4668",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 26 Credit Hours",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "115",
+              "title": "Pharmacology for Allied Health Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "207",
+              "title": "Advanced Medical Language",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "201",
+              "title": "Medical Supplies and Patient Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "209",
+              "title": "Laboratory Testing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MOS",
+              "number": "107",
+              "title": "Medical Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "203",
+              "title": "Specialty Areas for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "210",
+              "title": "Medical Assistant Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NHA Certified Clinical Medical Assistant ♦ CERTIFICATE OF TECHNICAL STUDIES: MEDICAL ASSISTANT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional 12 Credit Hours from the following:",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "105",
+              "title": "Medical Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "211",
+              "title": "Phlebotomy Hospital Clinicals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "102",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "102L",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "112",
+              "title": "Basic ECG",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "203",
+              "title": "Basic Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MOS",
+              "number": "113",
+              "title": "Reimbursement Methodology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Unit Coordinator, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4686",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "105",
+              "title": "Medical Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "100",
+              "title": "Computer Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MOS",
+              "number": "107",
+              "title": "Medical Office Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NAHUC MedicaL Unit Coordinator Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medicolegal Death Investigation, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4740",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "SLGY Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "105",
+              "title": "Medical Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "202",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "295",
+              "title": "Criminalistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Loss and Death",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "204",
+              "title": "Accident Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "294",
+              "title": "Medicolegal Death Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "298",
+              "title": "Criminal Justice Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multimedia Specialist, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4722",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Fundamentals of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "141",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "211",
+              "title": "Newswriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "207",
+              "title": "Electronic Field Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "280",
+              "title": "Digital Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multimedia Specialist, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4733",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "125",
+              "title": "Media Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "135",
+              "title": "Design for Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "141",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "201",
+              "title": "Video Post-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Fundamentals of Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "218",
+              "title": "Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "223",
+              "title": "Publication Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "256",
+              "title": "Multimedia Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "270",
+              "title": "Commercial Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "280",
+              "title": "Digital Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "230",
+              "title": "Communication Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "258",
+              "title": "Media Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COMM Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Production and Technology, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4648",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "110",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "100",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "226",
+              "title": "Audio Production in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "120",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "121",
+              "title": "Jazz Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "101",
+              "title": "Class Voice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "107",
+              "title": "Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "294",
+              "title": "Studio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "111",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "112",
+              "title": "Ear Training/Sightsinging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "122",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "108",
+              "title": "Marketing of Recorded Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "290",
+              "title": "Pro Tools",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "National Center for Construction Education and Research",
+      "credential": "other",
+      "program_code": "NCCER",
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4747",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Security, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4719",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "112",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Notary Public Exam Preparation",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4748",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Assistant, CTC (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4778",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNUR",
+              "number": "103",
+              "title": "Nurse Asst Skills Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "102",
+              "title": "Nursing Assistant Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing, LPN to RN Transition Tracks, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 27 credit hours",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202L",
+              "title": "Microbiology Lab for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "114",
+                  "title": "Finite Mathematics"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses for “Work-Friendly” Track: 45 credit hours",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 8 Credit Hours (plus 12 LEAP Credit Hours): 20 Credit Hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "204",
+              "title": "LPN to RN Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "223",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "225",
+              "title": "Mental Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "211",
+              "title": "Adult Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Adult Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "214",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Women’s Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "224",
+              "title": "Women’s Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "210",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "213",
+              "title": "Pediatric Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Fine Arts Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "221",
+              "title": "Adult Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "222",
+              "title": "Adult Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "226",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "230",
+              "title": "Nursing Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses for “LPN to RN Apprentice” Track: 45 Credit Hours",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 8 Credit Hours (plus 12 LEAP Credit Hours): 20 Credit Hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "204",
+              "title": "LPN to RN Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "223",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "225",
+              "title": "Mental Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "211",
+              "title": "Adult Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Adult Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "214",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Fine Arts Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Women’s Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "224",
+              "title": "Women’s Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "210",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "213",
+              "title": "Pediatric Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "221",
+              "title": "Adult Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "222",
+              "title": "Adult Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "226",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "230",
+              "title": "Nursing Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing, Traditional Track, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4677",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 28 credit hours",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202L",
+              "title": "Microbiology Lab for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "114",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNUR",
+              "number": "101",
+              "title": "Nursing as a Career",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 44 credit hours",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "200",
+              "title": "Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "200L",
+              "title": "Nursing Fundamentals Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "201",
+              "title": "Adult Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "202",
+              "title": "Nursing Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "205",
+              "title": "Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "210",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "211",
+              "title": "Adult Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Adult Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "213",
+              "title": "Pediatric Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "214",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Women’s Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "224",
+              "title": "Women’s Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credits Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "221",
+              "title": "Adult Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "222",
+              "title": "Adult Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "223",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "225",
+              "title": "Mental Health Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "226",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "230",
+              "title": "Nursing Career Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "206",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Fine Arts Elective Credit Hours: 3 * *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4670",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 30 Credit Hours",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 42 Credit Hours",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 4 Credit Hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "200",
+              "title": "Introduction to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "201",
+              "title": "Functional Anatomy for OTA",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "203",
+              "title": "Physical Challenges to Occupation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "204",
+              "title": "Psychosocial Changes to Occupation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "205",
+              "title": "Developmental Challenges to Occupation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "206",
+              "title": "Therapeutic Interventions I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "208",
+              "title": "Clinical Documentation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "210",
+              "title": "OTA Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "213",
+              "title": "OT Strategies and Intervention to Physical Challenges",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "214",
+              "title": "OT Strategies and Intervention to Psychosocial Challenges",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "215",
+              "title": "OT Strategies and Interventions in Pediatrics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "216",
+              "title": "Therapeutic Interventions II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "217",
+              "title": "Fieldwork 1-B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "218",
+              "title": "Clinical Documentation II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "220",
+              "title": "Fieldwork Level II-A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "221",
+              "title": "Fieldwork Level II-B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NBCOT Occupational Therapy Assistant Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Oil and Gas Technology, Production Technology concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4694",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "111",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISAF",
+              "number": "111",
+              "title": "Safety, Health, and Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "101",
+              "title": "Introduction to the Exploration and Production of Oil and Gas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I (Non-Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "150",
+              "title": "Regulatory Issues for the Oil and Gas Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OGPT",
+              "number": "103",
+              "title": "Drilling Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved OGPT Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "245",
+              "title": "Pumps and Pump Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "153",
+              "title": "Hydraulic/Pneumatic Applications for the Oil and Gas Industry with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OGPT",
+              "number": "203",
+              "title": "Oil and Gas Instrumentation and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "207",
+              "title": "Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "217",
+              "title": "Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "280",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or OGPT Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OGPT",
+              "number": "221",
+              "title": "Reservoir Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective*** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "202",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4672",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "190",
+              "title": "Anatomy, Physiology, and Pathophysiology for Paramedics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "201",
+              "title": "Introduction to Paramedic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "202",
+              "title": "Airway Management and Ventilation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "203",
+              "title": "Patient Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "204",
+              "title": "Treatment of the Trauma Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "205",
+              "title": "Treatment of the Medical Patient I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Advanced Cardiac Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "209",
+              "title": "Applied Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "206",
+              "title": "Special Considerations and Assessment Based Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "207",
+              "title": "Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "208",
+              "title": "Treatment of the Medical Patient II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "211",
+              "title": "Paramedic Clinical Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "213",
+              "title": "Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "212",
+              "title": "Paramedic Assessment and Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "214",
+              "title": "Field Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "215",
+              "title": "Field Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: PARAMEDIC * IBC: NREMT Paramedic Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Courses for Associates Degree: 18 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4671",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "190",
+              "title": "Anatomy, Physiology, and Pathophysiology for Paramedics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program director approval required for substitutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "201",
+              "title": "Introduction to Paramedic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "202",
+              "title": "Airway Management and Ventilation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "203",
+              "title": "Patient Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "204",
+              "title": "Treatment of the Trauma Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "205",
+              "title": "Treatment of the Medical Patient I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Advanced Cardiac Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "209",
+              "title": "Applied Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "206",
+              "title": "Special Considerations and Assessment Based Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "207",
+              "title": "Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "208",
+              "title": "Treatment of the Medical Patient II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "211",
+              "title": "Paramedic Clinical Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "213",
+              "title": "Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 6 Credit Hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTP",
+              "number": "212",
+              "title": "Paramedic Assessment and Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "214",
+              "title": "Field Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTP",
+              "number": "215",
+              "title": "Field Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: NREMT Paramedic Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Performing Arts, Music Production and Technology Concentration, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4644",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "100",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "101",
+              "title": "Class Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "226",
+              "title": "Audio Production in Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Ensemble2 Credit Hours: 1 plus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "112",
+              "title": "Ear Training/Sightsinging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "122",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "107",
+              "title": "Sound Reinforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "299",
+              "title": "Sound Design for Film and Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Ensemble3 Credit Hours: 1 plus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "110",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "113",
+              "title": "Ear Training/Sightsinging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "123",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "108",
+              "title": "Marketing of Recorded Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "290",
+              "title": "Pro Tools",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "120",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "121",
+              "title": "Jazz Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "111",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "294",
+              "title": "Studio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Ensemble2 Credit Hours: 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Performing Arts, Musical Theatre Concentration, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4646",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "101",
+              "title": "Class Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "110",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "100",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "153",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "157",
+              "title": "Fundamentals of Stage Movement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "159",
+              "title": "Musical Theatre Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "231",
+              "title": "Applied Voice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "257",
+              "title": "Dance for the Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "231",
+              "title": "Applied Voice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Science Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "154",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "156",
+              "title": "Voice for the Stage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "231",
+              "title": "Applied Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "230",
+              "title": "Applied Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "111",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Theatre Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Performing Arts, Theatre Concentration, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4645",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "115",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Theatre Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective** Credit Hours:3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Mathematical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Theatre Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Sciences Elective Credit Hours: 3 ***",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4673",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "116",
+              "title": "Pharmaceutical Dosage Calculations and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses: 23 Credit Hours",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester Program Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "101",
+              "title": "Introduction to Pharmacy Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "102",
+              "title": "Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "102L",
+              "title": "Pharmacy Practice Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "104",
+              "title": "Pharmacology for Pharmacy Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester Program Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "110",
+              "title": "Sterile Products",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "110L",
+              "title": "Sterile Products Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "120",
+              "title": "Professional Practice Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "151",
+              "title": "Pharmacy Clinical Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: PTCB Pharmacy Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy, CTS (Bossier and Natchitoches Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4680",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "102",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "102L",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALHT",
+              "number": "211",
+              "title": "Phlebotomy Hospital Clinicals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: ASCP Phlebotomy Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Photography, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4656",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "160",
+              "title": "Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Compositing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "267",
+              "title": "Photography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4675",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 31 Credit Hours",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Psychology Elective Credit Hours: 3 (Recommended: PSYC 201, PSYC 220, PSYC 225)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 Courses with the prefixes COMM or SPCH are not acceptable electives.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required PTA Program Courses: 41 Credit Hours",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "200",
+              "title": "Functional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "201",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "202",
+              "title": "Clinical Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "203",
+              "title": "Orthopedic Conditions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "204",
+              "title": "Physical Therapy Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "205",
+              "title": "Therapeutic Modalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "206",
+              "title": "Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "212",
+              "title": "Clinical Neuroanatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "213",
+              "title": "Neurological Conditions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "214",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "215",
+              "title": "Special Areas of Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "216",
+              "title": "Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "217",
+              "title": "Comprehensive Interventions for the Physical Therapist Assistant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 7 Credit Hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "226",
+              "title": "Clinical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: FSBPT Physical Therapist Assistant Licensure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Police/Community Relations, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4626",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "201",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "211",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "290",
+              "title": "Homeland Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "297",
+              "title": "Violence, Domestic, and Other",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "291",
+              "title": "Criminal Evidence and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "292",
+              "title": "Police-Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "293",
+              "title": "Ethics in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "296",
+              "title": "Introduction to Jurisprudence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "299",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing, AAS (Bossier and Natchitoches Campuses)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4770",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 22 Credit Hours",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Social/Behavioral Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "100",
+              "title": "PN Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "120",
+              "title": "Practical Nursing Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "126",
+              "title": "Nutrition for PNs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 52 Credit Hours",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "121",
+              "title": "Basic Fundamentals in PN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "122",
+              "title": "Adv Fundamentals in PN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "123",
+              "title": "Basic Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "212",
+              "title": "Adv Pharmacology &amp; IV Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester:18 Credit Hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "211",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "222",
+              "title": "Medical Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "241",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "242",
+              "title": "Maternal &amp; Women’s Health Nsg",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "243",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester:10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "233",
+              "title": "Medical Surgical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "234",
+              "title": "Transition to Prof Prac for PN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing, TD (Bossier and Natchitoches Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4739",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "100",
+              "title": "PN Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "120",
+              "title": "Practical Nursing Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "126",
+              "title": "Nutrition for PNs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 52 Credit Hours",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 15 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "121",
+              "title": "Basic Fundamentals in PN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "122",
+              "title": "Adv Fundamentals in PN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "123",
+              "title": "Basic Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "212",
+              "title": "Adv Pharmacology &amp; IV Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 18 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "211",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "222",
+              "title": "Medical Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 9 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "241",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "242",
+              "title": "Maternal &amp; Women’s Health Nsg",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "243",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 10 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "233",
+              "title": "Medical Surgical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "234",
+              "title": "Transition to Prof Prac for PN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Private Investigator Exam Preparation",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4749",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming for Digital Gaming, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4703",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Course Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "130",
+              "title": "HTML5/CSS3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IBC*: HTML/CSS: CIW Advanced HTML5 & CSS3 Specialist",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "149",
+              "title": "Web Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Web Scripting: CIW JavaScript Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Course Credit Hours:3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "151",
+              "title": "Advanced Java Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "235",
+              "title": "Mobile App Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER TECHNICAL CERTIFICATE: WEB DESIGN ♦ CAREER TECHINCAL CERTIFICATE: SOFTWARE APPLICATIONS (with elective of CTEC 243)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 9 Credit Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "250",
+              "title": "Programming with C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "260",
+              "title": "Interactive Program Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "295",
+              "title": "The Software Development Process",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Real Estate Pre-licensing Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4744",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Residential Electrician, CTS (Sabine Valley Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4783",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦IBC: Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "103",
+              "title": "Residential Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "132",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4613",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 36 Credit Hours",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 9 Credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I (Non-Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "230L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202L",
+              "title": "Microbiology Lab for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "231L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "105",
+              "title": "Elemental Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 34 Credit Hours",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSTH",
+              "number": "203",
+              "title": "Cardiopulmonary Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSTH",
+              "number": "202",
+              "title": "Respiratory Care Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "204",
+              "title": "Cardiopulmonary Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "210",
+              "title": "Clinical Applications and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "220",
+              "title": "Pulmonary Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "226",
+              "title": "Respiratory Care Seminar I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSTH",
+              "number": "221",
+              "title": "Critical Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "225",
+              "title": "Clinical Applications and Procedure II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "235",
+              "title": "Cardiopulmonary Case Studies and Ethical Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "270",
+              "title": "Neonatology/Pediatric Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "275",
+              "title": "Cardiopulmonary Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Seventh Semester: 5 Credit Hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSTH",
+              "number": "265",
+              "title": "Clinical Applications and Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: AHA Advance Cardiac Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "285",
+              "title": "Advanced Practitioners Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSTH",
+              "number": "291",
+              "title": "Cardiopulmonary Rehabilitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: NBRC Respiratory Therapy Certification/NBRC Registered Respiratory Therapist",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Rural Health Medical Office Administration, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4757",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 6 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MOS",
+              "number": "101",
+              "title": "Disease and Conditions of Rural Communities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MOS",
+              "number": "102",
+              "title": "Introduction to Rural Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 3 Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MOS",
+              "number": "253",
+              "title": "Code Sets in Rural Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Scene Design, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4726",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "114",
+              "title": "Drawing for the Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "214",
+              "title": "Scene Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "255",
+              "title": "Directing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Senior Systems Managers, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4706",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "200",
+              "title": "Network Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "210",
+              "title": "Advanced Network Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "220",
+              "title": "Information System Security I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Security+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "279",
+              "title": "Information Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "299",
+              "title": "CTEC Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective 200 or Above Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Shampoo Assistant, CTC (Natchitoches Campus)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4793",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "111",
+              "title": "Intro to Decontam &amp; Infection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "112",
+              "title": "Properties-Skin, Scalp, Hair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "113",
+              "title": "Shampoo, Rinse, &amp; Condition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Applications, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4712",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "151",
+              "title": "Advanced Java Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Course Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Course Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4693",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: CompTIA Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "130",
+              "title": "HTML5/CSS3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: HTML/CSS: CIW Advanced HTML5 & CSS3 Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "151",
+              "title": "Advanced Java Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "149",
+              "title": "Web Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Web Scripting: CIW JavaScript Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective* or Software Development Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "243",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Software Development Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Software Development Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Software Development Elective** Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "270",
+              "title": "Relational Database Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Data Systems+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "295",
+              "title": "The Software Development Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4738",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Qualification Courses: 27 Credit Hours",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLGY",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120",
+              "title": "Introductory Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "May fulfill this requirement by passing both BLGY 230 and BLGY 231L",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "120L",
+              "title": "Introductory Human Anatomy and Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "May fulfill this requirement by passing both BLGY 230L and BLGY 231L",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "116",
+              "title": "Pharmaceutical Dosage Calculations and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "109",
+              "title": "Health Care Systems and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "* IBC: AHA Basic Life Support Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALHT",
+              "number": "206",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Program Courses: 34 Credit Hours",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STEC",
+              "number": "100",
+              "title": "Foundations of Surg. Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "102",
+              "title": "Introduction to Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "102L",
+              "title": "Introduction to Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Summer Session C)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202",
+              "title": "Microbiology for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Summer Session A)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "202L",
+              "title": "Microbiology Lab for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Summer Session A)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STEC",
+              "number": "110",
+              "title": "Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "111",
+              "title": "Clinical Specialties",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "112",
+              "title": "Surgical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STEC",
+              "number": "120",
+              "title": "Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "121",
+              "title": "Surgical Specialties and Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEC",
+              "number": "122",
+              "title": "Surgical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: NBSTSA Surgical Technologist Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Systems Administration, Cloud Computing Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4696",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "101",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BADM",
+              "number": "113",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "104",
+              "title": "Introduction to Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "165",
+              "title": "Introduction to Virtualization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "172",
+              "title": "Linux Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "263",
+              "title": "Cloud+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Cloud+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "272",
+              "title": "Advanced Topics in Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "264",
+              "title": "Advanced Cloud Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "270",
+              "title": "Relational Database Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "274",
+              "title": "Data Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Security+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "299",
+              "title": "CTEC Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Systems Administration, DevOps Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4695",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "101",
+              "title": "Information Technology Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Tech+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "107",
+              "title": "Skills for Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "101",
+                  "title": "Applied Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "104",
+              "title": "Introduction to Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "151",
+              "title": "Advanced Java Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "172",
+              "title": "Linux Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Behavioral/Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "130",
+              "title": "HTML5/CSS3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "243",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "272",
+              "title": "Advanced Topics in Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "270",
+              "title": "Relational Database Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "287",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Security+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "295",
+              "title": "The Software Development Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tack Welder/Pipe Fitter Helper, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4796",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "106",
+              "title": "SMAW Basic Beads &amp; Fillet Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teaching (Grades 1-5), AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4621",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "102",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "105",
+              "title": "Elements of Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "110",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "101",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "Composition and Rhetoric II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "117",
+              "title": "Elementary Number Structure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLGY",
+              "number": "106",
+              "title": "Elements of Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "105",
+              "title": "Intro to Education Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "201",
+              "title": "Teach &amp; Learn Diverse Setting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "217",
+              "title": "Elementary Geometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "201",
+              "title": "Major British Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "202",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GPHY",
+              "number": "101",
+              "title": "Physical Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "203",
+              "title": "Teach&amp;Learn Diverse SettingII",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "218",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POSC",
+              "number": "201",
+              "title": "National Government in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies - Electrician Technology Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4800",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours (Fall)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "103",
+              "title": "Residential Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "132",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERITIFICATE: RESIDENTIAL ELECTRICIAN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours (Spring)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "201",
+              "title": "Introduction to Digital Electronics and Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "252",
+              "title": "Electric Motor Controls and Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 Credit Hours (Fall)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "104",
+              "title": "Electrical Raceways",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "208",
+              "title": "Intermediate Programmable Logic Controllers (PLCs) and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "230",
+              "title": "Generators &amp; Transformer OPS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "260",
+              "title": "Mechatronics Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15/16 Credit Hours (Spring)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OGPT",
+              "number": "102",
+              "title": "Introduction to Process Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Engineering Technology Elective* Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "280",
+              "title": "Industrial Technology Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "282",
+              "title": "Industrial Engineering Technology Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective** Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ TECHNICAL DIPLOMA: ELECTRICIAN TECHNOLOGY",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies - Manufacturing Technology Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4802",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14/15 Credit Hours (Fall)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ISAF",
+              "number": "101",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISAF",
+              "number": "210",
+              "title": "Industrial Safety and OSHA Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "107",
+              "title": "Manufacturing Safety, Quality, and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "108",
+              "title": "Manufacturing Processes, Production, and Maintenance Awareness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Industrial Engineering Technology Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: CERTIFIED PRODUCTION TECHNICIAN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 Credit Hours (Spring)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "101",
+              "title": "Fundamentals of Electricity and Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "145",
+              "title": "Industrial Mechanical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: INDUSTRIAL MANUFACTURING",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Credit Hours (Fall)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "149",
+              "title": "Fluid Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "200",
+              "title": "Intro to PLC’s",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "145",
+              "title": "Industrial Mechanical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Sciences Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 17 Credit Hours (Spring)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEED",
+              "number": "105",
+              "title": "Basic Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "203",
+              "title": "Intro to Ind Cont, Comp &amp; Equi",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "205",
+              "title": "Millwright",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "207",
+              "title": "Basic Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Sciences Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ TECHNICAL DIPLOMA: INDUSTRIAL MANUFACTURING TECHNOLOGY",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies, HVAC Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4801",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credit hours (Fall)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "115",
+              "title": "HACR Safety, Health &amp; Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "116",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "117",
+              "title": "Principles of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "118",
+              "title": "Principles of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: AIR CONDITIONING AND REFRIGERATION HELPER I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours (Spring)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "121",
+              "title": "HACR Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "122",
+              "title": "HACR Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "123",
+              "title": "HACR Electric Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "124",
+              "title": "Applied Electricity &amp; Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: AIR CONDITIONING AND REFRIGERATION HELPER II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 Credit Hours (Fall)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "141",
+              "title": "Domestic Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "142",
+              "title": "Room Air Conditioners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "256",
+              "title": "Residential Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: DOMESTIC AIR CONDITION AND REFRIGERATION",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours (Spring)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "251",
+              "title": "Residential Central Air Conditioning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "252",
+              "title": "Residential Central Air Conditioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "253",
+              "title": "Residential System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "254",
+              "title": "Residential Heating I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "255",
+              "title": "Residential Heating II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ TECHNICAL DIPLOMA: AIR CONDITION AND REFRIGERATION TECHNICIAN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies, Welding Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4803",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credit Hours (Fall)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "129",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: THERMAL CUTTER",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 Credit Hours (Spring)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "106",
+              "title": "SMAW Basic Beads &amp; Fillet Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "108",
+              "title": "SMAW V-Groove BU/Gouge",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "110",
+              "title": "SMAW V-Groove Open",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "Composition and Rhetoric I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CAREER AND TECHNICAL CERTIFICATE: TACK WELDER/PIPE FITTER HELPER",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 Credit Hours (Fall)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "114",
+              "title": "GTAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "116",
+              "title": "GMAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "SMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanties Elective Credit Hours: 3 **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: ARC WELDER- SMAW",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "120",
+              "title": "GTAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "122",
+              "title": "GMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "124",
+              "title": "FCAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Sciences Elective Credit Hours: 3**",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "♦ CERTIFICATE OF TECHNICAL STUDIES: ARC WELDER- GTAW, GMAW, FCAW ♦ TECHNICAL DIPLOMA: WELDING",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Theatre Technician, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4725",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose any four (4) of the following courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "113",
+              "title": "Lighting Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "116",
+              "title": "Stage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "212",
+              "title": "Props Creation and Special Effects for the Stage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "215",
+              "title": "Scene Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "220",
+              "title": "Costume Construction Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4649",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "131",
+              "title": "Elements of Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "112",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "105",
+              "title": "Theatre Lab Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved THTR Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Thermal Cutter, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4797",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "TV Production, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Live Video Productions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "150",
+              "title": "Video Production Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "201",
+              "title": "Video Post-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Editing, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4732",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "109",
+              "title": "Introduction to Audio Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "201",
+              "title": "Video Post-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "216",
+              "title": "Adobe Photoshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "280",
+              "title": "Digital Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Production, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4727",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "150",
+              "title": "Video Production Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "170",
+              "title": "Introduction to Mass Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "202",
+              "title": "Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Live Video Productions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "130",
+              "title": "Film Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "281",
+              "title": "Documentary Filmmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "212",
+              "title": "Announcing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "213",
+              "title": "Voice and Diction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "211",
+              "title": "Newswriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "209",
+              "title": "Scriptwriting for Film and Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COMM Elective Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Virtualization, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4790",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 6 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "114",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA+ Core 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "155",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: CompTIA Network+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 9 hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTEC",
+              "number": "165",
+              "title": "Introduction to Virtualization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "170",
+              "title": "Microsoft Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "263",
+              "title": "Cloud+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Design, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4713",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CTEC Elective Course Credit Hours: 3*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "102",
+              "title": "Problem Solving and Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "130",
+              "title": "HTML5/CSS3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC:&nbsp;HTML/CSS: CIW Advanced HTML5 & CSS3 Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "149",
+              "title": "Web Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: Web Scripting: CIW JavaScript Specialist",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding I, CTS (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4773",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "106",
+              "title": "SMAW Basic Beads &amp; Fillet Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "108",
+              "title": "SMAW V-Groove BU/Gouge",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "110",
+              "title": "SMAW V-Groove Open",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding, TD (Natchitoches and Sabine Valley Campuses)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bpcc.edu/preview_program.php?catoid=19&poid=4758",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 11 Credit Hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "100",
+              "title": "Welding Orientation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEED",
+              "number": "142",
+              "title": "Print Reading for Engineering and Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "102",
+              "title": "Welding Inspection &amp; Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "104",
+              "title": "Oxyfuel Syst &amp; Cutting Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: NC3 Weld Safety ♦CAREER and TECHNICAL CERTIFICATE in Thermal Cutter",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "106",
+              "title": "SMAW Basic Beads &amp; Fillet Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "108",
+              "title": "SMAW V-Groove BU/Gouge",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "110",
+              "title": "SMAW V-Groove Open",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "112",
+              "title": "FCAW Bsc FILT Wld/Bsc Groove W",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: NC3 Introduction Shielded Metal ARC Welding (SMAW) *IBC: NC3 Introduction Flux-Corded ARC Welding (FCAW) ♦CAREER and TECHNICAL CERTIFICATE in Tack Welder/Pipe Fitter Helper",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 10 Credit Hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "114",
+              "title": "GTAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "116",
+              "title": "GMAW Basic Fillet Weld/V-Groov",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "118",
+              "title": "SMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*IBC: NC3 Introduction Gas Metal ARC Welding (GMAW) *IBC: NC3 Introduction Gas Tungsten ARC Welding (GTAW) ♦CERTIFICATE of TECHNICAL STUDIES in ARC Welder SMAW",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "120",
+              "title": "GTAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "122",
+              "title": "GMAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "124",
+              "title": "FCAW Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CERTIFICATE of TECHNICAL STUDIES in ARC Welder GTAW CERTIFICATE of TECHNICAL STUDIES in ARC Welder GMAW CERTIFICATE of TECHNICAL STUDIES in ARC Welder FCAW",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/la/programs/delgado-community-college.json
+++ b/data/la/programs/delgado-community-college.json
@@ -1,0 +1,27603 @@
+{
+  "college_slug": "delgado-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.dcc.edu",
+  "scraped_at": "2026-06-21T05:26:19.948Z",
+  "programs": [
+    {
+      "title": "General Education Requirements",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3152",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNAR",
+              "number": "121",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "125",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "126",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "158",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "227",
+              "title": "Contemporary Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "105",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "108",
+              "title": "Pop Music: Legends of Performance, Culture, and Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "137",
+              "title": "Jazz Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Intro to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "209",
+              "title": "Modern Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "207",
+              "title": "Classical Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "180",
+              "title": "History and Theory of Architecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "207",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "212",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "221",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "222",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "235",
+              "title": "Major World Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "240",
+              "title": "241 - Current Topics in Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "243",
+              "title": "Ethnic Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "244",
+              "title": "African-American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "245",
+              "title": "Introduction to Women’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "253",
+              "title": "The Bible as Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "125",
+              "title": "French Culture Around the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "225",
+              "title": "Perspectives on Contemporary French Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HIST - Any HIST Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "105",
+              "title": "Humanities Through the Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "150",
+              "title": "Structure of Western Thought: Ancient Greece",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "211",
+              "title": "Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "212",
+              "title": "Humanities II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "220",
+              "title": "Modernism in the Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "260",
+              "title": "Activism and Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "175",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "204",
+              "title": "Civilization and Cultures of Hispanoamerica",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ANTH - Any anthropology or geography course with ANTH prefix",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PSYC - Any psychology course with PSYC prefix except PSYC 290",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "155",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "250",
+              "title": "Studies in Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "255",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "257",
+              "title": "Social Gerontology: Aging and the Life Cycle",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENRE",
+              "number": "110",
+              "title": "English Composition I for Non-Native Speakers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "112",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician-Paramedic, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3147",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "225",
+              "title": "Introduction to Preparatory EMS and Patient Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "226",
+              "title": "Introduction to Preparatory EMS and Patient Assessment Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "235",
+              "title": "Acute Medical and Trauma Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "236",
+              "title": "Acute Medical and Trauma Emergencies Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "237",
+              "title": "Acute Medical and Trauma Emergencies Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "245",
+              "title": "Advanced Airway Management and Emergency Cardiac Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "246",
+              "title": "Advanced Airway Management and Emergency Cardiac Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "247",
+              "title": "Advanced Airway Management and Emergency Cardiac Care Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "255",
+              "title": "Obstetrical and Pediatric Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "256",
+              "title": "Obstetrical and Pediatric Emergencies Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "257",
+              "title": "Obstetrical and Pediatric Emergencies Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "265",
+              "title": "Assessment-Based Management and Special Situations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "266",
+              "title": "Assessment-Based Management and Special Situations Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "267",
+              "title": "Assessment-Based Management and Special Situations Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "225",
+              "title": "Introduction to Preparatory EMS and Patient Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "226",
+              "title": "Introduction to Preparatory EMS and Patient Assessment Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "235",
+              "title": "Acute Medical and Trauma Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "236",
+              "title": "Acute Medical and Trauma Emergencies Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "237",
+              "title": "Acute Medical and Trauma Emergencies Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "245",
+              "title": "Advanced Airway Management and Emergency Cardiac Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "246",
+              "title": "Advanced Airway Management and Emergency Cardiac Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "247",
+              "title": "Advanced Airway Management and Emergency Cardiac Care Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "255",
+              "title": "Obstetrical and Pediatric Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "256",
+              "title": "Obstetrical and Pediatric Emergencies Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "257",
+              "title": "Obstetrical and Pediatric Emergencies Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "265",
+              "title": "Assessment-Based Management and Special Situations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "266",
+              "title": "Assessment-Based Management and Special Situations Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "267",
+              "title": "Assessment-Based Management and Special Situations Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography, P.A.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3145",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMSU",
+              "number": "200",
+              "title": "Ultrasound Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "201",
+              "title": "Directed Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "211",
+              "title": "Superficial Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "221",
+              "title": "Physics and Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "222",
+              "title": "Physics and Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "223",
+              "title": "Physics and Instrumentation III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "241",
+              "title": "Ultrasound Learning Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "242",
+              "title": "Ultrasound Learning Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "251",
+              "title": "Ultrasound Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "252",
+              "title": "Ultrasound Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "253",
+              "title": "Ultrasound Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "254",
+              "title": "Ultrasound Practicum IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "261",
+              "title": "Ultrasound Obstetrics and Gynecology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "262",
+              "title": "Ultrasound Obstetrics and Gynecology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "263",
+              "title": "Ultrasound Obstetrics and Gynecology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "271",
+              "title": "Abdominal Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "272",
+              "title": "Abdominal Ultrasound II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "273",
+              "title": "Abdominal Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "280",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMSU",
+              "number": "200",
+              "title": "Ultrasound Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "201",
+              "title": "Directed Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "221",
+              "title": "Physics and Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "241",
+              "title": "Ultrasound Learning Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "251",
+              "title": "Ultrasound Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "261",
+              "title": "Ultrasound Obstetrics and Gynecology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "271",
+              "title": "Abdominal Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMSU",
+              "number": "211",
+              "title": "Superficial Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "222",
+              "title": "Physics and Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "242",
+              "title": "Ultrasound Learning Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "252",
+              "title": "Ultrasound Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "262",
+              "title": "Ultrasound Obstetrics and Gynecology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "272",
+              "title": "Abdominal Ultrasound II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMSU",
+              "number": "223",
+              "title": "Physics and Instrumentation III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "253",
+              "title": "Ultrasound Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "263",
+              "title": "Ultrasound Obstetrics and Gynecology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "273",
+              "title": "Abdominal Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMSU",
+              "number": "254",
+              "title": "Ultrasound Practicum IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMSU",
+              "number": "280",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Funeral Service Education, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3151",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "121",
+              "title": "History and Sociology of Funeral Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "129",
+              "title": "Funeral Home Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "130",
+              "title": "Dynamics of Grief",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "131",
+              "title": "Funeral Directing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "134",
+              "title": "Mortuary Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "135",
+              "title": "Funeral Service Merchandising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "139",
+              "title": "Embalming Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "140",
+              "title": "Embalming Techniques II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "145",
+              "title": "Embalming Laboratory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "146",
+              "title": "Embalming Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "152",
+              "title": "Funeral Service Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "169",
+              "title": "Funeral Directing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "225",
+              "title": "Funeral Service Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "227",
+              "title": "Funeral Service Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "228",
+              "title": "Funeral Services Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "243",
+              "title": "Restorative Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "247",
+              "title": "Restorative Art Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "270",
+              "title": "Funeral Services Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "111",
+              "title": "Fundamentals of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "121",
+              "title": "History and Sociology of Funeral Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "227",
+              "title": "Funeral Service Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "111",
+              "title": "Fundamentals of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "130",
+              "title": "Dynamics of Grief",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "131",
+              "title": "Funeral Directing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "152",
+              "title": "Funeral Service Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "169",
+              "title": "Funeral Directing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 Credit Hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "129",
+              "title": "Funeral Home Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "135",
+              "title": "Funeral Service Merchandising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "139",
+              "title": "Embalming Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "145",
+              "title": "Embalming Laboratory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "225",
+              "title": "Funeral Service Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "228",
+              "title": "Funeral Services Pathology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "134",
+              "title": "Mortuary Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "140",
+              "title": "Embalming Techniques II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "146",
+              "title": "Embalming Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "243",
+              "title": "Restorative Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "247",
+              "title": "Restorative Art Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "270",
+              "title": "Funeral Services Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 Credit Hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3159",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "101",
+              "title": "Fundamentals in Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "102",
+              "title": "Foundation for Swedish Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "103",
+              "title": "Muscle/Skeletal Anatomy and Palpation Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "104",
+              "title": "Anatomy and Physiology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "111",
+              "title": "Sports Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "112",
+              "title": "Deep Tissue Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "113",
+              "title": "Fundamentals of Traditional Chinese Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "114",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "115",
+              "title": "Business/Ethics/Law in Massage Therapy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "120",
+              "title": "Topics for Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "151",
+              "title": "Massage Therapy Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "152",
+              "title": "Massage Therapy Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "153",
+              "title": "Massage Therapy Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding, C.A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3160",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "103",
+              "title": "Basic Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "110",
+              "title": "Basic Medical Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "123",
+              "title": "Basic CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "125",
+              "title": "Health Care Revenue Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "127",
+              "title": "Advanced CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "141",
+              "title": "Medical Coding Revenue Cycle Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "203",
+              "title": "Basic Pathophysiology and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "230",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "230",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "203",
+              "title": "Basic Pathophysiology and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "103",
+              "title": "Basic Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "123",
+              "title": "Basic CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "125",
+              "title": "Health Care Revenue Cycle",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "110",
+              "title": "Basic Medical Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "127",
+              "title": "Advanced CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "141",
+              "title": "Medical Coding Revenue Cycle Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ophthalmic Medical Assistant, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3168",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OPHT",
+              "number": "101",
+              "title": "Introduction to Ophthalmic Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "201",
+              "title": "Anatomy and Physiology for Ophthalmic Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "202",
+              "title": "Principles of Tonometry/Glaucoma",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "203",
+              "title": "Maintenance of Ophthalmic Instruments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "204",
+              "title": "Ophthalmic Medical Assistant Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "205",
+              "title": "Ophthalmic Assisting Skills Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "206",
+              "title": "Ophthalmic Medical Assisting Administrative Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "221",
+              "title": "Basic Ophthalmic Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "222",
+              "title": "Ophthalmic Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "223",
+              "title": "Introduction to Diseases of the Eye",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "224",
+              "title": "Ophthalmic Optics and Basic Refractometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "225",
+              "title": "Ophthalmic Medical Assistant Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "226",
+              "title": "Ophthalmic Medical Assisting Skills Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "227",
+              "title": "Ophthalmic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "101",
+              "title": "Introduction to Ophthalmic Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "201",
+              "title": "Anatomy and Physiology for Ophthalmic Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "202",
+              "title": "Principles of Tonometry/Glaucoma",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "203",
+              "title": "Maintenance of Ophthalmic Instruments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "204",
+              "title": "Ophthalmic Medical Assistant Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "205",
+              "title": "Ophthalmic Assisting Skills Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "206",
+              "title": "Ophthalmic Medical Assisting Administrative Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OPHT",
+              "number": "221",
+              "title": "Basic Ophthalmic Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "222",
+              "title": "Ophthalmic Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "223",
+              "title": "Introduction to Diseases of the Eye",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "224",
+              "title": "Ophthalmic Optics and Basic Refractometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "225",
+              "title": "Ophthalmic Medical Assistant Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OPHT",
+              "number": "226",
+              "title": "Ophthalmic Medical Assisting Skills Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OPHT",
+              "number": "227",
+              "title": "Ophthalmic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3161",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "103",
+              "title": "Introduction to Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "207",
+              "title": "Hematology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "208",
+              "title": "Hematology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "220",
+              "title": "Immunology and Serology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "230",
+              "title": "Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "240",
+              "title": "Clinical Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "242",
+              "title": "Clinical Chemistry Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "245",
+              "title": "Urinalysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "260",
+              "title": "Clinical Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "262",
+              "title": "Clinical Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "264",
+              "title": "Parasitology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "270",
+              "title": "Clinical Immunohematology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "285",
+              "title": "Advanced Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "290",
+              "title": "Seminar in Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Prerequisites to program enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Prerequisites to program enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "103",
+              "title": "Introduction to Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "207",
+              "title": "Hematology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "208",
+              "title": "Hematology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "230",
+              "title": "Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "264",
+              "title": "Parasitology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "220",
+              "title": "Immunology and Serology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "260",
+              "title": "Clinical Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "262",
+              "title": "Clinical Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "240",
+              "title": "Clinical Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "242",
+              "title": "Clinical Chemistry Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "245",
+              "title": "Urinalysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "270",
+              "title": "Clinical Immunohematology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Seventh Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "290",
+              "title": "Seminar in Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Eighth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "285",
+              "title": "Advanced Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Technology, P.A.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3164",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUMT",
+              "number": "200",
+              "title": "Introduction to Nuclear Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "211",
+              "title": "Physics of Nuclear Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "221",
+              "title": "Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "232",
+              "title": "Radiopharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "242",
+              "title": "Radiation Biology and Radiation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "251",
+              "title": "Clinical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "252",
+              "title": "Clinical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "253",
+              "title": "Clinical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "261",
+              "title": "Practicum in Nuclear Medicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "262",
+              "title": "Practicum in Nuclear Medicine II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "263",
+              "title": "Practicum in Nuclear Medicine III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "283",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "270",
+              "title": "Computed Tomography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUMT",
+              "number": "200",
+              "title": "Introduction to Nuclear Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "211",
+              "title": "Physics of Nuclear Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "221",
+              "title": "Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "251",
+              "title": "Clinical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "261",
+              "title": "Practicum in Nuclear Medicine I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUMT",
+              "number": "232",
+              "title": "Radiopharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "242",
+              "title": "Radiation Biology and Radiation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "252",
+              "title": "Clinical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "262",
+              "title": "Practicum in Nuclear Medicine II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "270",
+              "title": "Computed Tomography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUMT",
+              "number": "253",
+              "title": "Clinical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "263",
+              "title": "Practicum in Nuclear Medicine III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUMT",
+              "number": "283",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3167",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "201",
+              "title": "Introduction to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "202",
+              "title": "Group Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "203",
+              "title": "Kinesiology and Occupational Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "204",
+              "title": "Conditions and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "205",
+              "title": "Occupational Theory and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "206",
+              "title": "Therapeutic Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "207",
+              "title": "Community Occupations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "208",
+              "title": "Psychosocial Applications to OT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "211",
+              "title": "Health Care Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "212",
+              "title": "Developmental Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "213",
+              "title": "Neurology and Occupational Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "214",
+              "title": "Conditions and Applications II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "215",
+              "title": "Occupational Theory and Applications II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "217",
+              "title": "Clinical Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "220",
+              "title": "Clinical Applications II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "221",
+              "title": "Occupational Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "240",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "226",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "128",
+                  "title": "Applied Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement Met in Required Related Courses (BIOL)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisites to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "201",
+              "title": "Introduction to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "226",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "240",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisites to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "202",
+              "title": "Group Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "205",
+              "title": "Occupational Theory and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "206",
+              "title": "Therapeutic Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "208",
+              "title": "Psychosocial Applications to OT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "203",
+              "title": "Kinesiology and Occupational Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "204",
+              "title": "Conditions and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "211",
+              "title": "Health Care Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "212",
+              "title": "Developmental Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "215",
+              "title": "Occupational Theory and Applications II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "207",
+              "title": "Community Occupations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "213",
+              "title": "Neurology and Occupational Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "214",
+              "title": "Conditions and Applications II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCTA",
+              "number": "217",
+              "title": "Clinical Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "220",
+              "title": "Clinical Applications II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "221",
+              "title": "Occupational Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician: Advanced-Level Pharmacy Technician, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3170",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "101",
+              "title": "Introduction to Pharmacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "102",
+              "title": "Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "104",
+              "title": "Pharmacology for the Pharmacy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "106",
+              "title": "Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "109",
+              "title": "Body Systems, Diseases, and Drugs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "116",
+              "title": "Pharmacy Math I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "117",
+              "title": "Pharmacy Math II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "122",
+              "title": "Advanced Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "123",
+              "title": "Advanced Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "151",
+              "title": "Pharmacy Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "152",
+              "title": "Pharmacy Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "155",
+              "title": "Pharmacy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "101",
+              "title": "Introduction to Pharmacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "109",
+              "title": "Body Systems, Diseases, and Drugs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "116",
+              "title": "Pharmacy Math I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "102",
+              "title": "Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "104",
+              "title": "Pharmacology for the Pharmacy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "106",
+              "title": "Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "151",
+              "title": "Pharmacy Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "155",
+              "title": "Pharmacy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "117",
+              "title": "Pharmacy Math II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "122",
+              "title": "Advanced Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "123",
+              "title": "Advanced Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "152",
+              "title": "Pharmacy Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiation Therapy, P.A.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3172",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RATH",
+              "number": "210",
+              "title": "Principles and Practice of Radiation Therapy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "212",
+              "title": "Dosimetry and Treatment Planning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "213",
+              "title": "Radiation Therapy Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "215",
+              "title": "Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "216",
+              "title": "Oncologic Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "221",
+              "title": "Radiation Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "223",
+              "title": "Radiation Therapy Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "225",
+              "title": "Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "230",
+              "title": "Principles and Practice of Radiation Therapy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "232",
+              "title": "Dosimetry and Treatment Planning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "233",
+              "title": "Radiation Therapy Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "235",
+              "title": "Clinical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "242",
+              "title": "Advanced Student Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "245",
+              "title": "Clinical Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "246",
+              "title": "Medical Imaging and Sectional Anatomy in Treatment Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "248",
+              "title": "Quality Management and Operational Issues",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RATH",
+              "number": "210",
+              "title": "Principles and Practice of Radiation Therapy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "215",
+              "title": "Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "216",
+              "title": "Oncologic Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "221",
+              "title": "Radiation Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "246",
+              "title": "Medical Imaging and Sectional Anatomy in Treatment Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RATH",
+              "number": "212",
+              "title": "Dosimetry and Treatment Planning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "213",
+              "title": "Radiation Therapy Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "225",
+              "title": "Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "230",
+              "title": "Principles and Practice of Radiation Therapy II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RATH",
+              "number": "223",
+              "title": "Radiation Therapy Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "232",
+              "title": "Dosimetry and Treatment Planning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "233",
+              "title": "Radiation Therapy Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "235",
+              "title": "Clinical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RATH",
+              "number": "242",
+              "title": "Advanced Student Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "245",
+              "title": "Clinical Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RATH",
+              "number": "248",
+              "title": "Quality Management and Operational Issues",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3174",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "113",
+              "title": "Introduction to Clinical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "114",
+              "title": "Patient Assessment for Respiratory Therapists",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "115",
+              "title": "Body Structure and Function for Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "116",
+              "title": "Respiratory Equipment I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "118",
+              "title": "Respiratory Equipment I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "120",
+              "title": "Respiratory Equipment II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "122",
+              "title": "Respiratory Equipment II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "124",
+              "title": "Introduction to Cardiopulmonary Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "126",
+              "title": "Critical Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "136",
+              "title": "Critical Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "150",
+              "title": "Respiratory Care Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "155",
+              "title": "Respiratory Care Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "250",
+              "title": "Pulmonary Function Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "251",
+              "title": "Advanced Cardiopulmonary Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "252",
+              "title": "Pediatric and Neonatal Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "254",
+              "title": "Clinical Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "255",
+              "title": "Respiratory Care Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "256",
+              "title": "Respiratory Care Practicum IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "257",
+              "title": "Pharmacology for Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "258",
+              "title": "Proficiency Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "260",
+              "title": "Physicians’ Lectures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "262",
+              "title": "Clinical Simulations in Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select One (1) Lecture/Lab pair from the following list:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIOL",
+                  "number": "163",
+                  "title": "Introductory Anatomy and Physiology Laboratory"
+                }
+              ]
+            },
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement met in Required Related courses (BIOL 211 or BIOL 251 or CHEM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Requirement met in Required Related coursework (PSYC 127)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIOL",
+                  "number": "163",
+                  "title": "Introductory Anatomy and Physiology Laboratory"
+                }
+              ]
+            },
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Completed prior to enrolling in programmatic courses.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Completed prior to enrollment in programmatic courses.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "113",
+              "title": "Introduction to Clinical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "114",
+              "title": "Patient Assessment for Respiratory Therapists",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "115",
+              "title": "Body Structure and Function for Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "116",
+              "title": "Respiratory Equipment I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "118",
+              "title": "Respiratory Equipment I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "120",
+              "title": "Respiratory Equipment II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "122",
+              "title": "Respiratory Equipment II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "124",
+              "title": "Introduction to Cardiopulmonary Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "126",
+              "title": "Critical Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "150",
+              "title": "Respiratory Care Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "136",
+              "title": "Critical Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "155",
+              "title": "Respiratory Care Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "257",
+              "title": "Pharmacology for Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "250",
+              "title": "Pulmonary Function Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "251",
+              "title": "Advanced Cardiopulmonary Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "252",
+              "title": "Pediatric and Neonatal Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "255",
+              "title": "Respiratory Care Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Seventh Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RSPT",
+              "number": "254",
+              "title": "Clinical Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "256",
+              "title": "Respiratory Care Practicum IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "258",
+              "title": "Proficiency Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "260",
+              "title": "Physicians’ Lectures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RSPT",
+              "number": "262",
+              "title": "Clinical Simulations in Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3171",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "201",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "202",
+              "title": "Health Care Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "203",
+              "title": "Functional Anatomy and Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "204",
+              "title": "Pathophysiological Conditions I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "205",
+              "title": "Clinical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "206",
+              "title": "Clinical Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "207",
+              "title": "Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "211",
+              "title": "The Health Care System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "212",
+              "title": "Development Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "213",
+              "title": "Functional Anatomy &amp; Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "214",
+              "title": "Pathophysiological Conditions II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "215",
+              "title": "Clinical Science III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "216",
+              "title": "Clinical Science IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "217",
+              "title": "Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "221",
+              "title": "Physical Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "227",
+              "title": "Clinical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisites to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisites to enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "201",
+              "title": "Introduction to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "202",
+              "title": "Health Care Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "203",
+              "title": "Functional Anatomy and Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "204",
+              "title": "Pathophysiological Conditions I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "205",
+              "title": "Clinical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "206",
+              "title": "Clinical Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "207",
+              "title": "Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "211",
+              "title": "The Health Care System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "212",
+              "title": "Development Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "213",
+              "title": "Functional Anatomy &amp; Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "214",
+              "title": "Pathophysiological Conditions II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "215",
+              "title": "Clinical Science III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "216",
+              "title": "Clinical Science IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "217",
+              "title": "Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTAP",
+              "number": "221",
+              "title": "Physical Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAP",
+              "number": "227",
+              "title": "Clinical Practice III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3173",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "212",
+              "title": "Pathology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "101",
+              "title": "Radiologic Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "102",
+              "title": "Radiologic Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "111",
+              "title": "Radiographic Positioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "113",
+              "title": "Radiographic Anatomy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "151",
+              "title": "Radiographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "152",
+              "title": "Radiographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "153",
+              "title": "Radiographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "211",
+              "title": "Advanced Radiographic Positioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "212",
+              "title": "Specialized Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "221",
+              "title": "Imaging Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "241",
+              "title": "Advanced Radiographic Technique",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "242",
+              "title": "Radiation Biology and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "251",
+              "title": "Advanced Radiographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "252",
+              "title": "Advanced Radiographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "253",
+              "title": "Advanced Radiographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "260",
+              "title": "Radiographic Technology Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 20 credit hours",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "101",
+              "title": "Radiologic Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "113",
+              "title": "Radiographic Anatomy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "151",
+              "title": "Radiographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "102",
+              "title": "Radiologic Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "111",
+              "title": "Radiographic Positioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "152",
+              "title": "Radiographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "212",
+              "title": "Pathology and Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "153",
+              "title": "Radiographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "211",
+              "title": "Advanced Radiographic Positioning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "212",
+              "title": "Specialized Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "241",
+              "title": "Advanced Radiographic Technique",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "251",
+              "title": "Advanced Radiographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "221",
+              "title": "Imaging Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "242",
+              "title": "Radiation Biology and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "252",
+              "title": "Advanced Radiographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "253",
+              "title": "Advanced Radiographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "260",
+              "title": "Radiographic Technology Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3178",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Animal Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Veterinary Office Procedures &amp; Hospital Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "105",
+              "title": "Animal Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "106",
+              "title": "Animal Anatomy &amp; Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "121",
+              "title": "Animal Nursing Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "125",
+              "title": "Pharmacology for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "127",
+              "title": "Veterinary Technology Dentistry Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "131",
+              "title": "Surgical Nursing for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "135",
+              "title": "Clinical Pathology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "136",
+              "title": "Clinical Pathology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "141",
+              "title": "Anesthesia for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "145",
+              "title": "Radiology for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "157",
+              "title": "Clinical Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "205",
+              "title": "Small Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "207",
+              "title": "Avian and Exotic Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "211",
+              "title": "Laboratory Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "221",
+              "title": "Animal Nursing Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "227",
+              "title": "Clinical Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "235",
+              "title": "Clinical Pathology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "241",
+              "title": "Large Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "251",
+              "title": "Veterinary Technology Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Completed prior to enrolling in programmatic courses.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Animal Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Veterinary Office Procedures &amp; Hospital Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "105",
+              "title": "Animal Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "106",
+              "title": "Animal Anatomy &amp; Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "125",
+              "title": "Pharmacology for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "121",
+              "title": "Animal Nursing Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "127",
+              "title": "Veterinary Technology Dentistry Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "131",
+              "title": "Surgical Nursing for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "135",
+              "title": "Clinical Pathology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "136",
+              "title": "Clinical Pathology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "141",
+              "title": "Anesthesia for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "145",
+              "title": "Radiology for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "157",
+              "title": "Clinical Externship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "205",
+              "title": "Small Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "207",
+              "title": "Avian and Exotic Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "221",
+              "title": "Animal Nursing Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "227",
+              "title": "Clinical Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "235",
+              "title": "Clinical Pathology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "211",
+              "title": "Laboratory Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "241",
+              "title": "Large Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "251",
+              "title": "Veterinary Technology Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy, C.T.S. (Fall Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3232",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Prerequisites to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "101",
+              "title": "Fundamentals in Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "102",
+              "title": "Foundation for Swedish Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "103",
+              "title": "Muscle/Skeletal Anatomy and Palpation Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "114",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**MSTH 114 may be taken in the second or third semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8-10 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "104",
+              "title": "Anatomy and Physiology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "112",
+              "title": "Deep Tissue Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "114",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "151",
+              "title": "Massage Therapy Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**MSTH 114 may be taken in the second or third semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6-8 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "111",
+              "title": "Sports Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "115",
+              "title": "Business/Ethics/Law in Massage Therapy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "152",
+              "title": "Massage Therapy Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "113",
+              "title": "Fundamentals of Traditional Chinese Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "120",
+              "title": "Topics for Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "153",
+              "title": "Massage Therapy Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Registration Specialist, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3189",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "121",
+              "title": "Business Math with Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "146",
+              "title": "Medical Registration Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "121",
+              "title": "Business Math with Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "146",
+              "title": "Medical Registration Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sleep Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3190",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSOM",
+              "number": "105",
+              "title": "Introduction to Sleep and Wake",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "107",
+              "title": "Fundamentals of Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "109",
+              "title": "Anatomy &amp; Physiology of Sleep and Breathing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "112",
+              "title": "Pathophysiology and Classification of Sleep Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "115",
+              "title": "Instrumentation in Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "117",
+              "title": "Monitoring and Introduction to Therapeutic Interventions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "120",
+              "title": "Polysomnographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "200",
+              "title": "Polysomnographic Theory Integration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "207",
+              "title": "Polysomnographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "209",
+              "title": "Therapeutic Interventions for Polysomnographic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "210",
+              "title": "Polysomnographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "220",
+              "title": "Polysomnographic Professional Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "112",
+              "title": "Advanced Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisite to enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "112",
+              "title": "Advanced Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisite to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSOM",
+              "number": "105",
+              "title": "Introduction to Sleep and Wake",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "107",
+              "title": "Fundamentals of Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "109",
+              "title": "Anatomy &amp; Physiology of Sleep and Breathing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSOM",
+              "number": "112",
+              "title": "Pathophysiology and Classification of Sleep Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "115",
+              "title": "Instrumentation in Polysomnography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "117",
+              "title": "Monitoring and Introduction to Therapeutic Interventions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "120",
+              "title": "Polysomnographic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSOM",
+              "number": "200",
+              "title": "Polysomnographic Theory Integration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "207",
+              "title": "Polysomnographic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSOM",
+              "number": "209",
+              "title": "Therapeutic Interventions for Polysomnographic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "210",
+              "title": "Polysomnographic Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSOM",
+              "number": "220",
+              "title": "Polysomnographic Professional Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Funeral Services, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3222",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "121",
+              "title": "History and Sociology of Funeral Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "130",
+              "title": "Dynamics of Grief",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "131",
+              "title": "Funeral Directing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "152",
+              "title": "Funeral Service Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "169",
+              "title": "Funeral Directing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "227",
+              "title": "Funeral Service Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "111",
+              "title": "Fundamentals of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "111",
+              "title": "Fundamentals of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "121",
+              "title": "History and Sociology of Funeral Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "130",
+              "title": "Dynamics of Grief",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "131",
+              "title": "Funeral Directing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "152",
+              "title": "Funeral Service Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSED",
+              "number": "227",
+              "title": "Funeral Service Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSED",
+              "number": "169",
+              "title": "Funeral Directing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 1 credit hour",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy, C.T.S. (Spring Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3233",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Prerequisites to enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "101",
+              "title": "Fundamentals in Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "102",
+              "title": "Foundation for Swedish Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "103",
+              "title": "Muscle/Skeletal Anatomy and Palpation Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "114",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**MSTH 114 may be taken in the second or fourth semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8-10 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "111",
+              "title": "Sports Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "115",
+              "title": "Business/Ethics/Law in Massage Therapy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "151",
+              "title": "Massage Therapy Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "113",
+              "title": "Fundamentals of Traditional Chinese Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "114",
+              "title": "Pathology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "120",
+              "title": "Topics for Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "152",
+              "title": "Massage Therapy Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**MSTH 114 may be taken in the second or fourth semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7-9 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSTH",
+              "number": "104",
+              "title": "Anatomy and Physiology for Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "112",
+              "title": "Deep Tissue Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSTH",
+              "number": "153",
+              "title": "Massage Therapy Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrocardiographic (EKG) Technician, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3248",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "161",
+              "title": "Introduction to Electrocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "162",
+              "title": "Electrocardiography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "161",
+              "title": "Introduction to Electrocardiography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "162",
+              "title": "Electrocardiography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician- Basic, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3249",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "112",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "112",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Technician, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3250",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "104",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "105",
+              "title": "Structure and Function of the Body Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "151",
+              "title": "Phlebotomy Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLTS",
+              "number": "104",
+              "title": "Introduction to Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "105",
+              "title": "Structure and Function of the Body Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLTS",
+              "number": "151",
+              "title": "Phlebotomy Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dialysis Technician, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3251",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "130",
+              "title": "Introduction to Dialysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "131",
+              "title": "Dialysis Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "132",
+              "title": "Dialysis Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "130",
+              "title": "Introduction to Dialysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "131",
+              "title": "Dialysis Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "132",
+              "title": "Dialysis Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Central Sterile Processing, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3258",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "101",
+              "title": "Introduction to Surgical Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "103",
+              "title": "Central Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "105",
+              "title": "Central Processing Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "107",
+              "title": "Central Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "109",
+              "title": "Central Processing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "111",
+              "title": "Central Processing Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "102",
+              "title": "Microbiology for Surgical Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "101",
+              "title": "Introduction to Surgical Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "103",
+              "title": "Central Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "105",
+              "title": "Central Processing Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "102",
+              "title": "Microbiology for Surgical Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCSP",
+              "number": "107",
+              "title": "Central Processing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "109",
+              "title": "Central Processing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCSP",
+              "number": "111",
+              "title": "Central Processing Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician: Entry Level Pharmacy Technician, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3270",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "101",
+              "title": "Introduction to Pharmacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "102",
+              "title": "Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "104",
+              "title": "Pharmacology for the Pharmacy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "106",
+              "title": "Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "109",
+              "title": "Body Systems, Diseases, and Drugs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "116",
+              "title": "Pharmacy Math I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "151",
+              "title": "Pharmacy Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "155",
+              "title": "Pharmacy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "101",
+              "title": "Introduction to Pharmacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "109",
+              "title": "Body Systems, Diseases, and Drugs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "116",
+              "title": "Pharmacy Math I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHAR",
+              "number": "102",
+              "title": "Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "104",
+              "title": "Pharmacology for the Pharmacy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "106",
+              "title": "Pharmacy Practice Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "151",
+              "title": "Pharmacy Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHAR",
+              "number": "155",
+              "title": "Pharmacy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Assistant, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3271",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETA",
+              "number": "103",
+              "title": "Veterinary Assistant Husbandry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "105",
+              "title": "Veterinary Assistant Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "107",
+              "title": "Veterinary Assistant Clinical Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "109",
+              "title": "Veterinary Assistant Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "111",
+              "title": "Veterinary Assistant Radiology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "115",
+              "title": "Veterinary Assistant Pharmacy Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "200",
+              "title": "Veterinary Assistant Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Veterinary Office Procedures &amp; Hospital Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Animal Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETT",
+              "number": "101",
+              "title": "Animal Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "103",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisites to enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETA",
+              "number": "103",
+              "title": "Veterinary Assistant Husbandry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "105",
+              "title": "Veterinary Assistant Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "107",
+              "title": "Veterinary Assistant Clinical Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "109",
+              "title": "Veterinary Assistant Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETT",
+              "number": "102",
+              "title": "Veterinary Office Procedures &amp; Hospital Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VETA",
+              "number": "111",
+              "title": "Veterinary Assistant Radiology Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "115",
+              "title": "Veterinary Assistant Pharmacy Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VETA",
+              "number": "200",
+              "title": "Veterinary Assistant Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3274",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURG",
+              "number": "101",
+              "title": "Introduction to Medical-Legal Aspects of Surgery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "111",
+              "title": "Surgical Instruments and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "121",
+              "title": "Introduction to Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "141",
+              "title": "Introduction to Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "201",
+              "title": "Clinical Specialties",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "202",
+              "title": "Clinical Specialties II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "211",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "212",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "213",
+              "title": "Clinical Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "215",
+              "title": "SACK Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "114",
+              "title": "Introduction to Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "114",
+              "title": "Introduction to Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Completed prior to enrolling in programmatic courses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURG",
+              "number": "101",
+              "title": "Introduction to Medical-Legal Aspects of Surgery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "111",
+              "title": "Surgical Instruments and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "121",
+              "title": "Introduction to Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "141",
+              "title": "Introduction to Clinical Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURG",
+              "number": "201",
+              "title": "Clinical Specialties",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "211",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURG",
+              "number": "202",
+              "title": "Clinical Specialties II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "212",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "213",
+              "title": "Clinical Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "215",
+              "title": "SACK Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3308",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "103",
+              "title": "Introduction to Medical Ethics and Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "112",
+              "title": "Advanced Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "142",
+              "title": "Human Diseases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "151",
+              "title": "Introduction to Health Care Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HESC Electives 6 (Choose from approved HESC Elective list)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "HESC ELECTIVES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "102",
+              "title": "First Aid",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "109",
+              "title": "Medical Nutrition Therapy for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "114",
+              "title": "Introduction to Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "125",
+              "title": "Health Care Systems and Structure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "151",
+              "title": "Introduction to Health Care Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "103",
+              "title": "Introduction to Medical Ethics and Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HESC Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "112",
+              "title": "Advanced Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "142",
+              "title": "Human Diseases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HESC Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Invasive Cardiovascular Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3313",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "100",
+              "title": "Cardiovascular Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "101",
+              "title": "Rhythm Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "102",
+              "title": "Patient Care and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "103",
+              "title": "Principles of Radiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "110",
+              "title": "Aseptic Technique",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "111",
+              "title": "Aseptic Technique Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "120",
+              "title": "invasive Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "125",
+              "title": "Invasive Procedures Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "130",
+              "title": "Pharmacology and Medication Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "220",
+              "title": "Invasive Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "225",
+              "title": "Invasive Clinical Rotation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "250",
+              "title": "Invasive Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "255",
+              "title": "Invasive Clinical Rotation II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisite to program enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "** Prerequisite to program enrollment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "100",
+              "title": "Cardiovascular Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "101",
+              "title": "Rhythm Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "102",
+              "title": "Patient Care and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "103",
+              "title": "Principles of Radiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "110",
+              "title": "Aseptic Technique",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "111",
+              "title": "Aseptic Technique Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "120",
+              "title": "invasive Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "125",
+              "title": "Invasive Procedures Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "130",
+              "title": "Pharmacology and Medication Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "220",
+              "title": "Invasive Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "225",
+              "title": "Invasive Clinical Rotation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "250",
+              "title": "Invasive Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "255",
+              "title": "Invasive Clinical Rotation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Invasive Cardiovascular Technology, P.A.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3314",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "100",
+              "title": "Cardiovascular Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "101",
+              "title": "Rhythm Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "102",
+              "title": "Patient Care and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "120",
+              "title": "invasive Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "130",
+              "title": "Pharmacology and Medication Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "220",
+              "title": "Invasive Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "225",
+              "title": "Invasive Clinical Rotation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "250",
+              "title": "Invasive Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "255",
+              "title": "Invasive Clinical Rotation II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "100",
+              "title": "Cardiovascular Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "101",
+              "title": "Rhythm Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "102",
+              "title": "Patient Care and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "130",
+              "title": "Pharmacology and Medication Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "120",
+              "title": "invasive Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "220",
+              "title": "Invasive Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "225",
+              "title": "Invasive Clinical Rotation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICVT",
+              "number": "250",
+              "title": "Invasive Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICVT",
+              "number": "255",
+              "title": "Invasive Clinical Rotation II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Criminal Justice",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3212",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "105",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "101",
+              "title": "Introduction to Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "103",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Literature, 2XX level, 3 credit hours (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "230",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "231",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science or Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Emergency Medical Technician- Advanced C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3387",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "215",
+              "title": "Advanced Emergency Medical Technician (AEMT)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "216",
+              "title": "Advanced Emergency Medical Technician Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "217",
+              "title": "Advanced Emergency Medical Technician Clincal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMTE",
+              "number": "215",
+              "title": "Advanced Emergency Medical Technician (AEMT)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "216",
+              "title": "Advanced Emergency Medical Technician Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMTE",
+              "number": "217",
+              "title": "Advanced Emergency Medical Technician Clincal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3155",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "102",
+              "title": "Legal Aspects of Health Information",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "103",
+              "title": "Basic Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "104",
+              "title": "Health Records Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "110",
+              "title": "Basic Medical Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "125",
+              "title": "Health Care Revenue Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "151",
+              "title": "Healthcare Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "201",
+              "title": "Introduction to Health Care Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "203",
+              "title": "Basic Pathophysiology and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "205",
+              "title": "Health Record Content and Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "211",
+              "title": "Performance Improvement in Health Information Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "212",
+              "title": "Advanced Medical Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "251",
+              "title": "Health Information Revenue Cycle Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "252",
+              "title": "Health Information Technology Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "253",
+              "title": "Health Information Technology Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "203",
+              "title": "Basic Pathophysiology and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "102",
+              "title": "Legal Aspects of Health Information",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "205",
+              "title": "Health Record Content and Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "253",
+              "title": "Health Information Technology Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "103",
+              "title": "Basic Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "125",
+              "title": "Health Care Revenue Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "212",
+              "title": "Advanced Medical Coding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "110",
+              "title": "Basic Medical Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "201",
+              "title": "Introduction to Health Care Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 5 credit hours",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "151",
+              "title": "Healthcare Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "207",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "251",
+              "title": "Health Information Revenue Cycle Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Seventh Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEIT",
+              "number": "104",
+              "title": "Health Records Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "211",
+              "title": "Performance Improvement in Health Information Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "252",
+              "title": "Health Information Technology Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Concentration in Humanities",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3213",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Fine Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3214",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "2 Fine Arts (FNAR), Theatre (THEA), or Music (MUSC) courses, 6 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "2 Fine Arts (FNAR), Theatre (THEA), or Music (MUSC) courses, 6 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Concentration in Social Sciences",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3215",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Mathematics course, 3 credit hours, (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Biological Sciences",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3216",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "142",
+              "title": "General Biology II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "144",
+              "title": "General Biology II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "131",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "144",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "141",
+              "title": "Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "143",
+              "title": "Physics I Lab (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language course, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Literature, 2XX level, 3 credit hours (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "142",
+              "title": "Physics II (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "144",
+              "title": "Physics II Lab (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Biology course (BIOL), 3 credit hours (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language course, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Physical Sciences",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3217",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "221",
+              "title": "Physics I (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "223",
+              "title": "Physics I Lab (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "221",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "228",
+              "title": "Physics II (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "144",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "224",
+              "title": "Physics II Lab (Calculus Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "222",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement (Science Majors), 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective, 3 credit hours (speak to an advisor to determine best course for transferability to senior college)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in General Business",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3195",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "115",
+              "title": "Starting a New Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "210",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select nine (9) hours from courses with the following prefixes: ACCT, BUSG (102 or above), BUSL, CMIN, ECON, MANG, MARK, or RLST.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Human Resource Management/Leadership",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3196",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "131",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "235",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "224",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Entrepreneurship/Small Business Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3197",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "222",
+              "title": "Computerized Accounting Using QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "115",
+              "title": "Starting a New Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "252",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "222",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Music Business",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3198",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "101",
+              "title": "Introduction to Music Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "102",
+              "title": "Music Publishing and Copyright",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "103",
+              "title": "Music Marketing and Promotion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "206",
+              "title": "Music Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose two (2) courses from the following list:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "115",
+              "title": "Starting a New Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "252",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "222",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "224",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "275",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "214",
+              "title": "Sports and Entertainment Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "105",
+              "title": "Seminar in Recording Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "200",
+              "title": "Live Audio Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "204",
+              "title": "Basic Audio Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSB",
+              "number": "205",
+              "title": "Seminar in Recording Techniques II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Office Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3199",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "105",
+              "title": "Survey of Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "121",
+              "title": "Business Math with Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "131",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one (1) course from the following list:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "218",
+              "title": "Payroll",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "222",
+              "title": "Computerized Accounting Using QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "101",
+              "title": "Human Relations in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "224",
+              "title": "Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Real Estate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3200",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLST",
+              "number": "161",
+              "title": "Principles of Real Estate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RLST",
+              "number": "261",
+              "title": "Louisiana Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Logistics Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3201",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "206",
+              "title": "Introduction to Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "208",
+              "title": "Transportation Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "229",
+              "title": "Supply Chain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "220",
+              "title": "Introduction to Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "230",
+              "title": "Warehouse and Inventory Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "265",
+              "title": "Manufacturing Logistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Civil Construction",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3202",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "125",
+              "title": "Introduction to Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "100",
+              "title": "Elementary Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "201",
+              "title": "Introduction to CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "115",
+              "title": "Civil Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "150",
+              "title": "Materials of Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "155",
+              "title": "Design and Control of Concrete Mixtures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIVT",
+              "number": "105",
+              "title": "Advanced Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "201",
+              "title": "Structural Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "222",
+              "title": "Micro-Computer Applications in Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "232",
+              "title": "Project Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "107",
+              "title": "Introduction to Concepts in Physics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "160",
+              "title": "Construction Practices and Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "165",
+              "title": "Office Practices and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "202",
+              "title": "Structural Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "251",
+              "title": "Soil Mechanics and Foundation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "256",
+              "title": "Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "287",
+              "title": "Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Construction Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3203",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "125",
+              "title": "Introduction to Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "100",
+              "title": "Elementary Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "201",
+              "title": "Introduction to CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "115",
+              "title": "Civil Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "150",
+              "title": "Materials of Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "155",
+              "title": "Design and Control of Concrete Mixtures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIVT",
+              "number": "201",
+              "title": "Structural Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "222",
+              "title": "Micro-Computer Applications in Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "232",
+              "title": "Project Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "107",
+              "title": "Introduction to Concepts in Physics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "201",
+              "title": "Engineering Economics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "160",
+              "title": "Construction Practices and Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "165",
+              "title": "Office Practices and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "202",
+              "title": "Structural Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "240",
+              "title": "Construction Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "287",
+              "title": "Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIVT",
+              "number": "288",
+              "title": "Construction Contracting and Laws",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Biomedical Equipment Repair",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3204",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "103",
+              "title": "Electrical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "104",
+              "title": "Electrical Principles Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "106",
+              "title": "Shop Practices Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "148",
+              "title": "Solid State Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "152",
+              "title": "Basic Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "154",
+              "title": "Basic Electronics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "271",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "213",
+              "title": "Medical Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "214",
+              "title": "Medical Electronics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "240",
+              "title": "Computers for Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "107",
+              "title": "Introduction to Concepts in Physics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "291",
+              "title": "Microprocessors and Advanced Digital Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "215",
+              "title": "Biomedical Instrumentation Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "216",
+              "title": "Biomedical Instrumentation Systems Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "251",
+              "title": "Biomedical Equipment Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Computer and Electronics Repair",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3205",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "103",
+              "title": "Electrical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "104",
+              "title": "Electrical Principles Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "106",
+              "title": "Shop Practices Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "148",
+              "title": "Solid State Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "152",
+              "title": "Basic Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "154",
+              "title": "Basic Electronics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "240",
+              "title": "Computers for Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "271",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "107",
+              "title": "Introduction to Concepts in Physics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "291",
+              "title": "Microprocessors and Advanced Digital Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Programmer/Analyst",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3207",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "136",
+              "title": "Visual Basic Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "173",
+              "title": "Database Managment Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "235",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "238",
+              "title": "Systems and Analysis Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Web Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3208",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "127",
+              "title": "Photo Editing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "224",
+              "title": "Back-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Information Security/Assurance",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3209",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "253",
+              "title": "Digital Analysis and Cybercrime",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Game Developer",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3210",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "161",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "162",
+              "title": "Game Structure and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "167",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "261",
+              "title": "Game Development for Virtual Reality (VR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Professional Culinarian",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3219",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "101",
+              "title": "Introduction to Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "103",
+              "title": "Food Safety and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "213",
+              "title": "Nutrition for the Culinary Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "227",
+              "title": "Menu Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "130",
+                  "title": "College Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "102",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "105",
+              "title": "Theory of Meat, Poultry, and Seafood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "107",
+              "title": "Foodservice Purchasing and Storeroom Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "121",
+              "title": "American Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "207",
+              "title": "Fundamentals of Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "208",
+              "title": "Soups, Stocks, and Sauces",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "215",
+              "title": "Food, Sales, Beverage, and Labor Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "Introduction to Garde-Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "211",
+              "title": "Dessert Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "226",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Culinary Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Dining Room and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "217",
+              "title": "Culinary Cafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "233",
+              "title": "Culinary Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Baking and Pastry Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3220",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "101",
+              "title": "Introduction to Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "103",
+              "title": "Food Safety and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "213",
+              "title": "Nutrition for the Culinary Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "227",
+              "title": "Menu Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "101",
+              "title": "Introduction to Baking and Pastry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "102",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "107",
+              "title": "Foodservice Purchasing and Storeroom Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "207",
+              "title": "Fundamentals of Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "102",
+              "title": "Baking and Pastry Skills Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAST",
+              "number": "103",
+              "title": "Baking and Pastry Skills Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "199",
+              "title": "Cake Baking, Design, and Decoration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Culinary Elective, 1 credit hour",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 8 credit hours",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Dining Room and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "215",
+              "title": "Food, Sales, Beverage, and Labor Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "200",
+              "title": "Contemporary Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "204",
+              "title": "Specialty Decoration and Showpiece Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Culinary Elective, 2 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAST",
+              "number": "218",
+              "title": "Baking and Pastry Cafe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAST",
+              "number": "233",
+              "title": "Pastry Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Restaurant Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3223",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "107",
+              "title": "Foodservice Purchasing and Storeroom Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Dining Room and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "104",
+              "title": "Hotel Systems and Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "215",
+              "title": "Food, Sales, Beverage, and Labor Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "227",
+              "title": "Menu Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "214",
+              "title": "Wine Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Hotel & Lodging Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3224",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "104",
+              "title": "Hotel Systems and Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "191",
+              "title": "Reservations and Ticketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "212",
+              "title": "Tour and Travel Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "213",
+              "title": "Geographic Destinations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "216",
+              "title": "Convention Management and Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "214",
+              "title": "Sports and Entertainment Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Tourism Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3225",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "200",
+              "title": "Hospitality Revenue Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hospitality Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "201",
+              "title": "Hospitality Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "221",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "212",
+              "title": "Tour and Travel Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "213",
+              "title": "Geographic Destinations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "128",
+                  "title": "Applied Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "250",
+              "title": "Studies in Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hospitality Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "231",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "283",
+              "title": "Overview of New Orleans",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Beverage Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3228",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "200",
+              "title": "Hospitality Revenue Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hospitality Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "201",
+              "title": "Hospitality Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "215",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "221",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "215",
+              "title": "Food, Sales, Beverage, and Labor Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "214",
+              "title": "Wine Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "250",
+              "title": "Studies in Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "231",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Dining Room and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hour",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Meeting and Event Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3229",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "205",
+              "title": "Introduction to Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Dining Room and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "215",
+              "title": "Food, Sales, Beverage, and Labor Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "104",
+              "title": "Hotel Systems and Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "227",
+              "title": "Menu Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "230",
+              "title": "On-Premises Catering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "214",
+              "title": "Sports and Entertainment Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Catering Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3230",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOST",
+              "number": "101",
+              "title": "Introduction to Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "103",
+              "title": "Introduction to Travel and Tourism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "200",
+              "title": "Hospitality Revenue Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hospitality Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "214",
+              "title": "Restaurant and Hospitality Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "201",
+              "title": "Hospitality Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "210",
+              "title": "Hospitality Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "215",
+              "title": "Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "221",
+              "title": "Hospitality Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOST",
+              "number": "214",
+              "title": "Wine Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "250",
+              "title": "Studies in Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hospitality Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "231",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "230",
+              "title": "On-Premises Catering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Business Systems Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3260",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "275",
+              "title": "Agile Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "276",
+              "title": "Foundations of Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "211",
+              "title": "Personal Selling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Concentration in Banking and Lending Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3262",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "102",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "129",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "145",
+              "title": "Principles of Banking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "165",
+              "title": "Consumer Lending",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "240",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MARK",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Banking elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSG",
+              "number": "275",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSL",
+              "number": "250",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Banking elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing – Practical Nursing, T.D.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3165",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PREREQUISITES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "109",
+              "title": "Medical Nutrition Therapy for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "105",
+              "title": "Pharmacology in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "101",
+              "title": "Introduction to Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "103",
+              "title": "Essential Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "110",
+              "title": "Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "117",
+              "title": "Pediatric, Obstetrical, and Mental Health Nursing for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "124",
+              "title": "Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "128",
+              "title": "Career Preparations for the Practical Nursing Student",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Practical Nursing, T.D. (Fall Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3206",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "109",
+              "title": "Medical Nutrition Therapy for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "105",
+              "title": "Pharmacology in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "101",
+              "title": "Introduction to Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "103",
+              "title": "Essential Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "110",
+              "title": "Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "117",
+              "title": "Pediatric, Obstetrical, and Mental Health Nursing for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "124",
+              "title": "Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "128",
+              "title": "Career Preparations for the Practical Nursing Student",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing – Practical Nursing, T.D. (Spring Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3218",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "109",
+              "title": "Medical Nutrition Therapy for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 7 credit hours",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "105",
+              "title": "Pharmacology in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "101",
+              "title": "Introduction to Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "103",
+              "title": "Essential Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "117",
+              "title": "Pediatric, Obstetrical, and Mental Health Nursing for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "110",
+              "title": "Medical-Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRNU",
+              "number": "124",
+              "title": "Medical-Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRNU",
+              "number": "128",
+              "title": "Career Preparations for the Practical Nursing Student",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Certified Nursing Assistant, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3252",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "100",
+              "title": "Essentials of Nursing Assisting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "100",
+              "title": "Essentials of Nursing Assisting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing – Registered Nursing, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3166",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "113",
+              "title": "Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "117",
+              "title": "Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "125",
+              "title": "Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "127",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "129",
+              "title": "Special Populations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "223",
+              "title": "Special Populations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "225",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "235",
+              "title": "Nursing IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "267",
+              "title": "Clinical Reasoning and Decision Making",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts OR Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "113",
+              "title": "Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "117",
+              "title": "Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 Credit Hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "125",
+              "title": "Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "127",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "129",
+              "title": "Special Populations I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 Credit Hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "220",
+              "title": "Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "223",
+              "title": "Special Populations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "225",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "235",
+              "title": "Nursing IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "267",
+              "title": "Clinical Reasoning and Decision Making",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts OR Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 Credit Hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Concentration in Biotechnology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3234",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "144",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "130",
+              "title": "Introduction to Science Laboratory Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "132",
+              "title": "Science Laboratory Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "265",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIOL",
+                  "number": "266",
+                  "title": "Cell Biology Lab"
+                }
+              ]
+            },
+            {
+              "prefix": "CHEM",
+              "number": "222",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "224",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "274",
+              "title": "Introduction to Nucleic Acids",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "223",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/ Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved SLT elective course 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTEC",
+              "number": "275",
+              "title": "Introduction to Protein Expression and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "282",
+              "title": "Introduction to Molecular and Genetic Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "285",
+              "title": "Bioinformatics and Bioethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "299",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Concentration in Chemical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3235",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "130",
+              "title": "Introduction to Science Laboratory Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "144",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "132",
+              "title": "Science Laboratory Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "223",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "241",
+              "title": "Analytical Chemistry (Quantitative Analysis)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "243",
+              "title": "Analytical Chemistry Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "261",
+              "title": "Instrumental Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "265",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "266",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "222",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "224",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "271",
+              "title": "Applied Instrumental Analysis I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "272",
+              "title": "Applied Instrumental Analysis II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved SLT elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCIE",
+              "number": "299",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Barber Styling, T.D. (Fall Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3255",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "101",
+              "title": "Introduction to Barbering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "110",
+              "title": "Sanitation and Safety for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "116",
+              "title": "Science of Barbering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "212",
+              "title": "Barber-Styling I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "142",
+              "title": "Facial Massage and Treatments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "214",
+              "title": "Chemical Services for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "226",
+              "title": "Barber-Styling II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "120",
+              "title": "Shaving, Mustaches, and Beards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "230",
+              "title": "Barber Shop Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "217",
+              "title": "Hair Coloring for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "250",
+              "title": "Louisiana State Barber Board Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "251",
+              "title": "Louisiana State Barber Board Review Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Barber Styling, T.D. (Spring Admission)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3256",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "101",
+              "title": "Introduction to Barbering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "110",
+              "title": "Sanitation and Safety for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "116",
+              "title": "Science of Barbering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "212",
+              "title": "Barber-Styling I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "120",
+              "title": "Shaving, Mustaches, and Beards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "230",
+              "title": "Barber Shop Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "142",
+              "title": "Facial Massage and Treatments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "214",
+              "title": "Chemical Services for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "226",
+              "title": "Barber-Styling II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 13 credit hours",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BARB",
+              "number": "217",
+              "title": "Hair Coloring for Barbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "250",
+              "title": "Louisiana State Barber Board Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BARB",
+              "number": "251",
+              "title": "Louisiana State Barber Board Review Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Service Technology, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3139",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "103",
+              "title": "Electrical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "104",
+              "title": "Electrical Principles Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "106",
+              "title": "Shop Practices Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "148",
+              "title": "Solid State Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "152",
+              "title": "Basic Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "154",
+              "title": "Basic Electronics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "103",
+              "title": "Electrical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "104",
+              "title": "Electrical Principles Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "106",
+              "title": "Shop Practices Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 11 credit hours",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "148",
+              "title": "Solid State Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "152",
+              "title": "Basic Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "154",
+              "title": "Basic Electronics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 10 credit hours",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3140",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Area of concentration: 21 hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Game Developer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "161",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "162",
+              "title": "Game Structure and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "167",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "261",
+              "title": "Game Development for Virtual Reality (VR)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Information Security/Assurance",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "253",
+              "title": "Digital Analysis and Cybercrime",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Programmer/Analyst Specialist",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "136",
+              "title": "Visual Basic Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "173",
+              "title": "Database Managment Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "235",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "238",
+              "title": "Systems and Analysis Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Web Design Specialist",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "127",
+              "title": "Photo Editing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "132",
+              "title": "Python Programming Logic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "224",
+              "title": "Back-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "232",
+              "title": "JAVA Programming II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Networking and Cyber Security, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3141",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "251",
+              "title": "Ethical Hacking and Network Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "253",
+              "title": "Digital Analysis and Cybercrime",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "251",
+              "title": "Ethical Hacking and Network Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "253",
+              "title": "Digital Analysis and Cybercrime",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical-Electronics Engineering Technology, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3146",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "101",
+              "title": "Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "102",
+              "title": "Electrical Circuits II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "103",
+              "title": "Circuit Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "155",
+              "title": "Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "160",
+              "title": "Programming for Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "287",
+              "title": "Programmable Logic Controllers (PLCs)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "271",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "274",
+              "title": "Electrical Machinery and Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "283",
+              "title": "Electronics Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "285",
+              "title": "Industrial Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "291",
+              "title": "Microprocessors and Advanced Digital Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "112",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "131",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "221",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "141",
+              "title": "Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "143",
+              "title": "Physics I Lab (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "101",
+              "title": "Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "103",
+              "title": "Circuit Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "102",
+              "title": "Electrical Circuits II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "155",
+              "title": "Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "112",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "131",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "274",
+              "title": "Electrical Machinery and Controls",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "287",
+              "title": "Programmable Logic Controllers (PLCs)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "271",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "221",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "141",
+              "title": "Physics I (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "143",
+              "title": "Physics I Lab (Algebra/Trigonometry Based)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 17 credit hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELET",
+              "number": "160",
+              "title": "Programming for Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "283",
+              "title": "Electronics Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "285",
+              "title": "Industrial Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "291",
+              "title": "Microprocessors and Advanced Digital Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Transfer Degree, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3177",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Site Design, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3180",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "127",
+              "title": "Photo Editing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "224",
+              "title": "Back-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "127",
+              "title": "Photo Editing Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "224",
+              "title": "Back-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "225",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Service Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3183",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELST",
+              "number": "103",
+              "title": "Electrical Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "104",
+              "title": "Electrical Principles Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "106",
+              "title": "Shop Practices Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "148",
+              "title": "Solid State Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "152",
+              "title": "Basic Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "154",
+              "title": "Basic Electronics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "240",
+              "title": "Computers for Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "271",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELET",
+              "number": "291",
+              "title": "Microprocessors and Advanced Digital Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Area of Concentration 15-16",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "107",
+              "title": "Introduction to Concepts in Physics Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biomedical Equipment Repair",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "213",
+              "title": "Medical Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "214",
+              "title": "Medical Electronics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "215",
+              "title": "Biomedical Instrumentation Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "216",
+              "title": "Biomedical Instrumentation Systems Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELST",
+              "number": "251",
+              "title": "Biomedical Equipment Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer and Electronics Repair",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science Laboratory Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3194",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "General Biology I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "144",
+              "title": "Chemistry II Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "223",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "130",
+              "title": "Introduction to Science Laboratory Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "132",
+              "title": "Science Laboratory Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "299",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Area of Concentration 19",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select One (1) Lecture/Lab pair from the following list:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "265",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "266",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "222",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "224",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Sciences Requirement Met in Courses Required in Major (BIOL or CHEM)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biotechnology",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "274",
+              "title": "Introduction to Nucleic Acids",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "275",
+              "title": "Introduction to Protein Expression and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "282",
+              "title": "Introduction to Molecular and Genetic Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "285",
+              "title": "Bioinformatics and Bioethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SLT approved elective (see advisor/program director for choice) 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Chemical Technology",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "241",
+              "title": "Analytical Chemistry (Quantitative Analysis)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "243",
+              "title": "Analytical Chemistry Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "261",
+              "title": "Instrumental Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "271",
+              "title": "Applied Instrumental Analysis I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHTC",
+              "number": "272",
+              "title": "Applied Instrumental Analysis II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SLT approved elective (see advisor/program director for choice) 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Network Technician, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3221",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "111",
+              "title": "Survey of Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "241",
+              "title": "Networking II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Programming, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3238",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "122",
+              "title": "Front-End Web Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Application Programming, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3240",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "141",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "231",
+              "title": "JAVA Programming I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3241",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "153",
+              "title": "Cyber Security II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Support, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3242",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Repair Certification, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3245",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Distribution Operator, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3263",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "116",
+              "title": "Water Distribution Operator I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "117",
+              "title": "Water Distribution Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "118",
+              "title": "Water Distribution Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "119",
+              "title": "Water Distribution Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "116",
+              "title": "Water Distribution Operator I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "117",
+              "title": "Water Distribution Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "118",
+              "title": "Water Distribution Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "119",
+              "title": "Water Distribution Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Production Operator, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3264",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "106",
+              "title": "Water Production Operator I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "107",
+              "title": "Water Production Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "108",
+              "title": "Water Production Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "109",
+              "title": "Water Production Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "106",
+              "title": "Water Production Operator I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "107",
+              "title": "Water Production Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "108",
+              "title": "Water Production Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "109",
+              "title": "Water Production Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Treatment Operator, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3265",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "111",
+              "title": "Water Treatment Operator I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "112",
+              "title": "Water Treatment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "113",
+              "title": "Water Treatment Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "114",
+              "title": "Water Treatment Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "111",
+              "title": "Water Treatment Operator I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "112",
+              "title": "Water Treatment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "113",
+              "title": "Water Treatment Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "114",
+              "title": "Water Treatment Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wastewater Collection Operator, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3266",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "121",
+              "title": "Wastewater Collection Operator I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "122",
+              "title": "Wastewater Collection Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "123",
+              "title": "Wastewater Collection Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "124",
+              "title": "Wastewater Collection Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "121",
+              "title": "Wastewater Collection Operator I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "122",
+              "title": "Wastewater Collection Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "123",
+              "title": "Wastewater Collection Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "124",
+              "title": "Wastewater Collection Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wastewater Treatment Operator, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3267",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "126",
+              "title": "Wastewater Treatment Operator I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "127",
+              "title": "Wastewater Treatment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "128",
+              "title": "Wastewater Treatment Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "129",
+              "title": "Wastewater Treatment Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "126",
+              "title": "Wastewater Treatment Operator I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WWTC",
+              "number": "127",
+              "title": "Wastewater Treatment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "128",
+              "title": "Wastewater Treatment Operator III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WWTC",
+              "number": "129",
+              "title": "Wastewater Treatment Operator IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "113",
+              "title": "Algebra for Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3268",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses Required in Major",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "173",
+              "title": "Database Managment Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "261",
+              "title": "Cloud Architecture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "101",
+              "title": "Computer and Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "121",
+              "title": "Front-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "131",
+              "title": "Python Programming Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "223",
+              "title": "Back-End Web Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "131",
+              "title": "I.T. Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "141",
+              "title": "Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "173",
+              "title": "Database Managment Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "132",
+              "title": "I.T. Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "211",
+              "title": "Virtual Computer Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "221",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "261",
+              "title": "Cloud Architecture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3269",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses Required in Major",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "111",
+              "title": "Information Technology and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "121",
+              "title": "Networking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITS",
+              "number": "116",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNCY",
+              "number": "151",
+              "title": "Cyber Security I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Media Development, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3309",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "131",
+              "title": "Photo Editing for Windows",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "161",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "162",
+              "title": "3D Modeling and Animation for Games and Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "209",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "217",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "218",
+              "title": "Game Structure and Character Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Chose two (2) courses from the following list:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMIN",
+              "number": "275",
+              "title": "Agile Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "295",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "131",
+              "title": "Photo Editing for Windows",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "161",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "217",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "162",
+              "title": "3D Modeling and Animation for Games and Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "209",
+              "title": "User Experience and Prototyping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "218",
+              "title": "Game Structure and Character Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Development Foundations, C.T.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3310",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "161",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADOT",
+              "number": "162",
+              "title": "3D Modeling and Animation for Games and Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "217",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "218",
+              "title": "Game Structure and Character Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "161",
+              "title": "Modeling and Texturing for 3D Animation and Games",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "217",
+              "title": "Introduction to Game Design and Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADOT",
+              "number": "162",
+              "title": "3D Modeling and Animation for Games and Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "218",
+              "title": "Game Structure and Character Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language Interpreting, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3130",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PREREQUISITE",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "110",
+              "title": "Fingerspelling and Numbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "150",
+              "title": "Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "220",
+              "title": "Introduction to Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "235",
+              "title": "ASL/English Translations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "261",
+              "title": "English-to-ASL Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "262",
+              "title": "ASL-to-English Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "270",
+              "title": "Advanced Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "298",
+              "title": "Interpreting Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Prerequisite",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "110",
+              "title": "Fingerspelling and Numbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "150",
+              "title": "Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 14 credit hours",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "220",
+              "title": "Introduction to Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "235",
+              "title": "ASL/English Translations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "133",
+              "title": "Intensive College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "261",
+              "title": "English-to-ASL Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "262",
+              "title": "ASL-to-English Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASLS",
+              "number": "270",
+              "title": "Advanced Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "298",
+              "title": "Interpreting Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Care and Development of Young Children, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3135",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "105",
+              "title": "Introduction to Care and Development of Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "111",
+              "title": "Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "112",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "115",
+              "title": "Guidance and Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "213",
+              "title": "Infant and Toddler Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "265",
+              "title": "Working with Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "273",
+              "title": "Curriculum and Teaching Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "280",
+              "title": "Administration of Child Care Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "281",
+              "title": "Children’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "APPROVED ELECTIVES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCSS",
+              "number": "107",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "109",
+              "title": "Strengthening the Care and Development of Young Children Module I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "110",
+              "title": "Strengthening the Care and Development of Young Children Module II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "113",
+              "title": "Strengthening the Care and Development of Young Children Module III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "125",
+              "title": "Music and Movement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "141",
+              "title": "Art with Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "179",
+              "title": "Math and Science for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "241",
+              "title": "Family Diversity in the Educational Process",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement Met in General Education Requirement Courses (PSYC 127 or PSYC 225).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "105",
+              "title": "Introduction to Care and Development of Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "111",
+              "title": "Observation and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "112",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "115",
+              "title": "Guidance and Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "213",
+              "title": "Infant and Toddler Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CDYC Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "265",
+              "title": "Working with Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "273",
+              "title": "Curriculum and Teaching Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "280",
+              "title": "Administration of Child Care Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "281",
+              "title": "Children’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CDYC Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "298",
+              "title": "Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CDYC Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3143",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "101",
+              "title": "Introduction to Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "103",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "105",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "160",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "162",
+              "title": "The Judicial Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "203",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "209",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "270",
+              "title": "Victimology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose nine hours from the following courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "110",
+              "title": "Introduction to Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "222",
+              "title": "Drug Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "246",
+              "title": "Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "298",
+              "title": "Criminal Justice Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "261",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 6",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "6 credit hours of Social/Behavioral Science requirement met in General Education Courses (PSYC 127 or POLI 180) and SOCI 151.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "101",
+              "title": "Introduction to Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "105",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "103",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "160",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "270",
+              "title": "Victimology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "162",
+              "title": "The Judicial Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "209",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CRJU Elective, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "203",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved CRJU Elective, 6 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "General Studies, A.G.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3153",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 6",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Course in Major Area of Concentration, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Course in Major Area of Concentration, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Free Elective (from courses numbered 100 or above), 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement, 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies, C.G.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3154",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate Elective (from courses numbered 100 or above), 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate Elective (from courses numbered 100 or above) 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Teaching Grades 1-5, A.S.T.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3175",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "181",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "General Biology I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "General Biology II (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "107",
+              "title": "General Biology I Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "108",
+              "title": "General Biology II Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "207",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional English Literature Requirement. Choose 3 credit hours from the following: ENGL 211, 212, 221, 222, 235, 240, 241, 243, 244, 245.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "105",
+              "title": "World Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "205",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math for Elementary Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Geometry for Elementary Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "235",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "101",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "103",
+              "title": "Physical Science I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "201",
+              "title": "Teaching &amp; Learning in Diverse Settings I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "203",
+              "title": "Teaching &amp; Learning in Diverse Settings II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement: Choose one (1) of the following courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "125",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "126",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "105",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Intro to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "General Biology I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "107",
+              "title": "General Biology I Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "125",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "126",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "105",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Intro to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "105",
+              "title": "World Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "123",
+              "title": "Math for Elementary Teachers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "General Biology II (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "108",
+              "title": "General Biology II Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "205",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "124",
+              "title": "Geometry for Elementary Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "201",
+              "title": "Teaching &amp; Learning in Diverse Settings I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "181",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "207",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "101",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "103",
+              "title": "Physical Science I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credit hours",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "235",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "203",
+              "title": "Teaching &amp; Learning in Diverse Settings II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional English Literature Requirement 3 credit hours (see approved list)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Transfer Degree, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3176",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math/ Analytical Reasoning",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "131",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "151",
+              "title": "Finite Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNAR",
+              "number": "121",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "125",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNAR",
+              "number": "126",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "105",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "137",
+              "title": "Jazz Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "101",
+              "title": "Intro to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "207",
+              "title": "Classical Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "209",
+              "title": "Modern Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "230",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "207",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "212",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "221",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "222",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "235",
+              "title": "Major World Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "243",
+              "title": "Ethnic Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "244",
+              "title": "African-American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "245",
+              "title": "Introduction to Women’s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "253",
+              "title": "The Bible as Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "101",
+              "title": "Elementary French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "102",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "103",
+              "title": "World Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "105",
+              "title": "World Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "141",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "205",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "206",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "260",
+              "title": "Louisiana History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "211",
+              "title": "Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "212",
+              "title": "Humanities II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "112",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "175",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biological Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "General Biology I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "102",
+              "title": "General Biology II (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "141",
+              "title": "General Biology I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "142",
+              "title": "General Biology II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physical Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "102",
+              "title": "Chemistry II (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "142",
+              "title": "Chemistry II (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "102",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "101",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "102",
+              "title": "Physical Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "111",
+              "title": "Astronomy/The Solar System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "112",
+              "title": "Astronomy/Stars and Galaxies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "141",
+              "title": "Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCIE",
+              "number": "142",
+              "title": "Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/ Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "160",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "165",
+              "title": "Biological Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "181",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "180",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "261",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "225",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "226",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "235",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "245",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "153",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "155",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "250",
+              "title": "Studies in Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "255",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Discipline Specific Courses (21 credit hours)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communications-Graphic Design, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3179",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "102",
+              "title": "Introduction to Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "132",
+              "title": "Color Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "142",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "154",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "204",
+              "title": "Pixel Design Software I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "214",
+              "title": "Vector Design Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "224",
+              "title": "Page Publishing Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "234",
+              "title": "Digital Pre-Press and Packaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "256",
+              "title": "Advertising Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "260",
+              "title": "Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "VISC Elective 6",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "VISC ELECTIVES:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNAR",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "107",
+              "title": "Illustration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "205",
+              "title": "Cartooning and Comic Book Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "225",
+              "title": "Pixel Design Software II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "226",
+              "title": "Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "242",
+              "title": "Digital Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "244",
+              "title": "Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "262",
+              "title": "Special Topics in Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "112",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Requirement 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "102",
+              "title": "Introduction to Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved VISC elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "112",
+              "title": "Foundations of Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "142",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "204",
+              "title": "Pixel Design Software I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "214",
+              "title": "Vector Design Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "224",
+              "title": "Page Publishing Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "132",
+              "title": "Color Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "154",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "234",
+              "title": "Digital Pre-Press and Packaging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "256",
+              "title": "Advertising Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "260",
+              "title": "Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Free elective 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Digital Photography, C.T.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3231",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "142",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "204",
+              "title": "Pixel Design Software I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "225",
+              "title": "Pixel Design Software II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "242",
+              "title": "Digital Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "260",
+              "title": "Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "262",
+              "title": "Special Topics in Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "142",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "204",
+              "title": "Pixel Design Software I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 6 credit hours",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "225",
+              "title": "Pixel Design Software II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "242",
+              "title": "Digital Photography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VISC",
+              "number": "260",
+              "title": "Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester (Summer Session)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VISC",
+              "number": "262",
+              "title": "Special Topics in Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development Associate (C.D.A) Preparation, C.T.C.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3237",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses in Major",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "109",
+              "title": "Strengthening the Care and Development of Young Children Module I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "110",
+              "title": "Strengthening the Care and Development of Young Children Module II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "113",
+              "title": "Strengthening the Care and Development of Young Children Module III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "109",
+              "title": "Strengthening the Care and Development of Young Children Module I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "110",
+              "title": "Strengthening the Care and Development of Young Children Module II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "113",
+              "title": "Strengthening the Care and Development of Young Children Module III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 3 credit hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Concentration in Health Sciences- Diagnostic Medical Sonography",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3277",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 7 credit hours from courses numbered 100 or above (6 credit hours must be from courses with the same prefix. The additional hour may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Funeral Service Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3278",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "111",
+              "title": "Fundamentals of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMIN",
+              "number": "201",
+              "title": "Computer &amp; Internet Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 6 credit hours from courses numbered 100 or above (these courses must be from the same prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Health Information Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3279",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "118",
+              "title": "Information Management for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 12 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSG",
+              "number": "224",
+              "title": "Business Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEIT",
+              "number": "203",
+              "title": "Basic Pathophysiology and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 4 credit hours from courses numbered 100 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "130",
+              "title": "Fundamentals of Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMST",
+              "number": "230",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Concentration in Health Sciences- Medical Laboratory Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3280",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "General Microbiology Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "143",
+              "title": "Chemistry I Lab (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 9 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining 3 credit hours may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "210",
+              "title": "General Microbiology (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "141",
+              "title": "Chemistry I (Science Majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Nuclear Medicine Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3281",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "107",
+              "title": "Chemistry I Lab (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 3 credit hours from courses numbered 100 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3282",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 7 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining credit hour may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "203",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "3 credit hours OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Concentration in Health Sciences- Occupational Therapy Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3283",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCTA",
+              "number": "201",
+              "title": "Introduction to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "226",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "240",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 1 credit hour from courses numbered 100 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Applied Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "151",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Practical Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3284",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "109",
+              "title": "Medical Nutrition Therapy for Nursing and Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 8 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining 2 credit hours may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Concentration in Health Sciences- Sleep Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3285",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "163",
+              "title": "Introductory Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HESC",
+              "number": "112",
+              "title": "Advanced Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 2 credit hours from courses numbered 100 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Physical Therapist Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3286",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 4 credit hours from courses numbered 100 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Radiologic Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3287",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 10 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining 4 credit hours may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Radiation Therapy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3288",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED COURSES IN MAJOR",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HESC",
+              "number": "111",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 15 credit hours from courses with a HESC prefix.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "254",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "101",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 7 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining credit hour may be from the same, or a different prefix).",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "252",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Contemporary Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concentration in Health Sciences- Respiratory Care Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dcc.edu/preview_program.php?catoid=60&poid=3289",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIRED RELATED COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Chose ONE (1) Lecture/ Lab Combination from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "161",
+              "title": "Introductory Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIOL",
+                  "number": "163",
+                  "title": "Introductory Anatomy and Physiology Laboratory"
+                }
+              ]
+            },
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "253",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 8 credit hours from courses numbered 100 or above (6 credit hours must be from the same prefix. The remaining 2 credit hours may be from the same, or a different prefix)..",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Microbiology of Human Pathogens",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "101",
+              "title": "Chemistry I (non-science majors)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "110",
+              "title": "Intensive English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "127",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts Requirement 3 credit hours",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/scripts/lib/scrape-acalog-programs.ts
+++ b/scripts/lib/scrape-acalog-programs.ts
@@ -120,27 +120,25 @@ async function playwrightFetch(
 ): Promise<string> {
   const page = await ctx.newPage();
   try {
-    // Use domcontentloaded, not networkidle: Acalog program pages embed
-    // analytics/widgets whose long-poll connections mean networkidle often
-    // never settles, so every fetch burned the full 30s timeout (and, under
-    // memory/disk pressure, stalled the renderer entirely on large catalogs
-    // like Delgado/Bossier). domcontentloaded returns as soon as the HTML is
-    // parsed — sufficient for the static catalog markup we scrape.
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 });
-    // AWS WAF JS-challenge pages are typically ≤2 KB and auto-redirect once
-    // the token is solved. Wait for the real page if we got the challenge.
+    // networkidle (not domcontentloaded): the WAF JS challenge needs the page's
+    // scripts to run and redirect before the real catalog HTML exists.
+    // domcontentloaded returns too early, lands on the ~2 KB challenge stub far
+    // more often, and the challenge-recovery path is fragile — so prefer
+    // networkidle and let the challenge settle in one shot. The earlier
+    // "networkidle stalls forever" symptom was actually the headless renderer
+    // crashing under a full disk, not networkidle itself (see memory
+    // feedback_disk_pressure_crashes_playwright).
+    await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+    // Belt-and-suspenders: if we still got the challenge stub, wait for the
+    // WAF redirect to the real document before reading content.
     const html = await page.content();
     if (html.length < 5_000 && html.includes("awswaf")) {
-      // Challenge page — wait for the WAF redirect to the real document.
-      await page
-        .waitForLoadState("domcontentloaded", { timeout: 15_000 })
-        .catch(() => {});
       await page.waitForNavigation({ timeout: 15_000 }).catch(() => {});
-      return page.content();
+      return page.content().catch(() => html);
     }
     return html;
   } finally {
-    await page.close();
+    await page.close().catch(() => {});
   }
 }
 


### PR DESCRIPTION
Follow-up to #1492.

## What changes for someone using the site

The degree-path planner now works for **two more Louisiana colleges** — the two biggest that #1492 left out:

- **Bossier Parish Community College** — 160 programs
- **Delgado Community College** — 120 programs

Their `/la/college/.../programs` pages now list real degrees with semester-by-semester course requirements. That brings Louisiana to **7 colleges with program data**, all the LCTCS colleges with public, parseable catalogs.

## What changes on the technical front

This PR also **fixes a regression I introduced in #1492.** In that PR I switched the shared Acalog scraper (`scripts/lib/scrape-acalog-programs.ts`) from `waitUntil: "networkidle"` to `"domcontentloaded"`, believing networkidle was hanging. It wasn't — those "hangs" were the headless browser crashing under a **full disk**. `networkidle` is the correct setting because it waits for the AWS WAF bot-challenge JavaScript to run and redirect to the real page before the HTML is read. `domcontentloaded` returns too early, so the scraper grabbed the ~2 KB unsolved challenge stub far more often — which is exactly why Delgado and Bossier crashed on every attempt.

Reverting to `networkidle` (with disk headroom) let both catalogs scrape cleanly on the first try. **This revert matters beyond these two colleges**: the next scheduled cron run uses this shared file for every WAF-gated Acalog programs scraper (the whole SC Technical College system, several LA ones), so leaving `domcontentloaded` in place risked those scrapers grabbing challenge stubs and producing empty data.

## Test plan

- `npm run typecheck` passes.
- Both files validated: JSON parses, schema is byte-identical to the already-live `fletcher-technical-community-college.json` (same 9 program keys, populated `requirement_groups`).
- Scrape ran clean end-to-end: Bossier 160 programs / 0 skipped, Delgado 120 / 0 skipped, no renderer crash (the fix confirmed).
- Post-merge prod check to follow once Vercel + the import pipeline redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
