### PR TITLE
data(wi): aggregate prereqs from on-disk catalog → clears the only F (F→D)

### DIFF
--- a/data/wi/prereqs.json
+++ b/data/wi/prereqs.json
@@ -1,0 +1,42 @@
+{
+  "851 750": {
+    "text": "74-851-740 or consent of instructor.",
+    "courses": []
+  },
+  "854 720": {
+    "text": "73-854-710 or consent of instructor. Lecture. 3 credits.",
+    "courses": []
+  },
+  "854 730": {
+    "text": "73-854-720 or consent of instructor. Lecture. 3 credits.",
+    "courses": []
+  },
+  "854 760": {
+    "text": "76-854-750 or consent of instructor. Lecture. 3 credits.",
+    "courses": []
+  },
+  "856 740": {
+    "text": "Science I or consent of instructor. 1-3 credits.",
+    "courses": []
+  },
+  "858 720": {
+    "text": "73-858-710 or consent of instructor. Lecture. 3 credits.",
+    "courses": []
+  },
+  "858 730": {
+    "text": "73-858-720 or consent of instructor. Lecture. 3 credits",
+    "courses": []
+  },
+  "858 740": {
+    "text": "74-858-730. Lecture. 3 credits.",
+    "courses": []
+  },
+  "858 750": {
+    "text": "74-858-740. Lecture. 3 credits.",
+    "courses": []
+  },
+  "858 760": {
+    "text": "76-858-750. Lecture. 3 credits.",
+    "courses": []
+  }
+}

--- a/lib/states/wi/config.ts
+++ b/lib/states/wi/config.ts
@@ -88,7 +88,10 @@ const wiConfig: StateConfig = {
     // COVERAGE GAP: UW-Milwaukee is the only receiver with a public API; other
     // UW campuses are Transferology-gated.
     transfers: [{ scripts: ["scripts/wi/scrape-transfer-uwm.ts"], runner: "http" }],
-    // manual-only: prereqs — Coursedog catalog data for Nicolet Area TC at data/wi/coursedog-catalog/; aggregate into prereqs.json manually.
+    // Prereqs aggregated from on-disk course/catalog data (no scrape). Only
+    // Nicolet's Coursedog catalog (data/wi/coursedog-catalog/) carries prereq
+    // text; the 4 scraped WTCS colleges have none, so coverage is thin (~11).
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — Phase 6 discovery found no matching catalog platforms; manual investigation needed.
   },
 };


### PR DESCRIPTION
## What this changes

**For someone using the site: effectively nothing visible today** — and I'd rather say that plainly than dress it up. This clears Wisconsin off the bottom (**F**) tier of our internal data-quality audit and wires up the prerequisite pipeline so it grows on its own going forward.

Wisconsin was the registry's **only F-tier state**, solely because it had no `data/wi/prereqs.json` file. This adds one (10 prerequisite entries) by aggregating prereq text already on disk — no scraping.

## Why the user-facing impact is minimal (being upfront)

The 10 entries all come from **Nicolet Area Technical College's** course catalog — remedial ABE courses (Math/Reading, prefixes 854/858/851). Two honest limitations:
- Those course codes have **no section data on the site** (Nicolet isn't one of WI's 4 scraped colleges, and the codes don't appear in the scraped ones), so the prereqs don't currently surface on any course page.
- WTCS's aid-prefixed numbering (`73-854-720`) doesn't resolve into the structured `courses[]` chain via the generic extractor, so every entry has clean prereq **text** but an empty `courses[]` (no clickable chain). Resolving WTCS's format is a possible follow-up, not this PR.

## The actual win

- **Clears the only F:** prereqs **F→B** (10 entries, wired, clean) → composite **F→D**. Courses (25% coverage — a separate ~12-scraper WTCS slog) is now the limiter; that's explicitly out of scope here.
- **Pipeline wiring (the durable part):** `lib/states/wi/config.ts` now declares `prereqs: { source: "aggregate-from-courses" }`, so `scripts/lib/aggregate-prereqs.ts` runs WI in the weekly prereq cron automatically. As future WI course scrapers land, prereq coverage grows with **no further config**.

## Files
- `lib/states/wi/config.ts` — replace the `// manual-only: prereqs` marker with the aggregate-from-courses declaration (+ a comment explaining the thin-source reality).
- `data/wi/prereqs.json` — new, 10 entries.

## Test plan
- `npx tsx scripts/lib/aggregate-prereqs.ts wi` → 10 entries written.
- Collector for `wi`: prereqs **B**, composite **D** (was F), limited by courses.
- `check:scrapers` ✓ (prereqs datatype now accounted for), `check:config-data` ✓, `check:data` → 0 errors (no new wi orphan-prereq refs, since `courses[]` are empty).
- No browser check: the affected courses have no pages on the site, so there is nothing observable in the preview — stated honestly rather than faked.