### PR TITLE
seo: return real 404s for invalid state slugs with a subroute (proxy.ts)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -49,6 +49,18 @@ const COURSE_PATH_RE = /^\/([a-z]{2})\/course\/([^/]+)\/?$/;
 // lowercase letters at the start of the path; everything after is anything.
 const STATE_PATH_RE = /^\/([a-z]{2})(\/.*)?$/;
 
+// `/<segment>/<state-subroute>` capture where <segment> is NOT necessarily a
+// 2-letter slug. STATE_PATH_RE above only validates exactly-2-lowercase-letter
+// first segments, so longer or oddly-cased junk slugs that still carry a real
+// state subroute — `/notastate/transfer`, `/zzz/courses`, `/VA/about` — fell
+// through to the ISR page and rendered a soft-404 (HTTP 200) instead of a true
+// 404 (the status is locked at 200 once app/loading.tsx starts streaming; same
+// problem as #158). Listing the known app/[state]/* subroutes keeps genuine
+// top-level routes (e.g. /plan/<id>) from being caught. Keep the alternation in
+// sync with the directories under app/[state]/.
+const STATE_SUBROUTE_RE =
+  /^\/([^/]+)\/(?:about|choose|college|colleges|course|courses|online|plan|program|programs|results|schedule|starting-soon|subject|transfer)(?:\/.*)?$/;
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -87,6 +99,19 @@ export async function proxy(request: NextRequest) {
     // branch (state pages don't need session refresh, and updateSession
     // touches cookies which kills ISR caching).
     return NextResponse.next();
+  }
+
+  // -------------------------------------------------------------------------
+  // Unregistered-state validation for non-2-letter junk slugs that still carry
+  // a real state subroute (e.g. /notastate/transfer, /zzz/courses, /VA/about).
+  // STATE_PATH_RE only handles exactly-2-letter first segments; these longer or
+  // oddly-cased slugs otherwise fall through and render a soft-404 (HTTP 200).
+  // Any first segment reaching here that isn't a valid state must 404 — valid
+  // states are 2 lowercase letters and already returned above.
+  // -------------------------------------------------------------------------
+  const subrouteMatch = pathname.match(STATE_SUBROUTE_RE);
+  if (subrouteMatch && !isValidState(subrouteMatch[1])) {
+    return new NextResponse(null, { status: 404 });
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What changes for someone using the site

Junk URLs like `/notastate/transfer`, `/zzz/courses`, or `/VA/about` now return a proper **HTTP 404** instead of a "Not Found" page served with a **200 OK** status. Real pages are unaffected. Users rarely type these, but search engines crawl them — and a 200-status "Not Found" page is a "soft 404" that Google penalizes (it's part of the same family of issues behind the May-2026 indexation problems).

## What changed technically

The Next.js proxy (`proxy.ts`, formerly middleware) already 404s unregistered state slugs before the route streams — but its `STATE_PATH_RE` only matched first segments that are **exactly two lowercase letters**. So `/zz` and `/zz/transfer` correctly hard-404, while anything longer or oddly-cased (`/notastate/...`, `/zzz/...`, `/VA/...`) slipped past, fell through to the ISR `[state]` route, and rendered a soft-404 — because once `app/loading.tsx` starts streaming the Suspense boundary, the HTTP status is locked at 200 and a page-level `notFound()` can only change the body, not the status (the same constraint documented for issue #158).

Added `STATE_SUBROUTE_RE`: any `/<segment>/<known-state-subroute>` path (the subroute alternation mirrors the directories under `app/[state]/` — `about|choose|college|colleges|course|courses|online|plan|program|programs|results|schedule|starting-soon|subject|transfer`) whose first segment isn't a valid state now returns a 404 in the proxy, before streaming. Scoping to the known subroutes keeps genuine top-level routes such as `/plan/<id>` untouched; valid two-letter states are handled by the existing branch above and never reach the new check.

### Known limitation (intentional)
Bare long junk slugs with **no** subroute (e.g. `/notastate` on its own) still pass through to a soft-404 — telling those apart from legitimate top-level routes would require a maintained allowlist, and they're rare compared with the deep-link soft-404s crawlers actually hit.

## Test plan
- Logic-tested the exact regexes against: the reported soft-404 URLs (now 404), valid state routes `/va/courses`, `/ca/transfer`, `/nc/college/abc` (still render), and real top-level routes `/plan/abc123`, `/colleges`, `/blog/foo`, `/online/something` (not caught). All pass.
- No new imports; CI build verifies compilation.
- Found during an end-to-end prod audit (the soft-404 was flagged by the HTTP availability sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)