### PR TITLE
docs(state-goals): refresh finish-line plan to 2026-06-22 audit + rewrite 8 cheap-lever goals

### DIFF
--- a/docs/state-goals/README.md
+++ b/docs/state-goals/README.md
@@ -1,8 +1,8 @@
 # State goals — finish-line plan
 
-_Generated 2026-06-01 from the canonical `/state-audit` collector (`.claude/skills/state-audit/scripts/collect-audit-data.ts`) plus a 40-agent effort/lever diagnosis workflow. Grades respect `documentedCeilings`._
+_**Tier data refreshed 2026-06-22** from the canonical `/state-audit` collector (commit `e6626372`). The cross-cutting registry health items that used to span many states — empty `popularCourses`, null `seniorWaiver`, unwired transfer scrapers, HTML-contaminated prereqs, missing scorecards — are now **all resolved**; the remaining ladder is course-coverage scrapers. Grades respect `documentedCeilings`. The ranking under "Historical diagnosis" is the original **2026-06-01** 40-agent analysis, kept for its effort/tranche reasoning but partially stale (the F-tier shrank from 10 states to 1)._
 
-**How to use:** open `{slug}.md` for any unfinished state and paste its **Goal checklist** into a fresh Claude session — each is written to be actionable cold. Tick states off the tracker below as they cross the line. Re-run the collector to regenerate `_audit-snapshot.json` and re-grade.
+**How to use:** open `{slug}.md` for any unfinished state and paste its **Goal checklist** into a fresh Claude session — each is written to be actionable cold. Re-run the collector (`npx tsx .claude/skills/state-audit/scripts/collect-audit-data.ts`) to re-grade.
 
 > ⚠️ **Registration ≠ data completeness.** All 50 states + DC are in the registry; this plan is about raising the *data quality* of the 40 that aren't yet A-tier.
 
