### PR TITLE
db: widen programs.college_slug + enable RLS on seat_snapshots (migration 032)

### DIFF
--- a/supabase/migrations/032_harden_programs_slug_and_seat_snapshots_rls.sql
+++ b/supabase/migrations/032_harden_programs_slug_and_seat_snapshots_rls.sql
@@ -1,0 +1,41 @@
+-- 032_harden_programs_slug_and_seat_snapshots_rls.sql
+--
+-- Applied to prod (Project CC) on 2026-06-21 via the management API; this file
+-- records it for traceability (repo migrations are applied by hand here).
+--
+-- Two independent fixes surfaced by a prod audit:
+--
+-- 1) programs.college_slug was varchar(50). Six community-college slugs exceed
+--    50 chars (e.g. "cossatot-community-college-of-the-university-of-arkansas"
+--    = 56), so every programs-import row for those colleges failed with
+--    "value too long for type character varying(50)" and was silently dropped —
+--    leaving those colleges with no programs (and a dead degree-path planner).
+--    courses.college_code is already `text`; widen college_slug to match.
+--
+-- 2) public.seat_snapshots had RLS disabled while being exposed through
+--    PostgREST (Supabase advisor 0013, ERROR). Enable RLS and mirror the
+--    public-read / service-role-write policy set used by courses, programs,
+--    and transfers.
+
+-- 1) Widen the slug column (non-destructive; varchar -> text needs no rewrite).
+ALTER TABLE public.programs ALTER COLUMN college_slug TYPE text;
+
+-- 2) Lock down seat_snapshots with the standard policy set.
+ALTER TABLE public.seat_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read seat_snapshots"
+  ON public.seat_snapshots FOR SELECT
+  USING (true);
+
+CREATE POLICY "Service write seat_snapshots"
+  ON public.seat_snapshots FOR INSERT
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+CREATE POLICY "Service update seat_snapshots"
+  ON public.seat_snapshots FOR UPDATE
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+CREATE POLICY "Service delete seat_snapshots"
+  ON public.seat_snapshots FOR DELETE
+  USING ((SELECT auth.role()) = 'service_role');


### PR DESCRIPTION
## What changes for someone using the site

Six community colleges in Arkansas, Alabama, and Kentucky will start showing their **degree programs** (and become usable in the degree-path planner) once the next programs import runs. Until now their programs silently failed to load. Affected colleges: Cossatot CC of the University of Arkansas, U of Arkansas CC Batesville, U of Arkansas CC Rich Mountain, Phillips CC of the University of Arkansas, George C. Wallace State CC–Hanceville, and Southcentral Kentucky CC&TC.

No other visible change. The second fix is invisible to users (a database security hardening).

## What changed technically

Records **migration 032**, already applied to prod (Project CC) on 2026-06-21 via the management API — repo `.sql` files are applied by hand here, so this commit is for traceability.

1. **`programs.college_slug` `varchar(50)` → `text`.** Those 6 colleges have slugs longer than 50 chars (`cossatot-community-college-of-the-university-of-arkansas` = 56). Every programs-import row for them was rejected by Postgres with `value too long for type character varying(50)` and dropped — the error showed up in the prod Postgres logs. `courses.college_code` is already `text`; this aligns them. `varchar → text` is non-destructive and needs no table rewrite.

2. **Enable RLS on `public.seat_snapshots`.** It was public + RLS-disabled (Supabase advisor [0013](https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public), ERROR-level). Enabled RLS and mirrored the exact policy set used by `courses`/`programs`/`transfers`: public `SELECT`, service-role `INSERT/UPDATE/DELETE`. Table is currently empty, so no read path is affected. Post-apply, the advisor ERROR is cleared.

## Context

Found during an end-to-end prod audit. The headline finding of that audit (separate, owner action) is that the Supabase REST + auth API is returning **HTTP 402 — egress quota exceeded / spend cap** site-wide; these two DDL fixes are independent of that and were safe to apply during the restriction (the management/DDL path is unaffected).

## Test plan

- Verified post-apply: `programs.college_slug` data_type = `text`; `seat_snapshots` `relrowsecurity = true` with 4 policies; security advisor no longer lists `rls_disabled_in_public` for `seat_snapshots`.
- Next scheduled programs import should populate the 6 previously-failing colleges (verify once the egress restriction is lifted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)