### PR TITLE
tn prereqs: WAF-aware catalog fetch + merge-not-overwrite (628→707)

### DIFF
--- a/data/tn/prereqs.json
+++ b/data/tn/prereqs.json
@@ -96,6 +96,11 @@
       "ENGL 1010"
     ]
   },
+  "AGRI 1015": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
   "AGRI 1020": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading and ACT English score of 18 or satisfactory placement scores or completion of Learning Support Writing",
     "courses": []
@@ -120,9 +125,127 @@
       "Biology 111"
     ]
   },
+  "AGRI 1055": {
+    "text": "High school algebra I and algebra II and ACT math score of at least 21 or MATH 1030 or MATH 1130 or MATH 1630 or MATH 1710 or MATH 1730 or MATH 1830 or MATH 1910",
+    "courses": [
+      "MATH 1030",
+      "MATH 1130",
+      "MATH 1630",
+      "MATH 1710",
+      "MATH 1730",
+      "MATH 1830",
+      "MATH 1910"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 1060": {
+    "text": "MATH 1130 or MATH 1630 or MATH 1710 or MATH 1730 or MATH 1830 or MATH 1910",
+    "courses": [
+      "MATH 1130",
+      "MATH 1630",
+      "MATH 1710",
+      "MATH 1730",
+      "MATH 1830",
+      "MATH 1910"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 1100": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
+  "AGRI 1110": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
+  "AGRI 1120": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
+  "AGRI 1170": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
+  "AGRI 1460": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
+  "AGRI 1470": {
+    "text": "AGRI 1460",
+    "courses": [
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 1480": {
+    "text": "AGRI 1460 or department approval",
+    "courses": [
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 1600": {
+    "text": "AGRI 1460 or department approval",
+    "courses": [
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2014": {
+    "text": "BIOL 1010 or BIOL 1110 or BIOL 2310",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1110",
+      "BIOL 2310"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2015": {
+    "text": "AGRI 2012",
+    "courses": [
+      "AGRI 2012"
+    ],
+    "source": "pstcc"
+  },
   "AGRI 2110": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
+  },
+  "AGRI 2120": {
+    "text": "AGRI 1110 or department approval",
+    "courses": [
+      "AGRI 1110"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2130": {
+    "text": "AGRI 1110 and one of the following: AGRI 2120 , AGRI 2140 , or AGRI 2150",
+    "courses": [
+      "AGRI 1110",
+      "AGRI 2120",
+      "AGRI 2140",
+      "AGRI 2150"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2140": {
+    "text": "AGRI 1110 or department approval",
+    "courses": [
+      "AGRI 1110"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2150": {
+    "text": "AGRI 1110 or department approval",
+    "courses": [
+      "AGRI 1110"
+    ],
+    "source": "pstcc"
   },
   "AGRI 2200": {
     "text": "BIOL 1110",
@@ -135,6 +258,90 @@
     "courses": [
       "AGRI 1020"
     ]
+  },
+  "AGRI 2260": {
+    "text": "AGRI 2250",
+    "courses": [
+      "AGRI 2250"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2460": {
+    "text": "AGRI 1460 . It is highly recommended that students enroll concurrently in AGRI 2680 Wine and Must Analysis",
+    "courses": [
+      "AGRI 1460",
+      "AGRI 2680"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2470": {
+    "text": "AGRI 1460 and AGRI 2460 (AGRI 1055 and AGRI 1100 recommended). It is highly recommended that students enroll concurrently in AGRI 2680 Wine and Must Analysis",
+    "courses": [
+      "AGRI 1055",
+      "AGRI 1100",
+      "AGRI 1460",
+      "AGRI 2460",
+      "AGRI 2680"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2570": {
+    "text": "AGRI 1460 , AGRI 1480 , AGRI 1600 , AGRI 2460 , or department approval",
+    "courses": [
+      "AGRI 1460",
+      "AGRI 1480",
+      "AGRI 1600",
+      "AGRI 2460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2590": {
+    "text": "AGRI 1460 , AGRI 1480 , AGRI 1600 , AGRI 2460 , AGRI 2470 , AGRI 2570 , AGRI 2680",
+    "courses": [
+      "AGRI 1460",
+      "AGRI 1480",
+      "AGRI 1600",
+      "AGRI 2460",
+      "AGRI 2470",
+      "AGRI 2570",
+      "AGRI 2680"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2660": {
+    "text": "AGRI 1460 or department approval",
+    "courses": [
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2680": {
+    "text": "AGRI 1460 and AGRI 1055 or department approval",
+    "courses": [
+      "AGRI 1055",
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2700": {
+    "text": "AGRI 1460 or department approval",
+    "courses": [
+      "AGRI 1460"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2750": {
+    "text": "BUSN 2320 and BUSN 2330",
+    "courses": [
+      "BUSN 2320",
+      "BUSN 2330"
+    ],
+    "source": "pstcc"
+  },
+  "AGRI 2900": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
   },
   "AHSC 1320": {
     "text": "PLBT 1301 (min D) and AHSC 1310 (min D)",
@@ -250,6 +457,11 @@
     "courses": [
       "ANIM 1010"
     ]
+  },
+  "ANIM 1999": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
   },
   "ANIM 2000": {
     "text": "ANIM 1500 and ANIM 1510",
@@ -378,6 +590,35 @@
       "APE 2015"
     ]
   },
+  "APE 2100": {
+    "text": "APE 1016 and APE 2016",
+    "courses": [
+      "APE 1016",
+      "APE 2016"
+    ],
+    "source": "pstcc"
+  },
+  "APE 2416": {
+    "text": "APE 1016",
+    "courses": [
+      "APE 1016"
+    ],
+    "source": "pstcc"
+  },
+  "APE 2432": {
+    "text": "APE 2016",
+    "courses": [
+      "APE 2016"
+    ],
+    "source": "pstcc"
+  },
+  "APE 2433": {
+    "text": "APE 2016",
+    "courses": [
+      "APE 2016"
+    ],
+    "source": "pstcc"
+  },
   "APE 2450": {
     "text": "APE 2016",
     "courses": [
@@ -396,6 +637,14 @@
       "APE 1015"
     ]
   },
+  "APE 2875": {
+    "text": "APE 1016 and APE 2016",
+    "courses": [
+      "APE 1016",
+      "APE 2016"
+    ],
+    "source": "pstcc"
+  },
   "APE 2910": {
     "text": "Department approval",
     "courses": []
@@ -411,6 +660,13 @@
     "courses": [
       "CIVT 1250"
     ]
+  },
+  "ARCT 2550": {
+    "text": "ACT Math score of 19 or satisfactory placement scores or completion of Learning Support Math and ARCT 2500 or department approval",
+    "courses": [
+      "ARCT 2500"
+    ],
+    "source": "pstcc"
   },
   "ARCT 2710": {
     "text": "ARCT 1710 and CADD 1650",
@@ -668,6 +924,11 @@
       "BIOL 2010"
     ]
   },
+  "BIOL 2000": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
   "BIOL 2010": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
@@ -679,6 +940,25 @@
       "Biology 211"
     ]
   },
+  "BIOL 2040": {
+    "text": "Completion of BIOL 1110 and BIOL 1120 , or BIOL 2310 and BIOL 2320 , or department approval",
+    "courses": [
+      "BIOL 1110",
+      "BIOL 1120",
+      "BIOL 2310",
+      "BIOL 2320"
+    ],
+    "source": "pstcc"
+  },
+  "BIOL 2120": {
+    "text": "BIOL 1110 and CHEM 1110 and BIOL 2310 , each taken within the past 5 years; or instructor approval, based on high achievement in related courses and a demonstration of understanding concepts that are required to be successful in this course. Instructor approval cannot replace all listed pre-requisites",
+    "courses": [
+      "BIOL 1110",
+      "BIOL 2310",
+      "CHEM 1110"
+    ],
+    "source": "pstcc"
+  },
   "BIOL 2130": {
     "text": "BIOL 1110 or BIOL 2010 or CHEM 1010 or CHEM 1110",
     "courses": [
@@ -687,6 +967,14 @@
       "CHEM 1010",
       "CHEM 1110"
     ]
+  },
+  "BIOL 2180": {
+    "text": "BIOL 1110 and BIOL 1120",
+    "courses": [
+      "BIOL 1110",
+      "BIOL 1120"
+    ],
+    "source": "pstcc"
   },
   "BIOL 2230": {
     "text": "BIOL 1110 (min D) or BIOL 2010 (min D) or Biology 111 (min D) or Biology 211 (min D)",
@@ -849,6 +1137,14 @@
       "BUSN 2330"
     ]
   },
+  "BUSN 2391": {
+    "text": "BUSN 1305 or BUSN 2330 or department approval",
+    "courses": [
+      "BUSN 1305",
+      "BUSN 2330"
+    ],
+    "source": "pstcc"
+  },
   "BUSN 2395": {
     "text": "ACCT 1010 and BUSN 2330 or HMGT 1030",
     "courses": [
@@ -856,6 +1152,11 @@
       "BUSN 2330",
       "HMGT 1030"
     ]
+  },
+  "BUSN 2420": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
   },
   "BUSN 2510": {
     "text": "Department approval",
@@ -878,6 +1179,13 @@
     "courses": [
       "CADD 1650"
     ]
+  },
+  "CADD 2301": {
+    "text": "ACT Math score of 19 or satisfactory placement scores or completion of Learning Support Math and CADD 1200",
+    "courses": [
+      "CADD 1200"
+    ],
+    "source": "pstcc"
   },
   "CENT 1320": {
     "text": "CENT 1310 (min D) or CENT 1114 (min D)",
@@ -1267,11 +1575,25 @@
       "MATH 1740"
     ]
   },
+  "CIVT 2310": {
+    "text": "BUSN 2385",
+    "courses": [
+      "BUSN 2385"
+    ],
+    "source": "pstcc"
+  },
   "CIVT 2500": {
     "text": "ACT Math score of 19 or satisfactory placement scores or completion of Learning Support Math and CIVT 2350",
     "courses": [
       "CIVT 2350"
     ]
+  },
+  "CIVT 2510": {
+    "text": "BUSN 2385",
+    "courses": [
+      "BUSN 2385"
+    ],
+    "source": "pstcc"
   },
   "CIVT 2550": {
     "text": "CIVT 1550 or department approval",
@@ -1531,6 +1853,25 @@
       "DWP 2110"
     ]
   },
+  "ECE 2010": {
+    "text": "MATH 1920",
+    "courses": [
+      "MATH 1920"
+    ],
+    "source": "pstcc"
+  },
+  "ECE 2020": {
+    "text": "ECE 2010",
+    "courses": [
+      "ECE 2010"
+    ],
+    "source": "pstcc"
+  },
+  "ECED 2300": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "ECED 2330": {
     "text": "ECED 1010 (min D) or ECED 1010 (min D) and ECED 2010 (min D) or ECED 2010 (min D)",
     "courses": [
@@ -1591,6 +1932,20 @@
       "ECON 2100"
     ]
   },
+  "EDLS 1020": {
+    "text": "ENGL 1010",
+    "courses": [
+      "ENGL 1010"
+    ],
+    "source": "pstcc"
+  },
+  "EDLS 1030": {
+    "text": "ENGL 1010",
+    "courses": [
+      "ENGL 1010"
+    ],
+    "source": "pstcc"
+  },
   "EDUC 2210": {
     "text": "EDUC 2000",
     "courses": [
@@ -1620,6 +1975,14 @@
     "courses": [
       "EETC 1311"
     ]
+  },
+  "EETC 2316": {
+    "text": "EETC 1313 and EETC 1314 or department approval",
+    "courses": [
+      "EETC 1313",
+      "EETC 1314"
+    ],
+    "source": "pstcc"
   },
   "EETC 2331": {
     "text": "EETC 1311 (min D) or EET  Electronic Technology 130 (min D)",
@@ -1858,11 +2221,25 @@
       "ENGL 1020"
     ]
   },
+  "ENGL 2520": {
+    "text": "ENGL 1020",
+    "courses": [
+      "ENGL 1020"
+    ],
+    "source": "pstcc"
+  },
   "ENGL 2620": {
     "text": "ENGL 1020",
     "courses": [
       "ENGL 1020"
     ]
+  },
+  "ENGL 2640": {
+    "text": "ENGL 1020",
+    "courses": [
+      "ENGL 1020"
+    ],
+    "source": "pstcc"
   },
   "ENGL 2860": {
     "text": "ENGL 1010",
@@ -1970,6 +2347,13 @@
       "ENST 1340"
     ]
   },
+  "ENST 1371": {
+    "text": "ENST 1370",
+    "courses": [
+      "ENST 1370"
+    ],
+    "source": "pstcc"
+  },
   "ENST 1372": {
     "text": "CADD 1200 or ENST 1311 and ENST 1340 or department approval",
     "courses": [
@@ -1977,6 +2361,11 @@
       "ENST 1311",
       "ENST 1340"
     ]
+  },
+  "ENST 1399": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
   },
   "ENST 1404": {
     "text": "ENST 1403 (min D)",
@@ -1989,6 +2378,13 @@
     "courses": [
       "ENST 1340"
     ]
+  },
+  "ENST 2342": {
+    "text": "ENST 2340",
+    "courses": [
+      "ENST 2340"
+    ],
+    "source": "pstcc"
   },
   "ENST 2343": {
     "text": "ENST 1340 or department approval",
@@ -2285,6 +2681,11 @@
       "GART 1040"
     ]
   },
+  "GEOL 1005": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "GEOL 1040": {
     "text": "High school algebra I and algebra II and ACT math score of at least 21 or MATH 1030 or MATH 1050 or MATH 1130 or MATH 1410 or MATH 1420 or MATH 1710 or MATH 1720 or MATH 1730 or MATH 1910",
     "courses": [
@@ -2302,6 +2703,13 @@
   "GEOL 1300": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
+  },
+  "GEOL 2030": {
+    "text": "ENGL 1010",
+    "courses": [
+      "ENGL 1010"
+    ],
+    "source": "pstcc"
   },
   "GERM 1010": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
@@ -2431,6 +2839,11 @@
       "HMGT 1030"
     ]
   },
+  "HMGT 2900": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "HPER 2350": {
     "text": "HPER 1150 (min D)",
     "courses": [
@@ -2495,6 +2908,11 @@
       "IDT 2306"
     ]
   },
+  "IDT 2500": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "IDT 2550": {
     "text": "IDT 1110 and IDT 2306",
     "courses": [
@@ -2525,6 +2943,11 @@
   "INFS 1010": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
+  },
+  "LAS 2020": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
   },
   "LEGL 1315": {
     "text": "LEGL 1300",
@@ -2567,6 +2990,20 @@
     "courses": [
       "LEGL 1300"
     ]
+  },
+  "LEGL 2300": {
+    "text": "LEGL 1300",
+    "courses": [
+      "LEGL 1300"
+    ],
+    "source": "pstcc"
+  },
+  "LEGL 2305": {
+    "text": "LEGL 1300",
+    "courses": [
+      "LEGL 1300"
+    ],
+    "source": "pstcc"
   },
   "LEGL 2330": {
     "text": "LEGL 1300",
@@ -3025,6 +3462,11 @@
       "MUS 1058"
     ]
   },
+  "MUS 2600": {
+    "text": "Topic dependent",
+    "courses": [],
+    "source": "pstcc"
+  },
   "MUS 2660": {
     "text": "MUS 1660 (min D)",
     "courses": [
@@ -3219,6 +3661,11 @@
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
   },
+  "PHIL 1500": {
+    "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
+    "courses": [],
+    "source": "pstcc"
+  },
   "PHIL 2200": {
     "text": "ENGL 1010 (min D)",
     "courses": [
@@ -3283,6 +3730,15 @@
       "PHO 1700"
     ]
   },
+  "PHO 2701": {
+    "text": "PHO 1000 and PHO 1100 and PHO 1700",
+    "courses": [
+      "PHO 1000",
+      "PHO 1100",
+      "PHO 1700"
+    ],
+    "source": "pstcc"
+  },
   "PHO 2800": {
     "text": "PHO 1100 and PHO 2200 or PHO 2400",
     "courses": [
@@ -3294,6 +3750,11 @@
   "PHO 2830": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading and ACT English score of 18 or satisfactory placement scores or completion of Learning Support Writing and department approval",
     "courses": []
+  },
+  "PHO 2950": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
   },
   "PHRX 1020": {
     "text": "PHRX 1010 (min D)",
@@ -3673,6 +4134,13 @@
       "RESP 2449"
     ]
   },
+  "SMGT 2070": {
+    "text": "BUSN 1305",
+    "courses": [
+      "BUSN 1305"
+    ],
+    "source": "pstcc"
+  },
   "SOCI 1010": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
@@ -3952,6 +4420,22 @@
       "VPT 1500"
     ]
   },