@@ -10,13 +10,67 @@ _Generated 2026-06-01 from the canonical `/state-audit` collector (`.claude/skil
 
 | Tier | Count | States |
 |------|-------|--------|
-| A | 11 | al, ct, de, ga, hi, ky, me, nv, sc, tn, ut |
-| B | 7 | co, dc, fl, la, mn, nh, ri |
-| C | 17 | ar, az, ca, il, ma, md, mi, mo, mt, nc, nd, nj, nm, or, pa, tx, vt |
-| D | 6 | ia, ny, oh, sd, va, wv |
-| F | 10 | ak, id, in, ks, ms, ne, ok, wa, wi, wy |
+| A | 21 | al, ar, ct, de, fl, ga, hi, in, ky, la, md, me, mn, nc, nj, nv, ri, sc, tn, ut, va |
+| B | 13 | ak, az, ca, co, dc, mi, mt, ne, nh, tx, vt, wa, wy |
+| C | 12 | id, il, ks, ma, mo, ms, nd, nm, ny, ok, or, pa |
+| D | 4 | ia, oh, sd, wv |
+| F | 1 | wi |
 
-**Done (A-tier, 11):** al, ct, de, ga, hi, ky, me, nv, sc, tn, ut
+**Done (A-tier, 21):** al, ar, ct, de, fl, ga, hi, in, ky, la, md, me, mn, nc, nj, nv, ri, sc, tn, ut, va
+
+_Movement since the 2026-06-01 baseline (11A/7B/17C/6D/10F): **+10 A, +6 B, −5 C, −2 D, −9 F** — no regressions. The single remaining F is `wi`._
+
+## Current status — every non-A state (2026-06-22)
+
+Authoritative current grades, regenerated from the collector. `Limited by` names the one dimension setting the composite (composite = worst dimension). The ceiling-capped transfer rows (co, dc, nh, vt, ms, ak) are at a documented structural limit, not an open gap.
+
+| State | Name | Tier | Limited by | Reason |
+|-------|------|------|-----------|--------|
+| [ak](ak.md) | Alaska | B | prereqs | 71 entries (needs ≥100 for A) |
+| [az](az.md) | Arizona | B | courses | 95% — 1 college (arizona-western: wired Colleague, transient 502) |
+| [ca](ca.md) | California | B | courses | 100% adj coverage; capped by stale + heterogeneous term codes |
+| [co](co.md) | Colorado | B | transfers | ceiling: U Denver only public CO receiver |
+| [dc](dc.md) | DC | B | transfers | ceiling: UDC equivalencies all out-of-state |
+| [mi](mi.md) | Michigan | B | courses | 94% — 1 college (alpena: wired Colleague, 0-section term bug) |
+| [mt](mt.md) | Montana | B | courses | 89% — 1 college (fort-peck: Jenzabar auth, PDF-only) |
+| [ne](ne.md) | Nebraska | B | courses | 89% — 1 college (NCTA: custom HTML, low-value) |
+| [nh](nh.md) | New Hampshire | B | transfers | ceiling: USNH publishes no public articulation DB |
+| [tx](tx.md) | Texas | B | courses | 100% adj coverage; capped by stale + heterogeneous term codes |
+| [vt](vt.md) | Vermont | B | transfers | ceiling: UVM only public VT receiver |
+| [wa](wa.md) | Washington | B | transfers | 2 universities, 48,100 mappings (a 3rd lifts to A) |
+| [wy](wy.md) | Wyoming | B | courses | 86% — 1 college (central-wyoming: SAML+WAF, Google-Docs only) |
+| [id](id.md) | Idaho | C | courses | 75% (3/4) |
+| [il](il.md) | Illinois | C | courses | 60% (29/48) |
+| [ks](ks.md) | Kansas | C | courses | 54% (13/24) |
+| [ma](ma.md) | Massachusetts | C | courses | 53% (8/15) |
+| [mo](mo.md) | Missouri | C | courses | 62% (8/13) |
+| [ms](ms.md) | Mississippi | C | transfers | thin: 1 university, 2,109 mappings |
+| [nd](nd.md) | North Dakota | C | courses | 63% (5/8) |
+| [nm](nm.md) | New Mexico | C | courses | 58% (7/12) |
+| [ny](ny.md) | New York | C | courses | 62% (23/37) |
+| [ok](ok.md) | Oklahoma | C | courses | 54% (7/13) |
+| [or](or.md) | Oregon | C | courses | 53% (9/17) |
+| [pa](pa.md) | Pennsylvania | C | courses | 67% (10/15) |
+| [ia](ia.md) | Iowa | D | courses | 31% (5/16) |
+| [oh](oh.md) | Ohio | D | courses | 41% (9/22) |
+| [sd](sd.md) | South Dakota | D | courses | 33% (2/6) |
+| [wv](wv.md) | West Virginia | D | courses | 33% (3/9) |
+| [wi](wi.md) | Wisconsin | F | prereqs | no prereqs file (also courses D, transfers C) |
+
+### Cheap-lever goals refreshed this pass (2026-06-22)
+
+These eight `{slug}.md` files were rewritten against current code evidence; the rest still carry their 2026-06-01 framing.
+
+- **wi** — aggregate on-disk prereqs → clears the only F (F→D).
+- **az** / **mi** — land an already-wired Colleague scraper (az = re-run a transient 502; mi = debug a 0-section term bug) → each B→A.
+- **wy** / **mt** / **ne** — *not* cheap flips: wy (SAML+WAF, Google-Docs-only) and mt (Jenzabar PDF-only) are deferred-buildables their config authors explicitly declined to ceiling; ne (NCTA) is low-value. Disposition documented; no quick win.
+- **ca** / **tx** — term-code hygiene: both at 100% adjusted coverage; the B-cap is mostly the collector flagging real-but-non-canonical term encodings. A grader-vocabulary fix, partly a grading artifact.
+
+---
+
+## ⓘ Historical diagnosis (generated 2026-06-01)
+
+> Everything below — the biggest-lever framing, secondary levers, the impact÷effort ranking, and the progress tracker — is from the original 2026-06-01 40-agent diagnosis. It is preserved for the effort/value reasoning, but **its tiers are stale**: use the current-status table above for authoritative grades. Many states ranked F/D/C here have since reached A (va, nc, ak, la, in, ar, md, nj, mn, fl, …). The "documented-ceiling" biggest lever was largely executed — that's why the F-tier collapsed from 10 to 1.
 
 ## 🎯 The single biggest lever
 

--- a/docs/state-goals/az.md
+++ b/docs/state-goals/az.md
@@ -1,30 +1,28 @@
 # Arizona (az) — state goals
 
-> **Current tier: C** · Rank **#4 of 40** · Tranche: **NOW** · Impact 5/5 · Effort: cheap · Value/effort: **H**
+> **Current tier: B** · Limited by: **courses** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _Large state; AWC re-run (transient 502) + central-AZ coursedog lands courses ~95% with tohono-oodham as documented ceiling -> composite A-/A._
+> _95% course coverage (18/19). The single gap, Arizona Western, already has a wired Colleague scraper that only failed on a transient 502 — a re-run flips B→A. tohono-oodham is already a documented ceiling._
 
 ## Diagnosis
 
-- **Primary gap:** Courses at 84% (16/19 system colleges); transfers (3 unis/31k mappings), prereqs (2788, clean), config, scorecard all A. 2 of 3 missing colleges are buildable, 1 is a documented ceiling.
-- **Cheapest lever** (wire-existing-scraper): Re-run scripts/az/scrape-colleague.ts --college arizona-western-college (transient 502 at last run; scraper already wired) to land AWC course data, then add central-arizona-college via a coursedog course scrape.
-- **Effort:** cheap — AWC already has a wired Colleague scraper (scripts/az/scrape-colleague.ts, host colss-prod.ec.azwestern.edu) that only failed on a transient 502 — re-run, no new code. central-arizona-college is public coursedog (catalog.centralaz.edu) with a reusable template (scripts/lib/scrape-coursedog.ts) and catalog data already on disk. Landing both takes courses to ~95%, clearing the 90% bar. No SSO/CAPTCHA blockers.
-- **Course colleges:** 2 buildable / 1 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** yes ✅
-
-> Notes: composite C, limitedBy courses only. tohono-oodham-community-college (jenzabar behind my.tocc.edu ICS login, tiny tribal college) is already in documentedCeilings.courseColleges — accept. No data/az/programs/ dir exists, so planner is not GOLD; that's the only thing between B+ and A-tier. central-az coursedog json on disk is catalog/program data (no sections), so a real course-section scrape is still needed for that college.
+- **Primary gap:** courses 95% (18/19). The lone missing college, `arizona-western-college`, already has a wired Colleague scraper — it just didn't land data on the last run. Transfers (3 unis/31k), prereqs (clean), scorecard, config all A. (central-arizona-college, a prior gap, has since landed.)
+- **Cheapest lever** (re-run a wired scraper): `scripts/az/scrape-colleague.ts` already declares AWC (host `colss-prod.ec.azwestern.edu`, documented in the file header). Last run hit a transient Ellucian-Cloud 502. Re-run; if the 502 persists, confirm the host resolves and retry — no new code.
+- **Effort:** cheap — one re-run, no new scraper.
+- **Course colleges:** 1 buildable (AWC, wired) / 0 blocked. `tohono-oodham-community-college` already in `documentedCeilings.courseColleges` (tribal Jenzabar behind login).
+- **Programs / planner:** 0 program files — planner not GOLD (an A-tier extra, not gating).
 
 ## Goal checklist
 
-### AZ — current tier C (limited only by courses; transfers/prereqs/config/scorecard all A)
+### AZ — current tier B (limited only by courses; all other dims A)
 
-- [ ] Re-run the already-wired Colleague scraper for Arizona Western (transient 502 last time): `npx tsx scripts/az/scrape-colleague.ts --college arizona-western-college` (host colss-prod.ec.azwestern.edu). Confirm data lands in `data/az/courses/arizona-western-college/`.
-- [ ] Add central-arizona-college course sections via coursedog: adapt `scripts/lib/scrape-coursedog.ts` for `catalog.centralaz.edu` (catalog data already at `data/az/coursedog-catalog/central-arizona-college.json`, 913/1412 have credits). Wire into a new `scripts/az/scrape-coursedog-courses.ts` and declare in `StateConfig.scrapers`.
-- [ ] Verify courses coverage: 18/19 ≈ 95% (tohono-oodham excused as documented ceiling) → courses clears 90% → composite A-/A.
-- [ ] Pre-PR check: load `/az`, search a course at AWC and Central AZ, confirm sections render.
-- [ ] (A-tier extra, optional) Create `data/az/programs/` aligned to institutions.json college_slug values to unlock the degree-path planner — currently 0 program files.
+- [ ] Pre-flight: `WT=$(scripts/new-pr-worktree.sh az-awc); cd "$WT"`.
+- [ ] Re-run the wired Colleague scraper for Arizona Western: `npx tsx scripts/az/scrape-colleague.ts --college arizona-western-college` (host `colss-prod.ec.azwestern.edu`). Confirm sections land in `data/az/courses/arizona-western-college/`.
+- [ ] If the host 502s again, verify it resolves (Ellucian-Cloud transient) and retry; do NOT substitute placeholder data.
+- [ ] Re-run the collector for az: courses → A (19/19 with tohono-oodham exempt), composite → A.
+- [ ] Pre-PR check: load `/az`, search an AWC course, confirm sections render with terms/credits.
+- [ ] PR (branch `claude/az-awc`): plain-English first ("Arizona Western College now shows course sections on the site"). Stage only `data/az/courses/arizona-western-college/**`. DO NOT MERGE — stop for review.
 
-Definition of done: AWC + Central AZ course data present and wired; courses ≥90% with tohono-oodham as documented ceiling; composite lifts to A-/A.
+Definition of done: AWC course data present; courses A (tohono-oodham documented ceiling); composite A.

--- a/docs/state-goals/ca.md
+++ b/docs/state-goals/ca.md
@@ -1,33 +1,31 @@
 # California (ca) — state goals
 
-> **Current tier: C** · Rank **#29 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+> **Current tier: B** · Limited by: **courses (term hygiene)** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=C` `prq=A` `trf=A` `sc=B` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _Highest student reach; ~9 detected colleges wire into existing templates (65%->85%) but the 90% bar needs ~27 custom re-fingerprints — biggest partial win, not a clean finish._
+> _Adjusted course coverage is effectively full (the unbuildable colleges are documented ceilings). The B-cap is now almost entirely term-code hygiene: the collector flags 10 "suspicious" + 1 stale term, but most are real 2026 terms in non-canonical encodings (`2026-FA`, `FA2026`, `26-FA`, …). A grader-vocabulary issue, partly a grading artifact._
 
 ## Diagnosis
 
-- **Primary gap:** 41 of 117 colleges have no course data (65% coverage, dim C); transfers/prereqs/config/scorecard all healthy (A/A/A/B). ~9 missing are buildable on existing generic templates; ~5 SSO-blocked; ~27 custom/unknown need re-fingerprint.
-- **Cheapest lever** (wire-existing-scraper): Wire the ~9 already-detected buildable colleges into the existing generic templates: add Colleague HOSTS entries (modesto, mt-san-jacinto, las-positas) and Banner SSB targets (glendale, ohlone, california-indian-nations, chabot banner-8), plus miracosta PeopleSoft and one new courseleaf scraper for long-beach. Lifts 76→~85/117.
-- **Effort:** medium — Generic scrape-banner-ssb.ts and scrape-colleague.ts templates already exist and are cron-wired; ~9 confirmed-buildable colleges have high-confidence guest courseSearchUrls in fingerprint-baseline.json and join via a HOSTS-map/target-list edit (cheap each). But reaching the 90% B+ bar requires the ~27 custom/unknown colleges too, which need re-fingerprinting (Ellucian-cloud subdomain probe) and likely several bespoke/cluster scrapers — a multi-hour body of work, not config-only.
-- **Course colleges:** 9 buildable / 5 blocked (of the missing set)
-- **Programs / planner:** 18 program files · aligned ✅ · planner-ready: yes
-- **Shippable (B+) bar met:** no
-
-> Notes: Fingerprint baseline (data/state-health/fingerprint-baseline.json, perCollege keyed {state}-{slug}) shows 115 ca colleges: 13 banner-ssb-9, 18 colleague, 1 banner-8, 1 courseleaf, 1 peoplesoft, 1 coursedog (all buildable), vs 52 custom + 23 unknown + 3 ellucian-experience + 2 auth-gated. Of the 41 missing: 9 buildable, 5 SSO-blocked (irvine-valley, mendocino, lake-tahoe, college-of-the-canyons + copper-mountain — last two flagged SAML/SSO inside scripts/ca/scrape-colleague.ts despite a Colleague detection), 27 custom/unknown. Many custom/unknown are district members (san-bernardino/crafton-hills, riverside/norco/moreno-valley) that may yield to re-fingerprint or cluster scrapers. Generic templates scrape-banner-ssb.ts/scrape-colleague.ts are cron-declared in lib/states/ca/config.ts; colleague template uses a HOSTS map so adding a college is a one-line edit. Programs (18 files in data/ca/programs) all align to college_slug — planner-visible. No documented course ceilings recorded.
+- **Primary gap:** `gradeCourses()` returns B only because `suspicious>0 || stale>0` (coverage is already ≥95% adjusted). CA's 10 suspicious terms are largely encoding variants of valid current terms across 117 colleges; the lone stale `2025FA` is a genuine old term a re-scrape clears.
+- **Cheapest lever** (grader term hygiene): teach the collector's `isSuspicious()` (`.claude/skills/state-audit/scripts/collect-audit-data.ts:213`) to recognize canonical-equivalent encodings (and real sub-sessions), ideally via a shared `lib/term-normalize.ts` also used on the courses read path so the UI groups terms consistently. Update `grade-snapshot.test.ts`.
+- **Honesty:** partly a grading-artifact fix, not new student data. The durable win is consistent term labels in the UI. The stale `2025FA` is a separate re-scrape.
+- **Effort:** medium — shared util + collector + snapshot test. Out of scope: per-college SIS scraper rewrites (coverage gaps are already ceiling-documented).
+- **Programs / planner:** 18 program files, aligned ✅ (planner-ready).
 
 ## Goal checklist
 
-### CA — current tier C (limited by courses, 65% / 76-117)
+### CA — current tier B (coverage maxed; limited by term-code hygiene)
 
-Wire/build course scrapers; transfers, prereqs, config, scorecard already A/A/A/B.
+This is the shared **ca/tx term-code hygiene** goal — one PR covers both states.
 
-- [ ] Add Colleague HOSTS entries in `scripts/ca/scrape-colleague.ts` for `mt-san-jacinto-community-college-district` (msjc.edu/Student/Courses), `las-positas-college` (laspositascollege.edu/Student/Courses); run + import.
-- [ ] Add Banner SSB targets to `scripts/ca/scrape-banner-ssb.ts` for `glendale-community-college` (portal.glendale.edu), `ohlone-college` (my.ohlone.edu), `california-indian-nations-college` (cincollege.org) — all have high-confidence guest URLs in `data/state-health/fingerprint-baseline.json`.
-- [ ] Build small scrapers: `chabot-college` (Banner 8 bwckschd at chabotcollege.edu), `miracosta-college` (PeopleSoft surf.miracosta.edu), `long-beach-city-college` (CourseLeaf lbcc-public.courseleaf.com), `modesto-junior-college` (WebAdvisor piratesnet.mjc.edu). Declare each in `lib/states/ca/config.ts` scrapers.courses.
-- [ ] Re-fingerprint the 27 custom/unknown (santa-monica, palomar, el-camino, riverside-city, cerritos, etc.) using Ellucian-cloud subdomain probe (colss-prod.ec/selfservice/reg-prod patterns) to convert to Colleague/Banner; build cluster scrapers (e.g. SBCCD: san-bernardino-valley+crafton-hills; RCCD: riverside-city+norco+moreno-valley).
-- [ ] Accept 5 SSO-blocked (irvine-valley, mendocino, lake-tahoe, college-of-the-canyons, copper-mountain) as documented ceilings.
-- [ ] Re-run state-audit; confirm coverage >=90% (>=105/117) for B+.
+- [ ] Pre-flight: `WT=$(scripts/new-pr-worktree.sh term-normalize); cd "$WT"`.
+- [ ] Add a canonical term normalizer (`lib/term-normalize.ts`): map separators / ordering / 2-3-digit-year variants → `YYYY<SEASON>[#]`; recognize real sub-sessions (MAY/DEC/SM/SUL/SUMINI/intersession) as valid.
+- [ ] Use it in `isSuspicious()` / term collection so canonical-equivalent codes stop counting; optionally also on the courses read path for UI consistency.
+- [ ] Update `grade-snapshot.test.ts` ca expected grade + a one-line justification.
+- [ ] Re-scrape (or prune) the genuinely-stale `2025FA`; spot-check any far-future codes are real.
+- [ ] Re-run collector for ca; `npm test`. Report suspicious/stale before→after. ca reaches A only if both hit 0; if not, say so honestly (stays B, with cleaner term labels).
+- [ ] PR (branch `claude/term-normalize`): plain-English first ("term labels across CA colleges are now recognized in their many formats, so the data-quality grade reflects reality"). DO NOT MERGE — stop for review.
 
-Definition of done: courses dim >=B+ (>=90% covered or remainder documented ceilings), all new scrapers cron-declared, audit re-run green.
+Definition of done: ca's suspicious-term count driven to ~0 via canonical recognition; stale cleared or named as a follow-up; snapshot test updated; honest about whether A is actually reached.

--- a/docs/state-goals/mi.md
+++ b/docs/state-goals/mi.md
@@ -1,30 +1,29 @@
 # Michigan (mi) — state goals
 
-> **Current tier: C** · Rank **#30 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+> **Current tier: B** · Limited by: **courses** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _Big state; build one Coursedog scraper (henry-ford+lake-michigan) + alpena re-run, then ceiling the 12 blocked — realistic cap ~61%, document the rest._
+> _94% adjusted coverage (16/17); 14 tribal/blocked colleges are already documented ceilings. The one remaining real gap is Alpena, whose Colleague scraper is wired but returns 0 sections — a term-selector bug to debug. Fixing it flips B→A._
 
 ## Diagnosis
 
-- **Primary gap:** 15 of 31 colleges have no course data (52% coverage); transfers (5 univ/152k mappings), prereqs (2317, clean), config, and scorecards are all A. Of the 15 gaps, ~3 are buildable (2 Coursedog + 1 declared-but-failing Colleague) and ~12 are SSO/CAPTCHA/custom-blocked.
-- **Cheapest lever** (build-course-scrapers): Build a MI Coursedog course-section scraper by adapting scripts/lib/scrape-coursedog.ts for henry-ford-college (hfcc.edu/courses) and lake-michigan-college (lakemichigancollege.events.prod.coursedog.com), wire it into lib/states/mi/config.ts scrapers, then run it.
-- **Effort:** medium — The only buildable course work is one new MI Coursedog scraper (adapt scripts/lib/scrape-coursedog.ts) covering henry-ford + lake-michigan, plus a rerun/fix of the already-declared Colleague target alpena. That is ~1-3hr. The remaining 12 gaps are genuinely blocked (Banner login/CAPTCHA on grcc/west-shore, Jenzabar SAML/guest-disabled on bay-de-noc/gogebic/kirtland/kbocc — already investigated, northwestern auth-gated, 4 custom with no public endpoint, wayne-county acalog catalog-only). 90% course bar is unreachable; ~58-61% is the realistic ceiling.
-- **Course colleges:** 3 buildable / 12 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** no
-
-> Notes: Colleague scraper (scripts/mi/scrape-colleague.ts) declares alpena-community-college but no data/mi/courses/alpena-community-college dir exists — target is failing (auth or term-discovery); needs a rerun/log check, not guaranteed. Jenzabar candidates bay-de-noc/gogebic/kirtland/kbocc already documented as SAML/guest-disabled in scrape-jenzabar-webforms.ts header — do not re-investigate. grcc/west-shore Banner noted in scrape-banner-ssb.ts as login-redirect/CAPTCHA. No documentedCeilings recorded in audit despite a real ~58-61% course ceiling — worth adding courseColleges ceilings for the 12 blocked colleges so courses grades fairly.
+- **Primary gap:** courses 94% adjusted (16/17). The 14 blocked colleges (tribal/SSO/CAPTCHA/acalog) are recorded in `documentedCeilings.courseColleges`. The lone non-ceiling gap is `alpena-community-college`.
+- **Cheapest lever** (debug a wired scraper): `scripts/mi/scrape-colleague.ts` declares alpena (host `acc-ss.colleague.elluciancloud.com`). `lib/states/mi/config.ts` explicitly notes alpena "responds 200 but the scraper finds 0 sections — a term-selector bug to debug (a deferred buildable), not a ceiling." Fix the term discovery for this tenant.
+- **Effort:** low-medium — not a new scraper; a term-selector/term-code fix in the existing Colleague scraper. Compare alpena's term-selector markup against a working mi Colleague college.
+- **Course colleges:** 1 buildable (alpena, wired but 0-section) / 14 documented ceilings.
+- **Programs / planner:** 0 program files (A-tier extra only).
 
 ## Goal checklist
 
-### MI — current tier C (limited by courses, 52% / 16-of-31)
+### MI — current tier B (limited only by courses; all other dims A)
 
-- [ ] Build MI Coursedog scraper: copy scripts/fl/scrape-coursedog.ts pattern using scripts/lib/scrape-coursedog.ts for henry-ford-college (hfcc.edu/courses) and lake-michigan-college (lakemichigancollege.events.prod.coursedog.com). Write to data/mi/courses/{slug}/.
-- [ ] Wire the new scraper into lib/states/mi/config.ts `scrapers.courses[]` (CI check:scrapers requires it).
-- [ ] Re-run scripts/mi/scrape-colleague.ts --college alpena-community-college; it is declared but produced no data/mi/courses/alpena dir. Capture the failure (auth vs term) and either fix or mark manual-only.
-- [ ] Record documented course ceilings in the audit/config for the 12 blocked colleges (grand-rapids, west-shore = Banner login/CAPTCHA; bay-de-noc, gogebic, kirtland, keweenaw-bay-ojibwa = Jenzabar SAML/guest-disabled per scrape-jenzabar-webforms.ts; northwestern-michigan = auth-gated; bay-mills, kalamazoo-valley, monroe-county, saginaw-chippewa = custom/no public endpoint; wayne-county = acalog catalog-only) so courses grades against the ~58-61% ceiling.
-- [ ] (Gold, optional) Add data/mi/programs/ via Coursedog programs template + align filenames to institutions.json college_slug for planner visibility.
+- [ ] Pre-flight: `WT=$(scripts/new-pr-worktree.sh mi-alpena); cd "$WT"`.
+- [ ] Reproduce: run `scripts/mi/scrape-colleague.ts` for alpena; confirm the host 200s but returns 0 sections.
+- [ ] Debug the term query/selector for the `acc-ss.colleague.elluciancloud.com` tenant — compare against a working mi Colleague college's term handling; fix so the current term resolves.
+- [ ] Land sections to `data/mi/courses/alpena-community-college/`.
+- [ ] Re-run the collector for mi: courses → A (17/17 adjusted), composite → A.
+- [ ] Pre-PR check: load `/mi`, search an Alpena course, confirm sections render.
+- [ ] PR (branch `claude/mi-alpena`): plain-English first ("Alpena Community College now shows course sections"). Stage only the scraper fix + `data/mi/courses/alpena-community-college/**`. DO NOT MERGE — stop for review.
 
-Definition of done: HFC + LMC course sections live under data/mi/courses/ and wired to cron; alpena resolved or documented; the 12 blocked colleges recorded as documented ceilings so courses is no longer flagged as an open buildable gap (shippable B+).
+Definition of done: alpena course data present; courses A; composite A. The 14 documented ceilings stay as-is (not buildable).

--- a/docs/state-goals/mt.md
+++ b/docs/state-goals/mt.md
@@ -1,31 +1,31 @@
 # Montana (mt) — state goals
 
-> **Current tier: C** · Rank **#8 of 40** · Tranche: **NOW** · Impact 2/5 · Effort: cheap · Value/effort: **H**
+> **Current tier: B** · Limited by: **courses** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=C` `prq=A` `trf=A` `sc=A` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _All dims A except courses 60%; the 4 missing are tribal/auth-gated ceilings — recording them lifts courses 60%->effective 100%, composite C->A._
+> _Three of the four tribal/auth-gated colleges are already documented ceilings; coverage is 89% (8/9). The single remaining gap, Fort Peck CC, is a deferred-buildable (Jenzabar auth-gated, but public PDF schedules exist) — its config author explicitly declined to call it a ceiling. NOT a cheap flip._
 
 ## Diagnosis
 
-- **Primary gap:** 4 of 10 colleges have no course data (60% coverage); all 4 are tribal/auth-gated colleges with no public course-search. Transfers (6 universities, 1309 mappings, wired), prereqs (119, clean), scorecard (10/10), config all A. No programs dir.
-- **Cheapest lever** (documented-ceiling-accept): Document the 4 missing tribal/auth-gated colleges (aaniiih-nakoda, stone-child, highlands-college-of-montana-tech, fort-peck) as course-data ceilings so the audit excuses them — lifts courses 60%→effective 100% and composite C→A with no scraping.
-- **Effort:** cheap — The composite is C limited ONLY by courses at 60%. The 4 missing colleges are not buildable: Aaniiih Nakoda + Stone Child are custom tribal-college sites with no courseSearchUrl, Highlands College of Montana Tech is auth-gated (high-confidence SSO), and Fort Peck's only Jenzabar URL is an Admissions/Apply portlet, not class search. These are a documented ceiling. Recording them as course-ceiling colleges (no scraping) excuses them, making 6/6 reachable = 100% and lifting courses C→A and composite to A. <1hr config/audit edit.
-- **Course colleges:** 0 buildable / 4 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** yes ✅
-
-> Notes: scripts/mt/ already has scrapers for the 6 covered colleges (banner8 for dawson+miles, cdkc, fvcc, lbhc, skc, transfer-ccn). dawson + chief-dull-knife are in lowSection (thin but present, not missing). Transfers via CCN are strong (A). Term 2025FA flagged stale — a cron rerun would refresh to current term but is not gating. Programs are manualOnly ("Phase 5+") — building them is a separate A-tier extra, not needed for a B+ finish. The 4 missing are classic tribal-college / SSO ceilings: no public Banner SSB / Colleague guest / CollegeScheduler endpoint detected.
+- **Primary gap:** courses 89% (8/9). Already-documented ceilings: aaniiih-nakoda, stone-child, highlands-college-of-montana-tech. The lone non-ceiling gap is `fort-peck-community-college`.
+- **Disposition (honest):** `lib/states/mt/config.ts` marks fort-peck `DEFERRED-scrapers`: its interactive Jenzabar JICS (`fpcportal.jenzabarcloud.com`) is auth-gated, BUT term-by-term **PDF class schedules are public** on a Webflow CDN (linked from fpcc.edu). The author's note verbatim: "Needs a PDF extractor — distinct, larger effort. **NOT a ceiling (data is public), just deferred.**"
+- **B is fair.** Two honest paths to A:
+  1. **Accept B** — fort-peck is one tiny tribal college; B is honest. (recommended unless going for A)
+  2. **Build a PDF extractor** — fetch the public term PDFs and parse sections → `data/mt/courses/fort-peck-community-college/`. A new capability (PDF parsing), medium effort. This is the only legitimate path to A — do NOT ceiling-document public data to game the grade.
+- **Effort:** accept-B is free; the PDF extractor is a genuine medium build.
+- **Course colleges:** 0 cleanly buildable / 1 deferred (fort-peck, PDF) / 3 documented ceilings.
+- **Programs / planner:** manual-only (A-tier extra).
 
 ## Goal checklist
 
-### MT — current tier C (courses-limited; prereqs/transfers/scorecard/config all A)
+### MT — current tier B (limited only by courses; all other dims A)
 
-The only gap is course coverage 60% (6/10). The 4 missing are not buildable — they are tribal/auth-gated colleges with no public class search. Accept them as a documented ceiling.
+- [ ] **Decide:** accept B (honest — fort-peck is tiny) OR build the PDF extractor for A.
+- [ ] If building: pre-flight `WT=$(scripts/new-pr-worktree.sh mt-fortpeck); cd "$WT"`.
+- [ ] Locate the public term-schedule PDFs (linked from fpcc.edu/academics; hosted on the Webflow CDN). Build a PDF→sections extractor (new capability) writing `data/mt/courses/fort-peck-community-college/`. Wire it in `lib/states/mt/config.ts scrapers.courses`, or mark `// manual-only:` with a reason if it can't be cron-stable.
+- [ ] Do NOT add fort-peck to `documentedCeilings` — the config author already ruled it's not a ceiling (data is public).
+- [ ] Re-run the collector for mt: courses A (9/9), composite A.
+- [ ] PR (branch `claude/mt-fortpeck`): plain-English first; note the PDF-extraction mechanism. DO NOT MERGE — stop for review.
 
-- [ ] In the state-audit ceiling config (the source feeding `documentedCeilings.courseColleges` / `ceilingsApplied`), add the 4 missing slugs as course-data ceilings: `aaniiih-nakoda-college` (custom, no courseSearchUrl), `stone-child-college` (custom, no courseSearchUrl), `highlands-college-of-montana-tech` (auth-gated/SSO, high confidence), `fort-peck-community-college` (Jenzabar URL is an Admissions/Apply portlet, not class search). Cite the fingerprint-baseline.json platform verdicts as rationale.
-- [ ] Re-run `state-audit mt` — with 6/6 reachable colleges covered, courses should hit ~100% → A, lifting composite to A/B+.
-- [ ] (Optional, non-gating) Rerun cron `scripts/mt/scrape-banner8.ts` etc. to refresh the stale `2025FA` term to current.
-- [ ] (A-tier extra, defer) Build `data/mt/programs/` + planner alignment — currently manualOnly "Phase 5+", not required for B+.
-
-Definition of done: composite >= B with courses A/B after the 4 unbuildable tribal/auth-gated colleges are recorded as documented ceilings; transfers/prereqs/scorecard/config remain A.
+Definition of done: mt accepted at B (no change) OR fort-peck PDF sections landed + wired → courses A, composite A. No ceiling-gaming.

--- a/docs/state-goals/ne.md
+++ b/docs/state-goals/ne.md
@@ -1,31 +1,29 @@
 # Nebraska (ne) — state goals
 
-> **Current tier: F** · Rank **#18 of 40** · Tranche: **NEXT** · Impact 2/5 · Effort: medium · Value/effort: **H**
+> **Current tier: B** · Limited by: **courses** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=B` `prq=A` `trf=F` `sc=A` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=B` `sc=A` `cfg=A`
 >
-> _Courses B, all else A; F is empty transfers only — one Transfer Nebraska scraper (portal exists) flips F->B/A._
+> _The old F is cleared — transfers are now wired (B). Courses are 89% (8/9); the single gap, Nebraska College of Technical Agriculture (NCTA), is a tiny custom-HTML UNL ag college — buildable but low-value. Two separate levers could lift to A: the NCTA course scraper (courses B→A) or deepening transfers (B→A)._
 
 ## Diagnosis
 
-- **Primary gap:** Transfers is the sole blocker: transfer-equiv.json is [] (0 mappings, 0 universities, unwired, no scraper, no documented ceiling) → drags composite to F. Courses B (8/9, only NCTA missing), prereqs A, config A, scorecard A all healthy; programs present and planner-aligned.
-- **Cheapest lever** (investigate-articulation): Investigate Nebraska's statewide articulation portal (Transfer Nebraska, transfer.nebraska.edu), build scripts/ne/scrape-transfer.ts, populate data/ne/transfer-equiv.json, and declare transfers in lib/states/ne/config.ts scrapers — this alone lifts composite F→B.
-- **Effort:** medium — One investigation + one scraper. NE's statewide articulation source (Transfer Nebraska / transfer.nebraska.edu, run by the state college + university system) is simply not registered — the audit's "no articulation portal" means unwired, not nonexistent. Building and wiring a transfers scraper is 1-4hr and flips the only failing dimension. NCTA course gap is trivial/low-value (already B).
-- **Course colleges:** 1 buildable / 0 blocked (of the missing set)
-- **Programs / planner:** 2 program files · aligned ✅ · planner-ready: yes
-- **Shippable (B+) bar met:** no
-
-> Notes: Courses already B (8/9); only NCTA (ncta.unl.edu, tiny UNL ag college, not in fingerprint-baseline) missing — buildable but low-value. Prereqs/config/scorecard all A. Programs: 2 files (southeast, western-nebraska), both filenames match institutions.json college_slug and internal college_slug — planner can see them. The single F is transfers (empty transfer-equiv.json, no ceiling). Fingerprint-baseline.json predates NE and has no NE entries, so SIS-platform judgment for missing college came from clusters.json (NCTA = singleton, ncta.unl.edu).
+- **Primary gap (this lever):** courses 89% (8/9). The lone gap is `nebraska-college-of-technical-agriculture` (ncta.unl.edu), a small custom-HTML site with no detected public SIS (not in fingerprint-baseline; clusters.json = singleton).
+- **Disposition (honest):** buildable IF a public course-search endpoint exists — needs a live probe (`ncta.unl.edu/...` for a sections page or JSON). If public → build a small bespoke scraper inline; if login-walled → document as a ceiling. Low value: NCTA is tiny and courses is already B.
+- **Secondary lever (out of scope here):** transfers are B (not A) — a separate improvement, not part of this courses flip.
+- **Effort:** low (small custom scraper) but low-value. Programs present and planner-aligned (2 files).
+- **Course colleges:** 1 probe (NCTA) / 0 blocked.
 
 ## Goal checklist
 
-### NE — current tier F (limited by transfers)
+### NE — current tier B (limited by courses; transfers now wired at B)
 
-- [ ] **Investigate articulation (cheapest high-value).** Check Nebraska's statewide transfer portal — Transfer Nebraska at transfer.nebraska.edu (NE state colleges + University of Nebraska system course-equivalency tool). Find a public/guest course-equivalency or API endpoint. If genuinely none exists publicly, document it as a transfers ceiling in `lib/states/ne/config.ts` and the audit ceiling list (accept-as-is) — that alone clears the composite blocker.
-- [ ] **Build the scraper** `scripts/ne/scrape-transfer.ts` (model on `scripts/me/scrape-transfer-mainestreet.ts` or `scripts/ct/scrape-transfer-all.ts`). In-state targets only (UNL/UNO/UNK + Chadron/Peru/Wayne state colleges). Drop any cross-state rows.
-- [ ] **Write** `data/ne/transfer-equiv.json` with non-trivial mappings (currently `[]`).
-- [ ] **Wire cron**: add `transfers: [{ scripts: ["scripts/ne/scrape-transfer.ts"], runner: ... }]` to `scrapers` in `lib/states/ne/config.ts` (remove the `// manual-only: transfers` marker).
-- [ ] **Verify** at `/ne/transfer`: pick a sending CC + course, confirm equivalency renders.
-- [ ] (Optional, low value) NCTA course scraper (ncta.unl.edu, 1 college) to push courses 89%→100%; courses is already B so skip unless going for gold.
+- [ ] Pre-flight: `WT=$(scripts/new-pr-worktree.sh ne-ncta); cd "$WT"`.
+- [ ] **Probe first** (audit hint is optimistic): check `ncta.unl.edu` for a public course/section listing or JSON endpoint (no SSO).
+  - If public → build a small bespoke scraper → `data/ne/courses/nebraska-college-of-technical-agriculture/`; wire in `lib/states/ne/config.ts scrapers.courses`.
+  - If login-walled / no public sections → add NCTA to `documentedCeilings.courseColleges` with the probe evidence.
+- [ ] Re-run the collector for ne: courses A (9/9 or NCTA exempt), composite A.
+- [ ] Pre-PR check: if built, load `/ne` and search an NCTA course.
+- [ ] PR (branch `claude/ne-ncta`): plain-English first; state whether NCTA was built or ceilinged, with the probe result. DO NOT MERGE — stop for review.
 
-Definition of done: `/ne/transfer` shows real in-state equivalencies, transfers scraper cron-wired, composite ≥ B.
+Definition of done: NCTA either has real course data OR is a probe-verified documented ceiling; courses A; composite A.

--- a/docs/state-goals/tx.md
+++ b/docs/state-goals/tx.md
@@ -1,31 +1,28 @@
 # Texas (tx) — state goals
 
-> **Current tier: C** · Rank **#21 of 40** · Tranche: **NEXT** · Impact 5/5 · Effort: medium · Value/effort: **M**
+> **Current tier: B** · Limited by: **courses (term hygiene)** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=C` `prq=A` `trf=A` `sc=B` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _Largest state but courses 90% unreachable; re-run 3 wired colleges (galveston/southmost/north-central) then document the 19 SSO/custom as ceiling -> shippable B+._
+> _Adjusted course coverage is full (unbuildable colleges are documented ceilings). The B-cap is term-code hygiene: 21 "suspicious" + 2 stale terms, but most suspicious ones are real terms in non-canonical encodings across 59 colleges (`2026-FA`, `226FA`, `26-FA`, `FA2026`, plus real sub-sessions `2026MAY`/`2026DEC`/`2026SUL`). Partly a grading artifact._
 
 ## Diagnosis
 
-- **Primary gap:** 22 of 59 colleges have no course data (63% coverage, grade C); transfers (43 univ / 187k mappings), prereqs (2511, clean), and config are all A. Most missing colleges are SSO/custom/catalog-only blocked — only 3 are already-wired-but-never-landed.
-- **Cheapest lever** (wire-existing-scraper): Re-run the 3 already-wired course scrapers (galveston/texas-southmost via scrape-colleague.ts, north-central-texas via scrape-jenzabar-webforms.ts) and verify/repair the host endpoints so their data actually lands — nudges coverage 63%→68% with zero new scaffolding.
-- **Effort:** medium — 3 missing colleges (galveston, texas-southmost, north-central-texas) are already in existing scraper HOSTS maps but never produced committed data — a verify/fix run, not net-new scaffolding (cheap, ~1hr). Beyond those, reaching the 90% courses bar is impossible: 4 are acalog/coursedog catalog-only (no live sections), 3 are jenzabar/colleague login-gated, and 12 are custom/unknown with no detected public endpoint — that's a documented ceiling, not a build task.
-- **Course colleges:** 3 buildable / 19 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** yes ✅
-
-> Notes: galveston-college + texas-southmost-college are in scripts/tx/scrape-colleague.ts HOSTS (added bulk in #550) but have no committed course file — never verified. north-central-texas-college is in scripts/tx/scrape-jenzabar-webforms.ts HOSTS (#708), also no data. These 3 are the only cheap course wins. austin-acc/hill/ranger are documented login-gated in scraper docstrings. brazosport/dallas/midland (acalog) + trinity-valley (coursedog) are catalog-only — no live section endpoint; trinity-valley already has a coursedog-catalog dump usable for prereqs only. Remaining 12 (grayson, san-jacinto, tyler-junior, angelina, central-texas, el-paso, lamar-state-orange, lee, southwest-texas-junior, western-texas, wharton-county, texas-state-technical) are custom/unknown with no public SIS detected. Even maxing every buildable college reaches only ~73% — courses is a documented structural ceiling, so composite C is near its realistic floor. shippableBarMet=true because transfers/prereqs/config pass and the courses shortfall is ceiling-bound, not a quality gap.
+- **Primary gap:** courses graded B only because `suspicious>0 || stale>0` (coverage ≥95% adjusted). TX's 21 suspicious terms split into (a) encoding variants of valid 2026 terms, (b) real sub-sessions outside the FA/SP/SU/WI vocabulary (MAY/DEC/SM/SUL/SUMINI), and (c) far-future codes (`2028*`/`2029*`) worth a spot-check. The 2 stale (`2024FA`,`2025FA`) are genuinely old.
+- **Cheapest lever** (grader term hygiene): the same shared `lib/term-normalize.ts` + `isSuspicious()` change as ca — one PR covers both states. Update `grade-snapshot.test.ts`.
+- **Honesty:** partly a grading-artifact fix. The far-future `2028`/`2029` codes are NOT encoding noise — list them as a data follow-up (verify at the offending colleges; fix or exclude). Stale clears on a re-scrape.
+- **Effort:** medium — shared util + collector + snapshot. Out of scope: per-college SIS rewrites (coverage already ceiling-documented).
+- **Programs / planner:** 0 program files (A-tier extra).
 
 ## Goal checklist
 
-### TX — current tier C (limited by courses; transfers/prereqs/config all A)
+### TX — current tier B (coverage maxed; limited by term-code hygiene)
 
-Course coverage is 37/59 (63%). The 90% bar is unreachable (16+ colleges are SSO/custom/catalog-only). Goal: capture the cheap already-wired colleges, then document the ceiling.
+Shared **ca/tx term-code hygiene** goal — one PR covers both (see `ca.md` for the core steps). TX-specific:
 
-- [ ] Re-run `npx tsx scripts/tx/scrape-colleague.ts --college=galveston-college` and `--college=texas-southmost-college` (hosts already in HOSTS map from #550). If endpoints 404/redirect-to-login, update the host in `scripts/tx/scrape-colleague.ts`; else commit the new `data/tx/courses/*` files. (+2 colleges)
-- [ ] Re-run `npx tsx scripts/tx/scrape-jenzabar-webforms.ts --college=north-central-texas-college` (host in HOSTS from #708); verify data lands or repair the portlet URL. (+1 college → 40/59, 68%)
-- [ ] For brazosport/dallas/midland (acalog) + trinity-valley (coursedog catalog-only): confirm no live section endpoint exists; if not, mark them documented course-ceiling colleges in the audit record rather than building.
-- [ ] Record the remaining 12 custom/unknown + 3 login-gated (austin-acc, hill, ranger) colleges as a documented course ceiling so composite isn't penalized as a gap.
+- [ ] In the normalizer, ensure TX's variants resolve: `2026-FA`/`226FA`/`26-FA`/`FA2026`/`S12026` → canonical; accept `2026MAY`/`2026DEC`/`2026-SM`/`2026SUL`/`2026SUMINI` as real sub-sessions.
+- [ ] Spot-check the far-future codes (`2028FA`/`2028SP`/`2028SU`/`2029FA`/`2029SP`/`2027-SP`/`SP2027`) — if a college mis-emits a year, fix at the scraper or exclude; if they're real advance terms, allow them.
+- [ ] Re-scrape / prune the stale `2024FA`,`2025FA`.
+- [ ] Update `grade-snapshot.test.ts` tx expected grade; re-run collector + `npm test`; report suspicious/stale before→after. tx reaches A only if suspicious AND stale hit 0 — be honest if it stays B.
 
-Definition of done: the 3 wired colleges either yield committed course data or are confirmed blocked, and the 19 unbuildable colleges are recorded as a documented courses ceiling — leaving TX shippable at B+ (transfers/prereqs/config A, courses ceiling-capped).
+Definition of done: tx's suspicious count driven down via canonical recognition + far-future triage; stale cleared or named as a follow-up; snapshot updated; honest about whether A is reached.

--- a/docs/state-goals/wi.md
+++ b/docs/state-goals/wi.md
@@ -1,31 +1,30 @@
 # Wisconsin (wi) — state goals
 
-> **Current tier: F** · Rank **#40 of 40** · Tranche: **LATER** · Impact 4/5 · Effort: hard · Value/effort: **L**
+> **Current tier: F** (the registry's only F) · Limited by: **prereqs** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=D` `prq=F` `trf=F` `sc=A` `cfg=A`
+> Dimensions: `crs=D` `prq=F` `trf=C` `sc=A` `cfg=A`
 >
-> _F from prereqs (cheap aggregate fix), but courses 25% with 12 WTCS singletons each on a distinct custom platform (0 clusters) = a ~12-scraper greenfield slog._
+> _F solely because `data/wi/prereqs.json` doesn't exist. Aggregating prerequisite text already on disk (no scraping) clears the F → D. Courses 25% (12 WTCS singletons on distinct custom platforms) is a separate ~12-scraper slog, out of scope for the cheap fix._
 
 ## Diagnosis
 
-- **Primary gap:** 12 of 16 WTCS colleges have no course data (25% coverage, D); prereqs F (no file) and transfers F (no portal) compound it. Config + scorecard are A.
-- **Cheapest lever** (build-prereqs): Aggregate prereqs.json from on-disk data: parse prerequisite_text/prerequisite_courses already present in data/wi/coursedog-catalog/nicolet-area-technical-college.json + the 4 scraped course files; flips prereqs F (the composite limiter) without any scraping.
-- **Effort:** hard — The 12 missing colleges are WTCS singletons each on a distinct custom platform (Drupal, CMC Portal ASP.NET, PHP, Colleague cloud) — clusters.json found 0 clusters, so each needs its own bespoke scraper (>half-day for the set). Transfers need articulation from scratch (no WI portal). Only prereqs is cheap.
-- **Course colleges:** 12 buildable / 0 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** no
-
-> Notes: WTCS = 16 colleges, shared statewide course numbering. Built bespoke so far: CVTC (PHP coursesearch), Western (Colleague elluciancloud guest), NTC (Drupal faceted search), SWTC (CMC Portal). All 4 wired in config courses[]. No fingerprint-baseline entries for WI colleges (grep empty); clusters.json reports 0 clusters/15 singletons — no shared-endpoint shortcut, each remaining college is its own scraper. Course files carry prerequisite_text/prerequisite_courses fields but sampled values are null, so prereq yield may be thin; the Nicolet coursedog dump (467KB) is the richest prereq source and also seeds Nicolet's course data. Transfers: no documented ceiling set, but no articulation portal exists. Programs: 0 files, Phase 6 found no catalog platform.
+- **Primary gap:** prereqs F (no file) is the composite limiter. Courses D (4/16), transfers C (1 uni). Config + scorecard A.
+- **Cheapest lever** (aggregate prereqs from on-disk data): set `prereqs: { source: "aggregate-from-courses" }` in `lib/states/wi/config.ts` (replacing the `// manual-only: prereqs` marker, ~line 91), then run `npx tsx scripts/lib/aggregate-prereqs.ts wi`. The aggregator reads `data/wi/coursedog-catalog/nicolet-area-technical-college.json` (~11 courses carry prereq text) + the 4 scraped course dirs (whose prereq fields are null), sanitizes via `scripts/lib/prereq-sanitize.ts`, and writes `data/wi/prereqs.json`. Auto-included in the Sunday prereq cron via `scripts/lib/scraper-matrix.ts`.
+- **Expected outcome (honest):** ~11 entries → prereqs F→B (≥10, wired, clean) → composite F→**D** (courses becomes the limiter). Coverage is thin (only Nicolet has prereq text) — name it. This clears the worst tier cheaply.
+- **Effort:** cheap (one config line + an aggregator run). The courses slog (12 WTCS bespoke scrapers, 0 clusters) and transfers depth are separate, hard, deferred.
+- **Course colleges:** 4 covered / 12 bespoke-buildable (each a distinct custom platform).
+- **Programs / planner:** 0 program files (A-tier extra only).
 
 ## Goal checklist
 
-### WI — current tier F (limited by prereqs)
+### WI — current tier F (limited by prereqs; cheap aggregation fix)
 
-- [ ] Build `data/wi/prereqs.json`: extractor over existing on-disk data — `data/wi/coursedog-catalog/nicolet-area-technical-college.json` (`prerequisite_text`/`prerequisite_courses`) + the 4 scraped course dirs (`data/wi/courses/*/2026FA.json`). Flips prereqs F→D/C, the composite limiter. (cheap)
-- [ ] Wire prereqs: add a `prereqs` aggregator script to `lib/states/wi/config.ts scrapers` and remove the `// manual-only: prereqs` marker. (cheap)
-- [ ] Ingest Nicolet courses from the coursedog dump → `data/wi/courses/nicolet-area-technical-college/` (1 more college, no scrape). (cheap)
-- [ ] Build bespoke course scrapers for remaining WTCS colleges (each public, distinct platform): madison-area (madisoncollege.edu), fox-valley (fvtc.edu), gateway (gtc.edu), milwaukee-area (matc.edu), waukesha-county (wctc.edu), moraine-park, blackhawk, lakeshore, mid-state, northeast-wisconsin (nwtc.edu), northwood. Adapt scrape-ntc/swtc/cvtc templates; wire each in config. Target >=90% coverage. (hard, ~1 scraper each)
-- [ ] Transfers: no WI articulation portal — investigate UW System / WTCS articulation or document as a ceiling. (hard)
-- [ ] Programs: Phase 6 found no platform — defer or investigate WTCS program catalogs.
+- [ ] Pre-flight: `WT=$(scripts/new-pr-worktree.sh wi-prereqs); cd "$WT"`.
+- [ ] In `lib/states/wi/config.ts`, replace the `// manual-only: prereqs` comment with `prereqs: { source: "aggregate-from-courses" },` inside `scrapers` (copy the VA pattern in `lib/states/va/config.ts`).
+- [ ] Run `npx tsx scripts/lib/aggregate-prereqs.ts wi` → writes `data/wi/prereqs.json` (~11 entries).
+- [ ] Verify: `jq 'length' data/wi/prereqs.json` (~11) and `grep -c '<' data/wi/prereqs.json` (expect 0 — no HTML). Re-run the collector for wi → prereqs B, composite D. State the thin-coverage caveat honestly; if <10 entries it stays C.
+- [ ] `npm run build` (the JSON must load via `lib/prereqs.ts loadPrereqs`).
+- [ ] PR (branch `claude/wi-prereqs`): plain-English first ("Wisconsin now has prerequisite data — ~11 courses from Nicolet's catalog — clearing it off the F tier; the remaining gap is course coverage"). Stage only `lib/states/wi/config.ts` + `data/wi/prereqs.json`. DO NOT MERGE — stop for review.
+- [ ] (Separate, hard, deferred) The 12 missing WTCS colleges (madison-area, fox-valley, gateway, milwaukee-area, waukesha-county, …) each need a bespoke scraper — a multi-day greenfield effort, NOT this PR.
 
-Definition of done: >=90% of 16 colleges have course data, prereqs.json present+wired, transfers built-or-ceilinged, config/scorecard stay A.
+Definition of done: `data/wi/prereqs.json` present + wired + clean (~11 entries); composite F→D; courses slog explicitly deferred; no placeholder data.

--- a/docs/state-goals/wy.md
+++ b/docs/state-goals/wy.md
@@ -1,30 +1,31 @@
 # Wyoming (wy) — state goals
 
-> **Current tier: F** · Rank **#22 of 40** · Tranche: **NEXT** · Impact 1/5 · Effort: medium · Value/effort: **M**
+> **Current tier: B** · Limited by: **courses** · _Refreshed 2026-06-22_
 >
-> Dimensions: `crs=B` `prq=A` `trf=F` `sc=A` `cfg=A`
+> Dimensions: `crs=B` `prq=A` `trf=A` `sc=A` `cfg=A`
 >
-> _F is empty transfers; investigate WCCC matrix or accept no-portal ceiling (cheap) + record central-wyoming SAML course ceiling -> composite B._
+> _Transfers are now wired (A) — the old F is cleared. Courses sit at 86% (6/7); the single gap, Central Wyoming College, is a genuine deferred-buildable (Colleague behind SAML-SSO + Cloudflare WAF; schedule only in Google Docs). B is an honest grade — this is NOT a cheap flip._
 
 ## Diagnosis
 
-- **Primary gap:** Composite F driven entirely by transfers: 0 mappings, 0 in-state university targets, no articulation portal registered. Courses/prereqs/config/scorecard are all A/B and healthy.
-- **Cheapest lever** (investigate-articulation): Investigate Wyoming's statewide articulation source (WCCC transfer matrix to UW), register it in data/articulation-portals.json, scrape/import in-state mappings, and declare scrapers.transfers in lib/states/wy/config.ts — moves transfers F→passing and lifts composite off F.
-- **Effort:** medium — The only F dimension (transfers) has no registered portal and no documented ceiling — it needs a 1-4hr investigation to find Wyoming's articulation source (statewide WCCC transfer matrix / WyoTransfer-style guide) and a scraper or static-import, then wire it. Everything else is already done or a hard blocker.
-- **Course colleges:** 0 buildable / 1 blocked (of the missing set)
-- **Programs / planner:** 0 program files · no programs · planner-ready: no
-- **Shippable (B+) bar met:** no
-
-> Notes: central-wyoming-college (the only course gap) is a genuine documented blocker: Colleague host central-ss.colleague.elluciancloud.com is 100% SAML-SSO-gated (tenant central.edu), course-search behind Cloudflare WAF, schedule only in Google Docs — marked DEFERRED-scrapers in config. Courses sit at 86% (6/7) and cannot realistically reach 90%; recommend recording central-wyoming-college as a documented courseColleges ceiling so 86% is excused. Transfers is the true F: WY has no entry in data/articulation-portals.json. If transfers can be accepted as a documented ceiling (no statewide machine-readable matrix found), the state would be B-shippable immediately via a one-line config flag + audit ceiling.
+- **Primary gap:** courses 86% (6/7). The lone gap is `central-wyoming-college`.
+- **Disposition (honest):** `lib/states/wy/config.ts` marks it `DEFERRED-scrapers`: Colleague host `central-ss.colleague.elluciancloud.com` is 100% SAML-SSO-gated (tenant central.edu), course-search is behind Cloudflare WAF, and the only public schedule is Google Docs spreadsheets — no stable machine-readable public SIS endpoint.
+- **B is fair.** Don't ceiling-game public-but-hard data. Two optional paths to A, both judgment calls:
+  1. **Defensible ceiling** — argue that a SAML+WAF SIS with data only in ad-hoc Google Docs is not a stable public endpoint, and record `central-wyoming-college` in `documentedCeilings.courseColleges`. Borderline (the Docs are technically public) — only if you can defend it in the PR.
+  2. **Bespoke build** — parse the public Google-Docs schedule spreadsheets → real sections. Honest but fragile/brittle; medium effort.
+- **Effort:** accept-B is free; the ceiling path is cheap metadata (but a judgment call); the build path is medium and brittle.
+- **Course colleges:** 0 cleanly buildable / 1 deferred-buildable.
+- **Programs / planner:** check `scripts/wy/scrape-programs.ts` base URLs — a separate GOLD lever, not this gap.
 
 ## Goal checklist
 
-### WY — current tier F (limited by transfers)
+### WY — current tier B (limited only by courses; transfers now wired/A)
 
-- [ ] Record course ceiling: add `central-wyoming-college` to WY's documentedCeilings.courseColleges (SAML-SSO + Cloudflare WAF, schedule only in Google Docs — see DEFERRED-scrapers note in `lib/states/wy/config.ts`). Excuses the 86% (6/7) coverage so courses passes at ceiling. (cheap)
-- [ ] Investigate Wyoming articulation: confirm whether WCCC publishes a machine-readable CC→University of Wyoming transfer matrix (WyoTransfer / UW transfer guides). No portal is in `data/articulation-portals.json` today. (medium)
-- [ ] If a source exists: register it in `data/articulation-portals.json`, write `scripts/wy/scrape-transfers.ts`, populate `data/wy/transfer-equiv.json` (in-state only, UW as receiver), then declare `scrapers.transfers` in `lib/states/wy/config.ts` and verify `/wy/transfer` renders an equivalency. (medium)
-- [ ] If NO machine-readable source exists: set transfers as a documented ceiling (`documentedCeilings.transfers=true`) with rationale — this alone lifts composite off F to B. (cheap)
-- [ ] (GOLD, optional) Fix `scripts/wy/scrape-programs.ts` catalog base URLs (currently western.edu/eastern.edu/northern.edu look wrong vs WY domains), run it, confirm `data/wy/programs/*.json` filenames match institutions.json college_slug values for planner visibility. (medium)
+- [ ] **Default: accept B.** It's an honest grade for a single SAML+WAF-gated college. Only pursue A if there's appetite.
+- [ ] If pursuing A, pre-flight `WT=$(scripts/new-pr-worktree.sh wy-central); cd "$WT"` and pick a path for `central-wyoming-college`:
+  - **Path A (defensible ceiling):** add it to `documentedCeilings.courseColleges` in `lib/states/wy/config.ts` with the SAML-SSO + Cloudflare-WAF + Google-Docs-only rationale (cite the existing `DEFERRED-scrapers` note). Only if you can defend "no stable public endpoint" in the PR body.
+  - **Path B (bespoke build):** write a parser over the public Google-Docs schedule spreadsheets → `data/wy/courses/central-wyoming-college/`; wire or mark `// manual-only:` honestly.
+- [ ] Re-run the collector for wy; confirm courses A, composite A.
+- [ ] PR (branch `claude/wy-central`): plain-English first; name the SAML/WAF reality and which path you took. DO NOT MERGE — stop for review.
 
-Definition of done: transfers either populated+wired OR a recorded documented ceiling, central-wyoming-college recorded as course ceiling → composite ≥ B, no placeholder data.
+Definition of done: wy accepted at B (no change) OR central-wyoming has real course data OR is a defensibly-documented ceiling; no placeholder data, no grade-gaming.


### PR DESCRIPTION
## What this changes

**For someone using the site: nothing.** This is an internal planning doc (`docs/state-goals/`) — the "finish-line plan" we paste from to dispatch per-state data work. No app code, no user-facing change.

**What it fixes:** the plan's tier data was generated **2026-06-01** (11A / 7B / 17C / 6D / 10F) and had gone badly stale. A fresh `/state-audit` collector run grades the registry at **21A / 13B / 12C / 4D / 1F** — the "documented-ceiling" lever was executed in the interim, collapsing the F-tier from **10 states to 1** (`wi`). Anyone opening the old plan would have re-investigated states that are already done.

## README changes

- Tier-distribution table + `Done (A-tier)` list refreshed to current grades (21 A-tier).
- New **"Current status — every non-A state"** table, regenerated straight from the collector (composite, the single limiting dimension, and reason per state) — the new authoritative index.
- Notes that the cross-cutting registry-health gaps that used to span many states (empty `popularCourses`, null `seniorWaiver`, unwired transfer scrapers, HTML-contaminated prereqs, missing scorecards) are now **all resolved** — the remaining ladder is course-coverage scrapers.
- The 2026-06-01 ranking/tranche/tracker prose is preserved (its effort reasoning is still useful) but fenced under a dated **"Historical diagnosis"** header so its stale tiers don't mislead.

## 8 cheap-lever goals rewritten against current code evidence

These are the dispatch artifacts (paste the **Goal checklist** into a fresh session). The old versions carried optimistic 2026-06-01 framing that the actual config/scraper code contradicts:

| State | Was framed as | Corrected disposition (this PR) |
|---|---|---|
| **wi** (F) | "hard, ~12 scrapers" | Cheap **prereqs aggregation** (`scripts/lib/aggregate-prereqs.ts` over on-disk Nicolet catalog) clears the only F → D. Courses slog stays deferred. |
| **az** (B→A) | "build central-AZ + AWC" | central-AZ already landed; only AWC left, and its Colleague scraper is **already wired** — just a **transient-502 re-run**. |
| **mi** (B→A) | "build Coursedog + ceiling 12" | The 14 blocked are already ceilings; only `alpena` remains — wired but **0-section term-selector bug to debug** (config says explicitly "not a ceiling"). |
| **wy** (B) | "cheap flip / ceiling" | `central-wyoming` is SAML-SSO + Cloudflare WAF, schedule only in Google Docs — a **deferred-buildable**, not a cheap flip. B is honest; A needs a fragile build or a defensible ceiling argument. |
| **mt** (B) | "ceiling the 4 tribal" | 3 already ceilinged; `fort-peck` is **Jenzabar PDF-only** and its author explicitly ruled it **NOT a ceiling**. A needs a real PDF extractor — no grade-gaming. |
| **ne** (B) | "build Transfer Nebraska" | Transfers already wired (B); only gap is `NCTA`, a **low-value custom-HTML probe**. |
| **ca / tx** (B) | "build 9 / re-fingerprint 27" + "ceiling 19" | Coverage is now **effectively maxed** (unbuildable colleges already ceilinged). The B-cap is **term-code hygiene** — the collector flags real-but-non-canonical encodings (`2026-FA`/`226FA`/`FA2026`). Goal is a shared term normalizer + `isSuspicious()` fix + `grade-snapshot.test.ts` update; **partly a grading artifact**, named as such. |

## Honesty notes

- `wy`/`mt` are **not** recommended as cheap A-flips — documenting public-but-hard data as a ceiling to move a grade is called out as off-limits.
- `ca`/`tx` term hygiene is flagged as **partly a grading-heuristic fix**, not new student data; far-future (`2028`/`2029`) and stale (`2024FA`/`2025FA`) terms are named as separate follow-ups.

## Test plan

Docs-only; no code paths touched. Verified: collector run at the branch HEAD (`e6626372`) reproduces 21A/13B/12C/4D/1F identically to the audit snapshot; the README's current-status table is generated from that JSON; `git status` shows only the 9 `docs/state-goals/` files (no derived-data churn).