### PR TITLE
perf(egress): cross-instance Data Cache for the per-college course loader

### DIFF
--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import type { CourseSection } from "./types";
 import { supabase } from "./supabase";
 import { runPooled } from "./concurrency";
@@ -81,59 +82,93 @@ const COURSE_COLUMNS =
 
 /**
  * Load all course sections for a given college and term from Supabase.
+ *
+ * Two cache layers, same pattern as the transfers-by-university loader
+ * (lib/transfer.ts), both keyed by (state, college, term):
+ *   1. in-memory `cached()` — intra-instance dedup + fast warm hits, and a
+ *      safety net for results too large for the Data Cache's ~2 MB item limit
+ *      (no single college's term comes close — NOVA tops out ~2k sections /
+ *      ~0.5 MB after the COURSE_COLUMNS projection).
+ *   2. `unstable_cache` — Vercel Data Cache, shared ACROSS serverless
+ *      instances, so crawler deep-links into /[state]/college/[id] and its
+ *      /courses/[prefix] pages stop re-querying Postgres on every cold start.
+ *      This is the courses analogue of the transfers caching (#1517 narrowed
+ *      the columns; this adds the cross-instance layer the college pages still
+ *      lacked). Safe here because this loader is only ever called from Next
+ *      routes — the build-time snapshot scripts read committed JSON, not this.
  */
 export async function loadCoursesForCollege(
   collegeSlug: string,
   term: string,
   state: string
 ): Promise<CourseSection[]> {
-  return cached(`courses:${state}:${collegeSlug}:${term}`, async () => {
-    // Supabase caps rows at 1000 by default. Paginate in parallel to get
-    // everything for colleges with more than 1000 sections (e.g. NOVA ~2000+).
-    const { count, error: countErr } = await supabase
-      .from("courses")
-      .select("id", { count: "exact", head: true })
-      .eq("college_code", collegeSlug)
-      .eq("term", term)
-      .eq("state", state);
+  return cached(
+    `courses:${state}:${collegeSlug}:${term}`,
+    () => _xInstanceCoursesForCollege(collegeSlug, term, state),
+  );
+}
 
-    if (countErr || !count || count === 0) {
-      if (countErr) console.error("loadCoursesForCollege count error:", countErr.message);
-      return [];
-    }
+// Cross-instance persistent cache (Vercel Data Cache). revalidate 1800s (30m)
+// matches the in-memory CACHE_TTL and is well within the ~3×/week scrape
+// cadence; unstable_cache keys on the arguments automatically.
+const _xInstanceCoursesForCollege = unstable_cache(
+  (collegeSlug: string, term: string, state: string) =>
+    _loadCoursesForCollege(collegeSlug, term, state),
+  ["courses-by-college"],
+  { revalidate: 1800, tags: ["courses"] },
+);
 
-    const PAGE_SIZE = 1000;
-    const pages = Math.ceil(count / PAGE_SIZE);
+async function _loadCoursesForCollege(
+  collegeSlug: string,
+  term: string,
+  state: string
+): Promise<CourseSection[]> {
+  // Supabase caps rows at 1000 by default. Paginate in parallel to get
+  // everything for colleges with more than 1000 sections (e.g. NOVA ~2000+).
+  const { count, error: countErr } = await supabase
+    .from("courses")
+    .select("id", { count: "exact", head: true })
+    .eq("college_code", collegeSlug)
+    .eq("term", term)
+    .eq("state", state);
 
-    // Concurrency-cap page fetches (same pattern as loadAllCourses). The
-    // college page loads courses for every term simultaneously; without a cap,
-    // 4 terms × 3 pages × 3 build workers = 36 concurrent Supabase queries
-    // from this one function alone, which saturates the connection pool and
-    // causes statement_timeout on other queries.
-    const tasks: Array<() => Promise<CourseSection[]>> = [];
-    for (let i = 0; i < pages; i++) {
-      const start = i * PAGE_SIZE;
-      const end = start + PAGE_SIZE - 1;
-      tasks.push(async () => {
-        const { data, error } = await supabase
-          .from("courses")
-          .select(COURSE_COLUMNS)
-          .eq("college_code", collegeSlug)
-          .eq("term", term)
-          .eq("state", state)
-          .order("id", { ascending: true })
-          .range(start, end);
-        if (error) {
-          console.error(`loadCoursesForCollege page ${i} error:`, error.message);
-          return [];
-        }
-        return (data || []).map(mapRow);
-      });
-    }
+  // Throw (don't return []) on a Supabase error so neither cache layer pins an
+  // empty "no courses" result: in prod there is no JSON fallback, so a cached
+  // [] from a transient error would persist for the full 30-min TTL across
+  // every instance. A legitimate count === 0 (the college doesn't offer this
+  // term) is a real empty and is safe to cache.
+  if (countErr) throw countErr;
+  if (!count || count === 0) return [];
 
-    const results = await runPooled(tasks, 5);
-    return results.flat();
-  });
+  const PAGE_SIZE = 1000;
+  const pages = Math.ceil(count / PAGE_SIZE);
+
+  // Concurrency-cap page fetches (same pattern as loadAllCourses). The
+  // college page loads courses for every term simultaneously; without a cap,
+  // 4 terms × 3 pages × 3 build workers = 36 concurrent Supabase queries
+  // from this one function alone, which saturates the connection pool and
+  // causes statement_timeout on other queries.
+  const tasks: Array<() => Promise<CourseSection[]>> = [];
+  for (let i = 0; i < pages; i++) {
+    const start = i * PAGE_SIZE;
+    const end = start + PAGE_SIZE - 1;
+    tasks.push(async () => {
+      const { data, error } = await supabase
+        .from("courses")
+        .select(COURSE_COLUMNS)
+        .eq("college_code", collegeSlug)
+        .eq("term", term)
+        .eq("state", state)
+        .order("id", { ascending: true })
+        .range(start, end);
+      // Throw on a page error too, so a partial result is never cached.
+      if (error) throw error;
+      return (data || []).map(mapRow);
+    });
+  }
+
+  const results = await runPooled(tasks, 5);
+  return results.flat();
 }
 
 /**

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -147,9 +147,11 @@ export async function loadTransferMappingsByUniversity(
 // Cross-instance persistent cache (Vercel Data Cache). revalidate 1800s (30m)
 // matches the in-memory CACHE_TTL and is well within the ~3×/week scrape
 // cadence. unstable_cache keys on the function arguments automatically; the
-// keyParts entry is just a stable namespace. Only the transfers loader gets
-// this — the courses loaders run inside build scripts (no Next cache context),
-// whereas this loader is only ever called from Next routes (verified).
+// keyParts entry is just a stable namespace. The per-college courses loader
+// (lib/courses.ts loadCoursesForCollege) now uses the same two-layer pattern;
+// both are only ever called from Next routes — the build-time snapshot scripts
+// read committed JSON, not these loaders. loadAllCourses stays uncached: a big
+// state (CA ~135k sections) exceeds the Data Cache's ~2 MB per-item limit.
 const _xInstanceTransfersByUniversity = unstable_cache(
   (state: string, university: string, cap?: number) =>
     _loadTransferMappingsByUniversity(state, university, cap),


### PR DESCRIPTION
## What changes for someone using the site

No visible change — this is a performance/cost fix. College pages (`/[state]/college/[id]` and their per-subject `/courses/[prefix]` pages) will serve faster under crawler load and stop hammering the database with repeat reads. It does **not** change what any page shows.

(Context: the site is currently in the Supabase egress-cap outage. This lands now and its benefit kicks in once that cap is lifted.)

## What changes on the technical front

The per-college course loader `loadCoursesForCollege` was cached **only in memory** (`cached()`, 30-min TTL). On Vercel's serverless runtime that cache lives inside one function instance and dies on cold start — so under crawler traffic (which fans out across many short-lived instances and hits thousands of college/subject deep-links), almost every request was a cache miss that re-queried Postgres. That's a standing contributor to the Supabase egress overage even after #1517 narrowed the columns.

This wraps the loader in the **exact two-layer pattern the transfers loader already uses** (`lib/transfer.ts`):
1. in-memory `cached()` — intra-instance dedup + a safety net for the Data Cache's ~2 MB item limit;
2. **`unstable_cache`** (Vercel Data Cache, `revalidate: 1800` = the existing 30-min TTL) — persists **across** instances, so cold starts and crawler deep-links read the cache instead of Postgres.

**Why only this loader:** per-college results stay well under the ~2 MB Data Cache item limit (NOVA, the largest, is ~0.5 MB after the `COURSE_COLUMNS` projection). `loadAllCourses` is deliberately left uncached — a big state (CA ~135k sections ≈ 34 MB) exceeds that limit and `unstable_cache` would silently skip it anyway.

**Correctness — cache-poisoning guard:** `_loadCoursesForCollege` now **throws** on a Supabase error instead of returning `[]`. Without this, a transient error would pin an empty "no courses" result for the full 30 min across every instance (prod has no JSON fallback — it's excluded from the serverless bundle). A legitimate `count === 0` (a college that doesn't offer the term) still returns `[]` and is safely cached. This matches the transfers loader's guard.

Also corrects a now-stale comment in `transfer.ts` that said the courses loaders can't use this pattern because they "run inside build scripts" — verified they don't: the build-time snapshot scripts read committed JSON, and this loader is only ever called from Next routes.

## Test plan

- `npm run typecheck` clean; `npm run build` green (confirms `unstable_cache` works and the prebuild snapshot scripts are unaffected).
- No tests reference `loadCoursesForCollege` (the error-behavior change touches no test expectations).
- **Known limit:** the egress/cache-hit benefit is only measurable under live traffic once the Supabase egress cap is lifted — it can't be verified against prod right now (all REST is 402'd). The change mirrors the already-deployed transfers caching pattern exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
