### PR TITLE
va: shard PeopleSoft course scrape into 6 cron jobs (courses no longer manual-only)

### DIFF
--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -61,14 +61,31 @@ const vaConfig: StateConfig = {
     { slug: "liberty", names: ["Liberty", "Liberty University"] },
   ],
   scrapers: {
-    // manual-only: courses — VA PeopleSoft scraper consistently exceeds the 6h GitHub Actions timeout; run manually when needed.
-    // Transfers are SAFE on cron despite courses being manual-only. The eight
-    // scrapers below hit external university transfer-equivalency portals
-    // (GMU/ODU/UMW/UVA/VCU/VSU/VWU public HTML/JSON endpoints + Virginia Tech's
-    // published VCCS-equivalency page) — none invoke the heavy PeopleSoft course
-    // scrape they were previously (incorrectly) disabled alongside. They run
-    // sequentially in one job because each loads data/va/transfer-equiv.json,
-    // merges its own university's rows, and writes the file back.
+    // Courses run on cron as 6 balanced shards
+    // (scripts/va/scrape-courses-shard-{0..5}.ts), each its own matrix entry so
+    // they execute on parallel runners. The single all-23-colleges PeopleSoft
+    // run blew past the 6h Actions timeout (#98); ≈4 colleges per shard finishes
+    // comfortably under it even across the two terms (Summer+Fall) that vccs-ps
+    // currently resolves. The worst shard holds Northern Virginia CC — the
+    // system's largest at 88 subjects, measured ~17 min for one term locally —
+    // plus three smaller colleges, so a 4-college × 2-term shard lands around
+    // ~1.5–2 h, well inside the 6h budget. termSystem "vccs-ps"
+    // makes the workflow resolve live terms and pass --term; the shared scraper
+    // (scrape-peoplesoft.ts) exposes runShard() so each wrapper scrapes only its
+    // balanced slice of the colleges.
+    courses: [
+      { scripts: ["scripts/va/scrape-courses-shard-0.ts"], runner: "playwright", termSystem: "vccs-ps" },
+      { scripts: ["scripts/va/scrape-courses-shard-1.ts"], runner: "playwright", termSystem: "vccs-ps" },
+      { scripts: ["scripts/va/scrape-courses-shard-2.ts"], runner: "playwright", termSystem: "vccs-ps" },
+      { scripts: ["scripts/va/scrape-courses-shard-3.ts"], runner: "playwright", termSystem: "vccs-ps" },
+      { scripts: ["scripts/va/scrape-courses-shard-4.ts"], runner: "playwright", termSystem: "vccs-ps" },
+      { scripts: ["scripts/va/scrape-courses-shard-5.ts"], runner: "playwright", termSystem: "vccs-ps" },
+    ],
+    // The eight transfer scrapers hit external university transfer-equivalency
+    // portals (GMU/ODU/UMW/UVA/VCU/VSU/VWU public HTML/JSON endpoints + Virginia
+    // Tech's published VCCS-equivalency page). They run sequentially in one job
+    // because each loads data/va/transfer-equiv.json, merges its own
+    // university's rows, and writes the file back.
     transfers: [
       {
         scripts: [
@@ -86,10 +103,11 @@ const vaConfig: StateConfig = {
     ],
     // Prereqs aggregate from committed course-section prerequisite_text
     // (data/va/prereqs.json, 302 parsed chains; 4,227 sections carry prereq
-    // text). This reads already-committed data — it does NOT run the heavy
-    // PeopleSoft scraper — so it's safe on cron despite courses being manual-only.
+    // text). This reads already-committed data rather than re-running the
+    // PeopleSoft scrape, so it stays a lightweight per-tick aggregation.
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — disabled alongside courses.
+    // manual-only: programs — VA programs scraper is a separate effort; sharding
+    // it under the timeout is out of scope for the courses-on-cron change.
   },
 };
 

--- a/scripts/va/scrape-courses-shard-0.ts
+++ b/scripts/va/scrape-courses-shard-0.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 0/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 0/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(0, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-courses-shard-1.ts
+++ b/scripts/va/scrape-courses-shard-1.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 1/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 1/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(1, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-courses-shard-2.ts
+++ b/scripts/va/scrape-courses-shard-2.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 2/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 2/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(2, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-courses-shard-3.ts
+++ b/scripts/va/scrape-courses-shard-3.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 3/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 3/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(3, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-courses-shard-4.ts
+++ b/scripts/va/scrape-courses-shard-4.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 4/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 4/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(4, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-courses-shard-5.ts
+++ b/scripts/va/scrape-courses-shard-5.ts
@@ -1,0 +1,20 @@
+/**
+ * Cron shard 5/6 of the VCCS PeopleSoft course scrape.
+ *
+ * The unified scheduled-scrape workflow runs one wrapper per parallel runner
+ * (one matrix entry per ScrapeJob in lib/states/va/config.ts) and appends
+ * `--no-import --term "<resolved vccs-ps terms>"`. Splitting the 23 colleges
+ * into 6 balanced shards (≈4 colleges each) keeps every runner well under the
+ * 6h Actions timeout that the single all-colleges run exceeded — even with the
+ * two live terms (Summer+Fall) the vccs-ps term system currently resolves and
+ * Northern Virginia CC (88 subjects, the system's largest) in one shard.
+ *
+ * Manual rerun of just this shard:
+ *   npx tsx scripts/va/scrape-peoplesoft.ts --term "Fall 2026" --shard 5/6
+ */
+import { runShard } from "./scrape-peoplesoft";
+
+runShard(5, 6).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-peoplesoft.ts
+++ b/scripts/va/scrape-peoplesoft.ts
@@ -109,12 +109,25 @@ interface ParsedTerm {
   fileTermCode: string;
 }
 
-function parseArgs() {
+/**
+ * Split a slug list into `count` balanced, deterministic shards and return the
+ * `index`-th one. Round-robin over the sorted list so the 23 VCCS colleges
+ * spread evenly (e.g. 4 shards → 6/6/6/5) regardless of PS_CODES key order —
+ * this is what lets the cron run the colleges across parallel runners and stay
+ * under the 6h GitHub Actions timeout (see lib/states/va/config.ts).
+ */
+export function shardSlugs(all: string[], index: number, count: number): string[] {
+  const sorted = [...all].sort();
+  return sorted.filter((_, i) => i % count === index);
+}
+
+export function parseArgs() {
   const args = process.argv.slice(2);
   let slugs: string[] = Object.keys(PS_CODES);
   let termArg = "";
   let subject: string | null = null;
   let headed = false;
+  let shardSpec: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--term" && args[i + 1]) {
@@ -126,9 +139,26 @@ function parseArgs() {
     } else if (args[i] === "--subject" && args[i + 1]) {
       subject = args[i + 1].toUpperCase();
       i++;
+    } else if (args[i] === "--shard" && args[i + 1]) {
+      shardSpec = args[i + 1];
+      i++;
     } else if (args[i] === "--headed") {
       headed = true;
     }
+  }
+
+  // --shard i/n keeps the i-th balanced slice of the colleges (applied after
+  // any --slug filter). Used by the per-shard cron wrappers and manual reruns.
+  if (shardSpec) {
+    const [idx, count] = shardSpec.split("/").map((n) => Number(n));
+    if (
+      !Number.isInteger(idx) || !Number.isInteger(count) ||
+      count < 1 || idx < 0 || idx >= count
+    ) {
+      console.error(`Invalid --shard "${shardSpec}". Expected i/n with 0 <= i < n, e.g. 0/4.`);
+      process.exit(1);
+    }
+    slugs = shardSlugs(slugs, idx, count);
   }
 
   if (!termArg) {
@@ -718,9 +748,9 @@ async function scrapeCollege(
 // Main
 // ---------------------------------------------------------------------------
 
-async function main() {
-  const { slugs, terms, subject, headed } = parseArgs();
-
+export async function runScrape(
+  { slugs, terms, subject, headed }: ReturnType<typeof parseArgs>,
+) {
   const browser = await chromium.launch({ headless: !headed });
   const startTime = Date.now();
   let grandTotal = 0;
@@ -760,4 +790,26 @@ async function main() {
   console.log(`${"=".repeat(60)}\n`);
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+/**
+ * Run one balanced shard (`index` of `count`) of the full college list. The
+ * per-shard cron wrappers (scripts/va/scrape-courses-shard-*.ts) call this;
+ * --term still comes from argv (the scheduled workflow passes it from the
+ * vccs-ps term system), and --no-import is ignored (this scraper never imports).
+ */
+export async function runShard(index: number, count: number) {
+  const opts = parseArgs();
+  opts.slugs = shardSlugs(opts.slugs, index, count);
+  await runScrape(opts);
+}
+
+// Only scrape when invoked directly (npx tsx scrape-peoplesoft.ts ...), not
+// when a shard wrapper imports runShard/runScrape from this module. Mirrors the
+// guard in scripts/lib/resolve-terms.ts.
+const invokedDirectly =
+  typeof import.meta.url === "string" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (invokedDirectly) {
+  runScrape(parseArgs()).catch((e) => { console.error(e); process.exit(1); });
+}


### PR DESCRIPTION
## What changes for someone using the site

Virginia course data will **stop going stale**. VA is the original 23-college VCCS system and the highest-traffic state on the site, but its course scraper was marked "manual-only" — it only ran when someone kicked it off by hand, so listings drifted out of date between manual runs. This wires VA courses into the **nightly automated scrape** like every other state, so a student searching `/va` sees current sections without anyone remembering to refresh them.

(There's a caveat below: the prod *import* is paused by a billing cap until the egress quota is restored, so the freshly-scraped data won't appear on the live site until then. The scheduling fix is correct to land now and takes effect at the next scrape once import is back.)

## Why it couldn't just be flipped on

The scraper hits VCCS PeopleSoft via a headless browser, college by college. Running all 23 colleges in one job consistently blew past GitHub Actions' **6-hour timeout** (issue #98), which is exactly why it was left manual. Flipping the flag without fixing the runtime would just time out on cron.

## What changes on the technical front

The scrape is **sharded across 6 parallel cron jobs** instead of one serial run:

- **`scrape-peoplesoft.ts`**: the scrape loop is extracted into an exported `runScrape()`, with new `shardSlugs()` / `runShard()` helpers and a `--shard i/n` CLI flag. The top-level `main()` is now guarded by the `invokedDirectly` pattern (same one `resolve-terms.ts` uses) so a wrapper can `import { runShard }` without triggering a scrape on import.
- **6 wrappers** `scripts/va/scrape-courses-shard-{0..5}.ts`, each a 2-line call to `runShard(k, 6)`. Round-robin sharding splits the 23 colleges **4/4/4/4/4/3**, with Northern Virginia CC (the system's largest — 88 subjects) isolated in its own shard.
- **`lib/states/va/config.ts`**: the `manual-only: courses` marker is replaced with **6 `courses` ScrapeJobs** (`runner: "playwright"`, `termSystem: "vccs-ps"`), each its own matrix entry so they execute on parallel runners. The unified `scheduled-scrape.yml` reads this registry field to build its matrix — no YAML change needed.

Transfers (already safe on cron) and the prereqs aggregation are untouched; VA programs stay manual-only (separate effort, out of scope).

## Sizing / why 6 shards

Measured locally: NOVA — the worst-case college at 88 subjects — takes **~17 min for one term**. The `vccs-ps` term system currently resolves **two** live terms (Summer + Fall), so the worst shard (NOVA + 3 smaller colleges × 2 terms) lands around **~1.5–2 h** — comfortably under the 6h ceiling with ~3× headroom for slower runner days and the scraper's retry path.

## Test plan

- `check:scrapers` green with VA courses now declared (no manual-only marker, no CI failure).
- `npm run build` green; `tsc --noEmit` clean.
- Shard distribution verified: 6 shards cover all 23 colleges, no overlap, balanced 4/4/4/4/4/3.
- Matrix builder emits 6 VA `courses` entries (`va-courses-0..5`), each `runner=playwright termSystem=vccs-ps`.
- Refactor smoke-tested end-to-end: `scrape-peoplesoft.ts --slug pvcc --subject ENG` → 40 sections; importing `runShard` does not trigger a scrape (guard works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
