### PR TITLE
audit: fix lexicographic isStale() bug + re-green drifted grade snapshot

### DIFF
--- a/.claude/skills/state-audit/scripts/collect-audit-data.ts
+++ b/.claude/skills/state-audit/scripts/collect-audit-data.ts
@@ -200,14 +200,34 @@ function currentTerms(): { current: string[]; staleThreshold: string } {
     terms.push(`${year - 1}FA`);
   }
 
-  // Stale = more than 2 semesters ago
+  // Stale threshold = Spring of (last year in H1, else this year), compared
+  // chronologically via termRank below — NOT lexicographically. Alphabetical
+  // order ranks "FA" < "SP", so the old `term < threshold` wrongly flagged a
+  // recent Fall term (e.g. 2025FA) as older than a 2025SP threshold. The
+  // threshold season is always SP so the chronological compare reproduces the
+  // intended "prior academic year is stale" boundary in both halves of the year.
   const staleYear = month <= 6 ? year - 1 : year;
-  const staleSeason = month <= 6 ? "SP" : "FA";
-  return { current: terms, staleThreshold: `${staleYear}${staleSeason}` };
+  return { current: terms, staleThreshold: `${staleYear}SP` };
+}
+
+// Chronological rank of a term (higher = more recent), using 3 primary seasons
+// per academic year (SP < SU < FA). WI ≈ end-of-year (FA rank); U#/S# encode
+// summer/spring sub-sessions. Returns null for unrecognized forms — those are
+// caught by isSuspicious, and the staleness of a malformed term is unknowable.
+const SEASON_RANK: Record<string, number> = { SP: 0, SU: 1, FA: 2, WI: 2 };
+function termRank(term: string): number | null {
+  const m = term.match(/^(\d{4})(SP|SU|FA|WI)\d?$/);
+  if (m) return parseInt(m[1], 10) * 3 + SEASON_RANK[m[2]];
+  const sub = term.match(/^(\d{4})(U|S)\d$/);
+  if (sub) return parseInt(sub[1], 10) * 3 + (sub[2] === "U" ? 1 : 0);
+  return null;
 }
 
 function isStale(term: string, threshold: string): boolean {
-  return term < threshold;
+  const t = termRank(term);
+  const thr = termRank(threshold);
+  if (t === null || thr === null) return false;
+  return t < thr;
 }
 
 function isSuspicious(term: string): boolean {

--- a/.claude/skills/state-audit/scripts/grade-snapshot.test.ts
+++ b/.claude/skills/state-audit/scripts/grade-snapshot.test.ts
@@ -2,14 +2,17 @@
  * Grade snapshot test for the state-audit rubric.
  *
  * Asserts expected per-dim and composite grades for a curated set of
- * states that exercise the rubric's branches:
+ * states that exercise the rubric's branches. Grades drift as data lands,
+ * so the curated examples are re-baselined periodically (last: 2026-06-23,
+ * the same commit that fixed the lexicographic isStale bug — see
+ * collect-audit-data.ts). Branches currently covered:
  *
- *   - Wide-and-deep coverage (NC, NY) → composite A
- *   - Documented-ceiling exemption (NH) → transfers capped at B
- *   - Thin transfers (OH, VT, RI)      → transfers C or B
- *   - Course coverage gaps (FL, MI, TX) → courses D
- *   - Data-not-wired (VA)              → transfers D
- *   - Missing dimensions (CA, WV)      → composite F
+ *   - Wide-and-deep coverage (NC) → composite A
+ *   - Documented course ceilings (FL, AR, AZ, MI, TX, CA) → courses on adj. coverage
+ *   - Documented transfer ceiling (NH) → transfers capped at B
+ *   - Improving / thin transfers (OH, VT, WV, WA) → transfers A or B
+ *   - Course coverage gaps (NY, OH, WV) → courses C/D
+ *   - All-dims-wired flagship (VA) → composite A
  *
  * When the data legitimately shifts a grade, update the expected value
  * in the same commit with a one-line justification — the snapshot is a
@@ -47,12 +50,12 @@ const EXPECTATIONS: Expectation[] = [
   },
   {
     slug: "ny",
-    composite: "D",
+    composite: "C",
     limitedBy: "courses",
-    courses: "D",
-    prereqs: "C",
+    courses: "C",
+    prereqs: "A",
     transfers: "A",
-    note: "drift re-baseline (unrelated to collector fix): NY courses now 49% (18/37) + prereqs HTML-contaminated → composite D; was flagship A. Investigate NY data separately.",
+    note: "re-baseline 2026-06-23: NY courses recovered to C (62%, 23/37) and prereqs HTML cleaned → A; composite C (courses-limited). Was D.",
   },
   {
     slug: "nh",
@@ -67,8 +70,8 @@ const EXPECTATIONS: Expectation[] = [
     composite: "D",
     limitedBy: "courses",
     courses: "D",
-    transfers: "C",
-    note: "5/22 colleges → courses D dominates; transfers thin (OSU only)",
+    transfers: "A",
+    note: "re-baseline 2026-06-23: OH transfers now A (was thin C); composite still D (courses 41%, 9/22, dominates).",
   },
   {
     slug: "vt",
@@ -88,20 +91,22 @@ const EXPECTATIONS: Expectation[] = [
   },
   {
     slug: "mi",
-    composite: "C",
+    composite: "B",
     limitedBy: "courses",
-    courses: "C",
+    courses: "B",
     transfers: "A",
-    note: "drift re-baseline (unrelated to collector fix): MI courses now 52% (16/31, C); transfers A → composite C.",
+    ceilingsDimensions: ["courses"],
+    note: "re-baseline 2026-06-23: MI's blocked colleges now documented course ceilings → courses B (94% adj, 16/17); composite B. Was C.",
   },
   {
     slug: "tx",
-    composite: "C",
+    composite: "B",
     limitedBy: "courses",
-    courses: "C",
+    courses: "B",
     transfers: "A",
-    scorecard: "B",
-    note: "drift re-baseline (unrelated to collector fix): TX courses now 63% (37/59, C); transfers A → composite C.",
+    scorecard: "A",
+    ceilingsDimensions: ["courses"],
+    note: "re-baseline 2026-06-23: TX blocked colleges now documented course ceilings → courses B (100% adj) capped by term-code hygiene; scorecard A; composite B. Was C. (stale-fix removed its false 2025FA flag; the genuine 2024FA remains.)",
   },
   {
     slug: "va",
@@ -113,19 +118,20 @@ const EXPECTATIONS: Expectation[] = [
   },
   {
     slug: "ca",
-    composite: "C",
+    composite: "B",
     limitedBy: "courses",
     transfers: "A",
-    courses: "C",
-    note: "drift re-baseline (unrelated to collector fix): CA now has transfer data (A); composite limited by courses 65% (C).",
+    courses: "B",
+    ceilingsDimensions: ["courses"],
+    note: "re-baseline 2026-06-23: CA blocked colleges now documented course ceilings → courses B (100% adj) capped by suspicious term codes; composite B. Was C. (stale-fix removed its false 2025FA flag.)",
   },
   {
     slug: "wv",
     composite: "D",
     limitedBy: "courses",
     courses: "D",
-    transfers: "C",
-    note: "drift re-baseline (unrelated to collector fix): WV courses now 33% (3/9, D) + thin transfers (C) → composite D.",
+    transfers: "B",
+    note: "re-baseline 2026-06-23: WV transfers now B (was thin C); composite still D (courses 33%, 3/9).",
   },
   {
     slug: "ar",
@@ -145,11 +151,12 @@ const EXPECTATIONS: Expectation[] = [
   },
   {
     slug: "wa",
-    composite: "F",
-    limitedBy: "prereqs",
+    composite: "B",
+    limitedBy: "transfers",
     courses: "A",
-    prereqs: "F",
-    note: "collector fix: WA's valid term no longer flagged suspicious → courses A; composite still F (prereqs file missing — separate gap)",
+    prereqs: "A",
+    transfers: "B",
+    note: "re-baseline 2026-06-23: WA now has prereqs (A) and wired transfers (B) → composite B, transfers-limited. Was F (prereqs missing).",
   },
 ];
 


### PR DESCRIPTION
## What this changes

**For someone using the site: nothing** — this is purely internal tooling (the `/state-audit` grader and its snapshot test). No app code.

It fixes a real correctness bug in how the audit decides whether a course term is "stale," and restores the grade-snapshot test (which was silently half-failing) to green.

## The bug

`isStale()` compared term codes as **strings**: `term < threshold`. But alphabetically `"FA" < "SP"`, so a recent **Fall** term like `2025FA` sorted *before* a `2025SP` staleness threshold and got wrongly counted as stale — even though `currentTerms()` explicitly lists last fall as still acceptable. So states were docked a "stale term" flag for perfectly current data.

## The fix

Compare **chronologically** via a new `termRank()` helper (3 primary seasons per academic year, `SP < SU < FA`; `WI` ≈ end-of-year; `U#`/`S#` sub-sessions). The threshold season is now always `SP`, so the chronological compare reproduces the intended "prior academic year is stale" boundary in both halves of the calendar year (the old `{year}FA` threshold only worked under the buggy alphabetical compare).

**Verified before/after on the full collector:** removes exactly 3 false-stale flags — `ca`'s, `mt`'s, and `tx`'s `2025FA` — while correctly keeping `tx`'s genuinely-old `2024FA`. **Zero composite-tier moves** (still 21A/13B/12C/4D/1F): it corrects the courses *reason strings*, not the grades. (This is also why `ca`/`tx` don't flip to A — they're B for other reasons, as flagged when this work was scoped.)

## Snapshot re-baseline (the second half)

`grade-snapshot.test.ts` was **7/14 failing on `main`** from accumulated data drift unrelated to this fix — `ny/oh/mi/tx/ca/wv/wa` all shifted since it was last updated (ceilings documented, scrapers landed, prereqs cleaned). Updated those 7 expectations to current truth with one-line justifications per the file's own convention; now **14/14 green**. The 7 already-correct entries are untouched.

## Files
- `.claude/skills/state-audit/scripts/collect-audit-data.ts` — `termRank()` + chronological `isStale()` + `SP`-based threshold (with a comment documenting the bug).
- `.claude/skills/state-audit/scripts/grade-snapshot.test.ts` — re-baseline 7 drifted entries + refresh the header.

## Test plan
- Before/after collector diff: only ca/mt/tx stale-reason strings change; tier distribution identical (21A/13B/12C/4D/1F).
- `grade-snapshot.test.ts`: **14/14 pass** (was 7/14).
- `tsc --noEmit`: clean on both files (`noUncheckedIndexedAccess` is off, so `SEASON_RANK[...]` is `number`).
- Note: `termRank` isn't separately unit-tested (the collector runs as a subprocess in the snapshot test, not imported); the inline comment is the regression guard.