### PR TITLE
perf(courses): composite (state,term,title) trigram index — 50–500× faster course search

### DIFF
--- a/supabase/migrations/033_courses_search_composite_trgm.sql
+++ b/supabase/migrations/033_courses_search_composite_trgm.sql
@@ -1,0 +1,46 @@
+-- 033_courses_search_composite_trgm.sql
+--
+-- What:
+--   1. Add a composite GIN index on courses (state, term, course_title) that
+--      combines the scalar equality predicates with the title trigram match in
+--      a single index, via the btree_gin extension.
+--   2. Drop the dead idx_courses_fts (the GENERATED `fts` tsvector index from
+--      001_initial_schema.sql).
+--
+-- Why:
+--   Course keyword search runs `WHERE state = ? AND term = ? AND course_title
+--   ILIKE '%kw%'`. With only the single-column trigram index (021) plus the
+--   (state, term) btree, the planner had to BitmapAnd two huge bitmaps — the
+--   trigram match returns every "%kw%" title NATIONWIDE and (state, term)
+--   returns every section in that term — then intersect. On CA Fall that is
+--   ~41k ⋂ ~135k rows ≈ 1.4 s per keyword search (and the same shape caused the
+--   historical search 504s). A composite (state, term, course_title gin_trgm_ops)
+--   index lets a single bitmap index scan satisfy all three predicates at once.
+--
+--   idx_courses_fts has never been used (Supabase performance advisor: unused
+--   index) — title search is served by the trigram index, not the tsvector. The
+--   GIN index on `fts` is pure write-amplification on every course import, so we
+--   drop it. (The generated `fts` column itself is left in place; removing the
+--   column is a separate, more invasive change and is not needed to stop the
+--   index maintenance cost.)
+--
+-- Measured (EXPLAIN ANALYZE, prod, 1.45M-row courses):
+--   state=ca term=2026FA title ILIKE '%biology%'  1412 ms → 28 ms   (~50x)
+--   state=wa term=2026FA title ILIKE '%cse%'        410 ms →  0.8 ms (~500x)
+--   Both now use idx_courses_state_term_title_trgm as a single index scan.
+--
+-- Caveats / execution path:
+--   - Run statement-by-statement (Supabase Dashboard SQL Editor or one
+--     execute_sql call each). CREATE/DROP INDEX CONCURRENTLY CANNOT run inside a
+--     transaction (do not wrap in BEGIN/COMMIT).
+--   - CONCURRENTLY does not lock writes; the GIN build scans the table twice.
+--   - Idempotent: IF NOT EXISTS / IF EXISTS throughout.
+--   - Already applied to prod (project CC) via MCP on 2026-06-22; this file is
+--     the source-of-truth record (migrations here are applied by hand).
+
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_courses_state_term_title_trgm
+  ON courses USING gin (state, term, course_title gin_trgm_ops);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_courses_fts;


### PR DESCRIPTION
## What changes for someone using the site

**Course keyword search gets dramatically faster.** When a student types a word into course search (e.g. "biology", "welding"), the site queries Postgres for `state = X AND term = Y AND course_title ILIKE '%word%'`. On a big state that was taking **~1.4 seconds per search** — and it's the same query shape behind the search timeouts (504s) the site has hit historically. After this change the same searches return in **tens of milliseconds**.

Users see nothing new visually — searches just stop hanging. (Note: the site is currently in the Supabase egress-cap outage, so this lands now and pays off the moment that's restored; the index itself is already live on the database.)

## What changes on the technical front

Two index changes on the 1.45M-row `courses` table:

1. **New composite index** `idx_courses_state_term_title_trgm` — `GIN (state, term, course_title gin_trgm_ops)` via the `btree_gin` extension. Previously the planner had to `BitmapAnd` two huge bitmaps: the trigram match returned every `%word%` title **nationwide** (~41k rows for "biology") and `(state, term)` returned every section in that term (~135k on CA Fall), then intersect them. The composite index satisfies all three predicates — state, term, and the title trigram — in a **single bitmap index scan**.

2. **Drops `idx_courses_fts`** — the GIN index on the generated `fts` tsvector column from the initial schema. Supabase's performance advisor flagged it as **never used** (title search is served by the trigram index, not the tsvector), so it was pure write-amplification on every course import. The generated column itself is left in place (removing it is a separate, more invasive change).

### Measured before/after (EXPLAIN ANALYZE, prod, 1.45M rows)

| Query | Before | After | Speedup |
|---|---|---|---|
| `state=ca term=2026FA title ILIKE '%biology%'` | 1412 ms | 28 ms | ~50× |
| `state=wa term=2026FA title ILIKE '%cse%'` | 410 ms | 0.8 ms | ~500× |

Both now use `idx_courses_state_term_title_trgm` as a single index scan (no more BitmapAnd).

## How it was applied

Migrations on this project are applied by hand (Supabase Dashboard / MCP), so the index + extension + drop were **already applied to prod** via MCP, `CONCURRENTLY` (non-blocking, no table lock), and verified `indisvalid = true`. The committed `033_*.sql` is the source-of-truth record. No application code changes — the existing `.eq('state').eq('term').ilike('course_title', …)` query uses the new index automatically.

## Test plan

- Before/after `EXPLAIN ANALYZE` on prod confirms the new index is chosen and the ~50–500× speedup (table above).
- Index validity confirmed (`indisvalid`/`indisready` = true) after the `CONCURRENTLY` build.
- No code path references the dropped `fts` column / `textSearch` (grep-verified across `lib/`, `app/`, `scripts/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
