### PR TITLE
fix: graceful Supabase-down fallback for course & instructor pages

### DIFF
--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -120,7 +120,16 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (!institution) return { title: "Not Found" };
 
   const config = requireStateConfig(state);
-  const result = await findInstructor(institution.college_slug, state, slug);
+
+  let result: Awaited<ReturnType<typeof findInstructor>>;
+  try {
+    result = await findInstructor(institution.college_slug, state, slug);
+  } catch {
+    return {
+      title: `Instructor — Temporarily unavailable | ${config.branding.siteName}`,
+      robots: { index: false, follow: true },
+    };
+  }
   if (!result) return { title: "Not Found" };
   const { profile, term: resolvedTerm } = result;
 
@@ -173,7 +182,36 @@ export default async function InstructorPage(props: PageProps) {
   if (!institution) notFound();
 
   const config = requireStateConfig(state);
-  const result = await findInstructor(institution.college_slug, state, slug);
+
+  let result: Awaited<ReturnType<typeof findInstructor>>;
+  try {
+    result = await findInstructor(institution.college_slug, state, slug);
+  } catch {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">
+          Instructor
+        </h1>
+        <p className="text-gray-600 dark:text-slate-400 mb-8">
+          Instructor data is temporarily unavailable. Please try again in a few minutes.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={`/${state}/college/${id}`}
+            className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition"
+          >
+            Back to {institution.name}
+          </Link>
+          <Link
+            href={`/${state}`}
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition"
+          >
+            {config.name} home
+          </Link>
+        </div>
+      </div>
+    );
+  }
   if (!result) notFound();
   const { profile, term: resolvedTerm } = result;
 

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -154,8 +154,21 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (!parsed) return { title: "Not Found" };
 
   const config = requireStateConfig(state);
-  const currentTerm = await getCurrentTerm(state);
-  const sections = await loadCourseByCode(parsed.prefix, parsed.number, currentTerm, state);
+
+  let currentTerm: string;
+  let sections: CourseSection[];
+  try {
+    currentTerm = await getCurrentTerm(state);
+    sections = await loadCourseByCode(parsed.prefix, parsed.number, currentTerm, state);
+  } catch {
+    // Supabase outage (402 egress, timeout, etc.) — return minimal metadata
+    // with noindex so Google doesn't index the degraded page, but also doesn't
+    // see a 500 and start de-indexing the URL.
+    return {
+      title: `${parsed.prefix} ${parsed.number} — Temporarily unavailable | ${config.branding.siteName}`,
+      robots: { index: false, follow: true },
+    };
+  }
 
   if (sections.length === 0) {
     // Course code is well-formed but has no sections this term. We render a
@@ -238,19 +251,46 @@ export default async function CoursePage(props: PageProps) {
 
   const { prefix, number } = parsed;
   const config = requireStateConfig(state);
-  const institutions = loadInstitutions(state);
-  const currentTerm = await getCurrentTerm(state);
 
-  // Two cheap, indexed reads instead of pulling the whole subject's sections:
-  //  • this course's own sections via the (state,term,prefix,number) index
-  //    (loadCourseByCode — also already cached from generateMetadata above), and
-  //  • a tiny DISTINCT course list for the "Related courses" sidebar.
-  // A big subject in a big state (CA Fall ENGL = 9,120 wide rows) used to be
-  // pulled in full here, which tripped Vercel's 15s FUNCTION_INVOCATION_TIMEOUT.
-  const [sections, subjectCourses] = await Promise.all([
-    loadCourseByCode(prefix, number, currentTerm, state),
+  let institutions: ReturnType<typeof loadInstitutions>;
+  let currentTerm: string;
+  let sections: CourseSection[];
+  let subjectCourses: Awaited<ReturnType<typeof loadSubjectCourseList>>;
+  try {
+    institutions = loadInstitutions(state);
+    currentTerm = await getCurrentTerm(state);
+    [sections, subjectCourses] = await Promise.all([
+      loadCourseByCode(prefix, number, currentTerm, state),
     loadSubjectCourseList(prefix, currentTerm, state),
-  ]);
+    ]);
+  } catch {
+    // Supabase outage — render a degraded page instead of 500ing.
+    // generateMetadata already sets noindex for this case.
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">
+          {prefix} {number}
+        </h1>
+        <p className="text-gray-600 dark:text-slate-400 mb-8">
+          Course data is temporarily unavailable. Please try again in a few minutes.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={`/${state}/courses`}
+            className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition"
+          >
+            Search courses
+          </Link>
+          <Link
+            href={`/${state}`}
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition"
+          >
+            {config.name} home
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   if (sections.length === 0) {
     // The course code is well-formed and the state is valid — but no sections


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible when Supabase is healthy. When Supabase goes down (egress quota exceeded, timeout, etc.), course and instructor pages now show a clean "temporarily unavailable" message with navigation links instead of a raw 500 error page. This prevents Google from de-indexing those URLs during outages.

## Technical context

On 2026-06-21 and again 2026-06-23, Supabase returned HTTP 402 (egress quota exceeded), causing every `/[state]/course/[code]` and `/[state]/college/[id]/instructor/[slug]` page to crash with 500. The individual data-loading functions (`loadCourseByCode`, `getInstructorBySlug`, etc.) handle Supabase errors gracefully, but something in the rendering chain still threw on Vercel's serverless runtime.

This PR wraps `generateMetadata` and the page component body with try/catch so any uncaught Supabase failure renders a degraded page with `robots: { index: false, follow: true }` instead of crashing. Google treats a renderable noindex page very differently from a 500: it keeps the URL in its index and retries later, rather than starting de-indexation.

## Files changed

| File | Change |
|---|---|
| `app/[state]/course/[code]/page.tsx` | try/catch around `generateMetadata` data loads + page body data loads |
| `app/[state]/college/[id]/instructor/[slug]/page.tsx` | same pattern |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx next build` passes
- [ ] Verify course pages still render normally on prod after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)