+  "VPT 2150": {
+    "text": "VPT 1045 and VPT 1090 and VPT 1400",
+    "courses": [
+      "VPT 1045",
+      "VPT 1090",
+      "VPT 1400"
+    ],
+    "source": "pstcc"
+  },
+  "VPT 2160": {
+    "text": "VPT 2150",
+    "courses": [
+      "VPT 2150"
+    ],
+    "source": "pstcc"
+  },
   "VPT 2215": {
     "text": "VPT 1211",
     "courses": [
@@ -3970,6 +4454,11 @@
       "VPT 1400"
     ]
   },
+  "VPT 2660": {
+    "text": "Department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "VPT 2750": {
     "text": "VPT 1050 and VPT 1400 and VPT 1875",
     "courses": [
@@ -3983,6 +4472,13 @@
     "courses": [
       "VPT 1400"
     ]
+  },
+  "VPT 2875": {
+    "text": "VPT 1875",
+    "courses": [
+      "VPT 1875"
+    ],
+    "source": "pstcc"
   },
   "VPT 2960": {
     "text": "VPT 1030 , VPT 1045 , VPT 1050 , and VPT 1500",
@@ -3998,6 +4494,40 @@
     "courses": [
       "WEB 1600"
     ]
+  },
+  "WEB 2120": {
+    "text": "CITC 2375 or WEB 1600 or department approval for WEB students; VPT 1030 for VPT students",
+    "courses": [
+      "CITC 2375",
+      "VPT 1030",
+      "WEB 1600"
+    ],
+    "source": "pstcc"
+  },
+  "WEB 2150": {
+    "text": "CITC 2375 or WEB 1600 or department approval",
+    "courses": [
+      "CITC 2375",
+      "WEB 1600"
+    ],
+    "source": "pstcc"
+  },
+  "WEB 2300": {
+    "text": "CITC 2375 or WEB 2010 or department approval",
+    "courses": [
+      "CITC 2375",
+      "WEB 2010"
+    ],
+    "source": "pstcc"
+  },
+  "WEB 2400": {
+    "text": "CITC 2375 or WEB 2010 and ENGL 1010",
+    "courses": [
+      "CITC 2375",
+      "ENGL 1010",
+      "WEB 2010"
+    ],
+    "source": "pstcc"
   },
   "WEB 2500": {
     "text": "WEB 1600",
@@ -4018,6 +4548,23 @@
       "DWP 1010",
       "WEB 1600"
     ]
+  },
+  "WEB 2715": {
+    "text": "WEB 1600 and WEB 2500",
+    "courses": [
+      "WEB 1600",
+      "WEB 2500"
+    ],
+    "source": "pstcc"
+  },
+  "WEB 2812": {
+    "text": "CITC 2375 or WEB 1600 and WEB 2010 or department approval",
+    "courses": [
+      "CITC 2375",
+      "WEB 1600",
+      "WEB 2010"
+    ],
+    "source": "pstcc"
   },
   "WELD 1384": {
     "text": "WELD 1381",
@@ -4067,6 +4614,11 @@
     "text": "Course must be taken during final semester and with department approval",
     "courses": []
   },
+  "WELD 2491": {
+    "text": "Course must be taken during final semester or with department approval",
+    "courses": [],
+    "source": "pstcc"
+  },
   "WGST 2050": {
     "text": "ACT Reading score of 19 or satisfactory placement scores or completion of Learning Support Reading",
     "courses": []
@@ -4083,6 +4635,13 @@
       "WTRQ 2110"
     ]
   },
+  "WTRQ 2180": {
+    "text": "WTRQ 2110",
+    "courses": [
+      "WTRQ 2110"
+    ],
+    "source": "pstcc"
+  },
   "WTRQ 2210": {
     "text": "WTRQ 1001",
     "courses": [
@@ -4094,6 +4653,13 @@
     "courses": [
       "WTRQ 2210"
     ]
+  },
+  "WTRQ 2270": {
+    "text": "WTRQ 2210",
+    "courses": [
+      "WTRQ 2210"
+    ],
+    "source": "pstcc"
   },
   "WTRQ 2330": {
     "text": "WTRQ 2110 or WTRQ 2210",

--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -88,7 +88,19 @@ const tnConfig: StateConfig = {
   scrapers: {
     courses: [{ scripts: ["scripts/tn/scrape-banner-ssb.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/tn/transfer/scrape-all.ts"], runner: "http" }],
-    prereqs: [{ scripts: ["scripts/tn/scrape-catalog-prereqs.ts"], runner: "http" }],
+    // Hybrid prereqs, run in order: (1) rebuild ≈628 from live course-section
+    // prerequisite_text, then (2) merge ≈79 catalog-only prereqs on top (≈707).
+    // runner "playwright" because the catalog now sits behind AWS WAF and the
+    // scraper solves the JS challenge via headless Chromium (acalog-waf-fetch).
+    prereqs: [
+      {
+        scripts: [
+          "scripts/tn/aggregate-prereqs.ts",
+          "scripts/tn/scrape-catalog-prereqs.ts",
+        ],
+        runner: "playwright",
+      },
+    ],
     programs: [
       { scripts: ["scripts/tn/scrape-programs.ts"], runner: "http" },
       {

--- a/scripts/lib/__tests__/acalog-waf-fetch.test.ts
+++ b/scripts/lib/__tests__/acalog-waf-fetch.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { isWafChallenge, createAcalogFetch } from "@/scripts/lib/acalog-waf-fetch";
+
+/**
+ * Guards the regression that closed PR #1465: the old per-scraper retryFetch
+ * checked `res.ok`, which is TRUE for a 202, so an AWS WAF challenge (HTTP 202 +
+ * empty body) was returned as if it were a legitimate empty page — a silent
+ * partial scrape. isWafChallenge() must classify these as challenges so the
+ * fetcher solves the token / fails loudly instead of swallowing them.
+ */
+describe("isWafChallenge", () => {
+  it("treats HTTP 202 with an empty body as a challenge (acalog variant)", () => {
+    expect(isWafChallenge(202, "")).toBe(true);
+  });
+
+  it("treats a 202 with any body as a challenge", () => {
+    expect(isWafChallenge(202, "<html>anything</html>")).toBe(true);
+  });
+
+  it("treats a short 200 interstitial mentioning awswaf as a challenge (MN variant)", () => {
+    expect(isWafChallenge(200, "<script>window.awswaf.solve()</script>")).toBe(
+      true,
+    );
+  });
+
+  it("does NOT flag a normal 200 catalog page", () => {
+    const realPage =
+      "<html><body>" + "x".repeat(6000) + " course descriptions</body></html>";
+    expect(isWafChallenge(200, realPage)).toBe(false);
+  });
+
+  it("does NOT flag a short 200 page that merely lacks the awswaf marker", () => {
+    expect(isWafChallenge(200, "<html>tiny but real</html>")).toBe(false);
+  });
+
+  it("does NOT flag 404/500 as a challenge (handled by status, not WAF path)", () => {
+    expect(isWafChallenge(404, "")).toBe(false);
+    expect(isWafChallenge(500, "")).toBe(false);
+  });
+});
+
+describe("createAcalogFetch", () => {
+  it("returns a function with the (url, label, attempts) drop-in signature", () => {
+    const fetcher = createAcalogFetch({ ua: "test-agent" });
+    expect(typeof fetcher).toBe("function");
+    // url + label are required; attempts has a default, so arity is 2.
+    expect(fetcher.length).toBe(2);
+  });
+});

--- a/scripts/lib/acalog-waf-fetch.ts
+++ b/scripts/lib/acalog-waf-fetch.ts
@@ -1,0 +1,192 @@
+/**
+ * acalog-waf-fetch.ts — shared WAF-aware HTTP fetch for acalog-style catalogs.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Many acalog catalog hosts now sit behind AWS WAF bot protection. A flagged
+ * client gets **HTTP 202 with an empty body** (`x-amzn-waf-action: challenge`)
+ * instead of the catalog HTML — a JS challenge it expects a browser to solve.
+ *
+ * The original per-scraper `retryFetch` (copied from scripts/de/…) checked
+ * `res.ok`, which is `true` for a 202, and therefore returned the empty body as
+ * if it were a legitimate "no courses" / "no prereqs" page. The result was a
+ * SILENT partial scrape: list pages returned 0 coids → pagination stopped early;
+ * detail pages returned "" → courses were skipped — with no error and no retry.
+ * On 2026-06-21 this stripped tn prereqs 628 → 503 (slipping one course under
+ * the 80% regression guard) before it was caught in PR review.
+ *
+ * THE FIX
+ * -------
+ * Treat a 202 (and the MN-variant 200 + "awswaf" interstitial) as a challenge:
+ * solve it once via a headless-Chromium visit that yields an `aws-waf-token`
+ * cookie, carry that cookie on subsequent plain fetches for the same origin, and
+ * re-acquire if the challenge reappears. If the challenge cannot be cleared
+ * within the retry budget, **throw** — a loud failure that aborts the scrape and
+ * leaves existing data untouched, rather than a silent under-collection.
+ *
+ * Generalized from scripts/wa/scrape-catalog-prereqs.ts (same mechanism as
+ * scripts/mn/…). For non-WAF hosts this behaves exactly like the old fetch and
+ * never launches a browser — Chromium is only spawned when a challenge is seen.
+ *
+ * USAGE
+ * -----
+ *   import { createAcalogFetch } from "../lib/acalog-waf-fetch";
+ *   const retryFetch = createAcalogFetch({ ua: UA });
+ *   const html = await retryFetch(url, "list(cpage=1)");
+ */
+
+import { chromium } from "playwright";
+
+export const DEFAULT_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Per-origin token cache, shared across every fetcher created in the process so
+// concurrent scrapers hitting the same host don't each solve the challenge.
+const wafCookies = new Map<string, string>();
+const wafInFlight = new Map<string, Promise<string>>();
+
+/**
+ * True when an HTTP response is an AWS WAF challenge rather than real content.
+ * Two variants seen in the wild:
+ *   - acalog: HTTP 202 with an empty body
+ *   - MN-style: HTTP 200 with a short interstitial containing "awswaf"
+ */
+export function isWafChallenge(status: number, body: string): boolean {
+  if (status === 202) return true;
+  return body.length < 5_000 && body.includes("awswaf");
+}
+
+/**
+ * Solve the JS challenge in headless Chromium and capture the resulting cookie
+ * string (including `aws-waf-token`). Deduped per origin.
+ *
+ * `challengeUrl` must be the actual content URL that got challenged, NOT the
+ * bare origin: some WAF deployments (e.g. catalog.pstcc.edu) only issue the
+ * token on a real catalog path and never on `/`. We navigate to the challenged
+ * URL itself — which reliably triggers the token for every variant seen — and
+ * poll for the cookie rather than waiting a fixed interval, because the
+ * challenge resolves via a client-side reload that takes a variable moment.
+ */
+async function acquireWafCookies(
+  base: string,
+  challengeUrl: string,
+  ua: string,
+  force = false,
+): Promise<string> {
+  if (!force) {
+    const cached = wafCookies.get(base);
+    if (cached) return cached;
+  }
+  const inFlight = wafInFlight.get(base);
+  if (inFlight) return inFlight;
+
+  const p = (async () => {
+    console.log(`  Acquiring WAF token via headless browser: ${base}`);
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const ctx = await browser.newContext({ userAgent: ua });
+      const page = await ctx.newPage();
+      // networkidle lets the challenge's client-side reload settle. The reload
+      // can momentarily destroy the execution context, so the goto itself may
+      // throw — that's fine, we poll the cookie jar below regardless.
+      try {
+        await page.goto(challengeUrl, {
+          waitUntil: "networkidle",
+          timeout: 45_000,
+        });
+      } catch {
+        /* navigation churn during the challenge — proceed to poll */
+      }
+      // Poll up to ~12s for the token cookie to appear.
+      let cookieStr = "";
+      for (let i = 0; i < 8; i++) {
+        const cookies = await ctx.cookies();
+        cookieStr = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+        if (cookies.some((c) => c.name === "aws-waf-token")) break;
+        await page.waitForTimeout(1_500);
+      }
+      if (!cookieStr.includes("aws-waf-token")) {
+        console.log(`  ⚠ no aws-waf-token cookie acquired for ${base}`);
+      }
+      wafCookies.set(base, cookieStr);
+      return cookieStr;
+    } finally {
+      await browser.close();
+      wafInFlight.delete(base);
+    }
+  })();
+  wafInFlight.set(base, p);
+  return p;
+}
+
+export interface AcalogFetch {
+  (url: string, label: string, attempts?: number): Promise<string>;
+}
+
+export interface AcalogFetchOptions {
+  /** User-Agent for both fetch() and the Chromium challenge solve. */
+  ua?: string;
+  /** Default retry attempts when a call omits its own. */
+  attempts?: number;
+}
+
+/**
+ * Build a WAF-aware `retryFetch(url, label, attempts?)`.
+ *
+ * Drop-in for the old per-scraper signature `(url, label, attempts) => string`:
+ *   - 2xx (non-challenge) → returns the body
+ *   - 404 / other 4xx → returns "" (course delisted; skip silently — unchanged)
+ *   - 5xx → retried with backoff
+ *   - 202 / awswaf interstitial → solves the WAF token and retries
+ *   - all attempts exhausted → THROWS (loud failure, never a silent "")
+ */
+export function createAcalogFetch(opts: AcalogFetchOptions = {}): AcalogFetch {
+  const ua = opts.ua ?? DEFAULT_UA;
+  const defaultAttempts = opts.attempts ?? 4;
+
+  return async function retryFetch(
+    url: string,
+    label: string,
+    attempts = defaultAttempts,
+  ): Promise<string> {
+    const base = new URL(url).origin;
+    let lastErr: unknown;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        const headers: Record<string, string> = {
+          "User-Agent": ua,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+          Referer: `${base}/`,
+        };
+        const cookies = wafCookies.get(base);
+        if (cookies) headers["Cookie"] = cookies;
+
+        const res = await fetch(url, { headers });
+        // A 202 has an empty body; read it so the challenge check can run.
+        const body = res.ok || res.status === 202 ? await res.text() : "";
+        if (isWafChallenge(res.status, body)) {
+          // Force re-acquire after the first miss in case the token expired.
+          // Solve against the challenged URL itself — some WAFs only mint the
+          // token on a real content path, not the bare origin.
+          await acquireWafCookies(base, url, ua, i > 0);
+          continue;
+        }
+        if (res.ok) return body;
+        if (res.status >= 500) {
+          lastErr = new Error(`HTTP ${res.status}`);
+        } else {
+          return ""; // 404 etc. — course probably delisted; skip silently
+        }
+      } catch (e) {
+        lastErr = e;
+      }
+      await sleep(500 * Math.pow(2, i));
+    }
+    throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+  };
+}

--- a/scripts/tn/aggregate-prereqs.ts
+++ b/scripts/tn/aggregate-prereqs.ts
@@ -1,0 +1,27 @@
+/**
+ * aggregate-prereqs.ts (tn) — rebuild data/tn/prereqs.json from course sections.
+ *
+ * Runs FIRST in tn's scheduled prereqs job, before scrape-catalog-prereqs.ts.
+ *
+ * WHY a tn-specific wrapper rather than the generic scripts/lib version:
+ *   - The generic scripts/lib/aggregate-prereqs.ts SKIPS any state whose
+ *     StateConfig declares dedicated prereq scrape jobs (tn does) unless
+ *     --force is passed — that guard stops the post-scrape `aggregate-prereqs
+ *     <state>` step in scheduled-scrape-v2.yml from clobbering catalog output.
+ *   - tn is a *hybrid*: ≈628 prereqs come from real section prerequisite_text
+ *     (aggregation re-derives these every run, so they stay fresh as courses
+ *     change) and ≈79 come only from the Pellissippi catalog. We want both.
+ *
+ * So this wrapper forces the section rebuild; preserveSourcedEntries() inside
+ * aggregateState carries over the catalog scraper's `source: "pstcc"` entries
+ * from the committed file, and then scrape-catalog-prereqs.ts re-merges fresh
+ * catalog data on top. Net effect each run: 628 (live section-derived) + 79
+ * (catalog-only) = ≈707, with neither source able to silently drop the other.
+ *
+ * Usage: npx tsx scripts/tn/aggregate-prereqs.ts   (extra flags ignored)
+ */
+
+import { aggregateState } from "../lib/aggregate-prereqs";
+
+const count = aggregateState("tn", { force: true });
+console.log(`✓ tn section-aggregated prereqs rebuilt: ${count} entries`);

--- a/scripts/tn/scrape-catalog-prereqs.ts
+++ b/scripts/tn/scrape-catalog-prereqs.ts
@@ -35,10 +35,21 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { createAcalogFetch } from "../lib/acalog-waf-fetch";
 
 const BASE = "https://catalog.pstcc.edu";
 const CATOID = 20;       // Pellissippi 2026-2027 catalog id
 const NAVOID = 1165;     // "Course Descriptions" nav entry
+
+// We MERGE into the existing data/tn/prereqs.json rather than overwrite it.
+// That file's base is course-section-aggregated (≈628 entries, every one backed
+// by a live section's prerequisite_text — see scripts/tn/aggregate-prereqs.ts
+// which runs first in the prereqs job). This catalog adds ≈79 prereqs the
+// sections don't carry (e.g. AGRI). Each entry we own is tagged
+// `source: SOURCE` so a later `aggregate-prereqs --force` rebuild preserves it
+// via preserveSourcedEntries() instead of silently dropping it. Overwriting
+// here is exactly the regression that closed PR #1465 (628 → 503).
+const SOURCE = "pstcc";
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
@@ -58,37 +69,23 @@ const MAX_PAGES = 20;
 interface PrereqEntry {
   text: string;
   courses: string[];
+  /** Set on entries this scraper contributes, so a section-derived rebuild
+   *  (aggregate-prereqs --force) preserves them rather than dropping them. */
+  source?: string;
 }
 
 // ---------------------------------------------------------------------------
-// HTTP helpers (same shape as scripts/de/scrape-catalog-prereqs.ts)
+// HTTP helpers
 // ---------------------------------------------------------------------------
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
-  let lastErr: unknown;
-  for (let i = 0; i < attempts; i++) {
-    try {
-      const res = await fetch(url, {
-        headers: {
-          "User-Agent": UA,
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        },
-      });
-      if (res.ok) return res.text();
-      if (res.status >= 500) {
-        lastErr = new Error(`HTTP ${res.status}`);
-      } else {
-        return ""; // 404 — course probably delisted; skip silently
-      }
-    } catch (e) {
-      lastErr = e;
-    }
-    await sleep(500 * Math.pow(2, i));
-  }
-  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
-}
+// pstcc.edu moved behind AWS WAF (202 + empty body on plain fetch); the shared
+// WAF-aware fetcher solves the JS challenge via headless Chromium and carries
+// the aws-waf-token cookie. It throws (rather than silently returning "") when
+// a challenge can't be cleared, so a blocked run aborts instead of writing a
+// partial catalog. See scripts/lib/acalog-waf-fetch.ts.
+const retryFetch = createAcalogFetch({ ua: UA });
 
 // ---------------------------------------------------------------------------
 // Concurrency primitive
@@ -294,12 +291,43 @@ async function main() {
   console.log(`  Parsed ${seen}/${coidList.length} detail pages`);
   console.log(`  Extracted prereqs for ${Object.keys(prereqs).length} courses`);
 
-  // --- Write ---
+  // --- Merge into existing prereqs.json (never overwrite) ---
   const outDir = path.join(process.cwd(), "data", "tn");
   fs.mkdirSync(outDir, { recursive: true });
   const outPath = path.join(outDir, "prereqs.json");
-  fs.writeFileSync(outPath, JSON.stringify(prereqs, null, 2));
-  console.log(`\n✓ Wrote ${Object.keys(prereqs).length} prereqs to ${outPath}`);
+
+  let merged: Record<string, PrereqEntry> = {};
+  try {
+    const raw = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) merged = raw;
+  } catch {
+    /* no existing file — fresh start */
+  }
+  const baseCount = Object.keys(merged).length;
+
+  // Drop our own previous contributions so a re-run refreshes cleanly, leaving
+  // the course-aggregated base (entries without our source) untouched.
+  for (const k of Object.keys(merged)) {
+    if (merged[k]?.source === SOURCE) delete merged[k];
+  }
+
+  // Add only the catalog prereqs the base doesn't already carry. The base is
+  // derived from real section prerequisite_text, so on a key collision the base
+  // wins and we skip the catalog duplicate.
+  let added = 0;
+  for (const [key, entry] of Object.entries(prereqs)) {
+    if (merged[key]) continue;
+    merged[key] = { ...entry, source: SOURCE };
+    added++;
+  }
+
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(merged).sort()) sorted[key] = merged[key];
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(
+    `\n✓ Catalog yielded ${Object.keys(prereqs).length} prereqs; merged +${added} ` +
+      `net-new onto a base of ${baseCount} → ${Object.keys(sorted).length} total in ${outPath}`,
+  );
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## What changes for someone using the site

Tennessee's **course prerequisites get more complete and stop silently degrading**. The Pellissippi catalog (the source for all TBR prereqs) recently went behind a bot-protection wall, and the scheduled scraper was quietly overwriting the good prereq data with a partial copy — dropping prerequisites for ~200 health/trade courses (nursing, radiography, respiratory therapy, vet tech, med-lab) even though those classes are still actively offered. On the semester planner and course pages, a student looking up e.g. **NRSG 1120** would have stopped seeing its "NRSG 1710 + BIOL 2020" prerequisite. This PR restores those, *and* adds 79 catalog-only prerequisites the section data doesn't carry — net **628 → 707** entries for TN.

## What changes technically

The scheduled tn prereqs job ran *only* the catalog scraper, which **overwrote** `data/tn/prereqs.json`. Two root causes, both fixed:

1. **AWS WAF (silent partial).** `catalog.pstcc.edu` now answers plain `fetch()` with `HTTP 202` + empty body (a JS challenge). The old `retryFetch` treated 202 as a successful empty page (`res.ok` is `true` for any 2xx), so list pages returned 0 course IDs → pagination stopped early, detail pages were skipped — no error, no retry. New shared **`scripts/lib/acalog-waf-fetch.ts`** solves the challenge via headless Chromium (navigating the *challenged content URL* — pstcc never mints a token on the bare origin), carries the `aws-waf-token` cookie, and **throws** instead of returning `""` when a challenge can't be cleared.
2. **Overwrite → merge.** The catalog scrape now layers onto a course-aggregated base. tn's prereqs job is now `[aggregate (rebuild ~628 from live section prerequisite_text, --force), catalog (merge ~79 catalog-only, tagged source:"pstcc")]`. `preserveSourcedEntries` keeps the catalog entries across future section rebuilds; the section-derived base wins on collision. Self-healing and idempotent.

`runner` flips to `playwright` so cron installs Chromium for the WAF solve.

### Why this came up
Found while triaging the scheduled-scrape PR backlog. PR #1465 (tn) and #1464 (wa) were closed as partial-data; investigation showed tn's 503 was a *complete* catalog scrape, but the catalog is only one of two sources and the job was overwriting the richer course-aggregated file. (The wa hardening is deferred — it already has WAF handling and only drifted 1.8%.)

## Data delta
| | base | now |
|---|---|---|
| tn prereqs entries | 628 | **707** |

`+79 added, 0 removed, 0 of the 628 base entries changed` — the re-aggregation reproduces the existing base byte-for-byte, then adds the catalog-only entries.

## Test plan
- `npx tsc --noEmit` — clean
- `vitest run scripts/lib/__tests__/acalog-waf-fetch.test.ts` — 7 pass (202/empty-body challenge detection)
- `check:scrapers`, `check:config-data` — green
- Live end-to-end pipeline run (aggregate → catalog) verified: clears the WAF, parses all 718 catalog pages, lands at 707; a second tick stays 707 (catalog entries survive the section rebuild)
- Reader compatibility: MA already ships 925 `source`-tagged entries in prod; `lib/prereqs.ts` reads only `.text`/`.courses`

## Scope notes
Intentionally tn-only. The new `acalog-waf-fetch.ts` is available for the ~14 other plain-`fetch` catalog-prereq scrapers (de/ct/ky/nd/nv/pa/ri/vt/ma-middlesex/co/nh) to adopt later — they share the same latent 202-swallow bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)