### PR TITLE
ci: conservative auto-merge sweeper for scheduled-scrape PRs (report-only)

### DIFF
--- a/.github/workflows/auto-merge-scraper-prs.yml
+++ b/.github/workflows/auto-merge-scraper-prs.yml
@@ -1,0 +1,186 @@
+name: Auto-merge scraper PRs
+
+# Conservative "merge sweeper" for the routine scheduled-scrape data PRs
+# (opened by scheduled-scrape-v2.yml as app/github-actions). It re-validates
+# each PR and squash-merges only those passing every guard, replacing the
+# manual "skim the diff + click merge" step.
+#
+# SAFETY MODEL — this does not relax any existing guard:
+#   - A PR only exists if scrape-diff said no file dropped <50% of prior rows.
+#   - The eligibility filter (scripts/lib/automerge-eligible.ts, unit-tested)
+#     requires bot provenance + data-only paths + single state + labels +
+#     mergeable + soak + file-cap + state-not-unhealthy (per scraper triage).
+#   - Before each merge we re-validate the PR's data against CURRENT main
+#     (scrape-diff + check:data on an overlay) — catching PRs that went stale
+#     because main grew since they opened. check:data never runs on these PRs
+#     today (bot-token PRs don't trigger pull_request CI), so this is strictly
+#     more validation than the status quo.
+#   - After merge, import-on-merge.yml re-checks 50% change-detection + schema
+#     per row before any Supabase upsert; cloud data is untouched on abort.
+#
+# STAGED ROLLOUT (no degradation at any point):
+#   Phase 0 (default): AUTOMERGE_ENABLED is unset ⇒ every run is REPORT-ONLY.
+#     The job writes an eligibility report to the run summary and merges
+#     nothing. Run ~2 weeks; compare its "would merge" list to hand-merges.
+#   Phase 1: set repo variable AUTOMERGE_ENABLED=true and AUTOMERGE_ALLOWLIST
+#     to 2-3 stable states. Scheduled runs then live-merge within the caps.
+#
+# KILL SWITCH: set AUTOMERGE_ENABLED to anything but 'true' (or delete it).
+# PER-PR OPT-OUT: add the 'do-not-automerge' label to any PR.
+
+on:
+  schedule:
+    - cron: "30 * * * *" # hourly at :30, offset from the scrape crons at :00
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "report (dry-run, never merges) or merge (live, still gated by AUTOMERGE_ENABLED)"
+        type: choice
+        options: [report, merge]
+        default: report
+
+permissions:
+  contents: write # squash-merge + delete branch
+  pull-requests: write # merge PRs
+  actions: write # dispatch import-on-merge.yml after a merge
+
+# Never let two sweeps run at once (they'd race on the same PRs / git state).
+concurrency:
+  group: auto-merge-scraper-prs
+  cancel-in-progress: false
+
+env:
+  # Conservative defaults; override with repo variables (Settings → Variables).
+  ALLOWLIST: ${{ vars.AUTOMERGE_ALLOWLIST }} # comma-separated slugs; empty ⇒ nothing eligible
+  MAX_FILES: ${{ vars.AUTOMERGE_MAX_FILES || '25' }}
+  SOAK_HOURS: ${{ vars.AUTOMERGE_SOAK_HOURS || '4' }}
+  MAX_MERGES_PER_RUN: ${{ vars.AUTOMERGE_MAX_MERGES_PER_RUN || '3' }}
+  WINDOW_DAYS: "14"
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so we can diff PR data against main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Resolve mode + kill switch
+        id: cfg
+        run: |
+          # Scheduled runs intend to merge (still gated below); manual runs use
+          # the chosen input, defaulting to the safe 'report'.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            mode="merge"
+          else
+            mode="${{ github.event.inputs.mode }}"
+          fi
+          enabled="${{ vars.AUTOMERGE_ENABLED }}"
+          if [ "$mode" = "merge" ] && [ "$enabled" = "true" ]; then
+            echo "live=true" >> "$GITHUB_OUTPUT"
+            echo "Mode: LIVE MERGE (mode=$mode, AUTOMERGE_ENABLED=$enabled)"
+          else
+            echo "live=false" >> "$GITHUB_OUTPUT"
+            echo "Mode: REPORT-ONLY (mode=$mode, AUTOMERGE_ENABLED=${enabled:-unset})"
+          fi
+
+      - name: Evaluate open PRs
+        id: eval
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx tsx scripts/lib/automerge-eligible.ts \
+            --allowlist "${ALLOWLIST}" \
+            --max-files "${MAX_FILES}" \
+            --soak-hours "${SOAK_HOURS}" \
+            --window-days "${WINDOW_DAYS}" \
+            --out /tmp/eligible.json
+          # The markdown report is the run summary in BOTH modes.
+          jq -r '.markdown' /tmp/eligible.json >> "$GITHUB_STEP_SUMMARY"
+          echo "health_err=$(jq -r '.healthError // "null"' /tmp/eligible.json)" >> "$GITHUB_OUTPUT"
+          echo "candidate_count=$(jq -r '.candidates | length' /tmp/eligible.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Report-only notice
+        if: steps.cfg.outputs.live != 'true'
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> **Report-only run — no PRs were merged.** ${{ steps.eval.outputs.candidate_count }} candidate(s) would have been eligible." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Merge eligible PRs
+        # Live only, and only when health could be verified (triage succeeded).
+        if: steps.cfg.outputs.live == 'true' && steps.eval.outputs.health_err == 'null'
+        env:
+          # Phase 1: set AUTOMERGE_PAT (a fine-grained PAT / app token with
+          # repo + workflow scope) so the squash-merge is attributed to a user
+          # and import-on-merge.yml fires naturally on the push. Without it the
+          # merge still works via GITHUB_TOKEN, and we dispatch the import
+          # explicitly below, but VERIFY the import ran (a GITHUB_TOKEN push may
+          # not trigger downstream workflows).
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          max="${MAX_MERGES_PER_RUN}"
+          count="${{ steps.eval.outputs.candidate_count }}"
+          merged=0
+          echo "Candidates: $count; per-run cap: $max"
+
+          for i in $(seq 0 $((count - 1))); do
+            [ "$merged" -ge "$max" ] && { echo "Hit per-run cap ($max); stopping."; break; }
+
+            num=$(jq -r ".candidates[$i].number" /tmp/eligible.json)
+            state=$(jq -r ".candidates[$i].state" /tmp/eligible.json)
+            dt=$(jq -r ".candidates[$i].datatype" /tmp/eligible.json)
+            echo "::group::Re-validate + merge #$num ($state/$dt)"
+
+            # Clean slate at current main, then overlay this PR's data only.
+            git reset -q --hard origin/main
+            git clean -qfd data || true
+            git fetch origin main --quiet
+            git checkout -q origin/main
+            git fetch origin "pull/$num/head:pr-$num" --quiet
+            git checkout -q "pr-$num" -- "data/$state"
+
+            ok=true
+            # Re-diff against CURRENT main: broken==false means no file dropped
+            # below 50% of main's row count (catches staleness from main growth).
+            if ! npx tsx scripts/lib/scrape-diff.ts --path "data/$state" --format json > /tmp/diff.json; then
+              echo "::warning::#$num scrape-diff failed to run — skipping."; ok=false
+            elif [ "$(jq -r '.broken' /tmp/diff.json)" != "false" ]; then
+              echo "::warning::#$num regressed vs current main — skipping."; ok=false
+            fi
+            # Parse/shape gate that normally never runs on these PRs.
+            if [ "$ok" = "true" ] && ! npm run check:data -- --state "$state"; then
+              echo "::warning::#$num failed check:data — skipping."; ok=false
+            fi
+
+            # Restore clean main before merging (merge is a pure API call).
+            git reset -q --hard origin/main
+            git clean -qfd data || true
+
+            if [ "$ok" != "true" ]; then echo "::endgroup::"; continue; fi
+
+            gh pr merge "$num" --squash --delete-branch
+            merged=$((merged + 1))
+            echo "Merged #$num — $state/$dt"
+
+            # Make sure the merged data reaches Supabase. import is idempotent
+            # (upsert) and serialized, so a duplicate dispatch is harmless.
+            gh workflow run import-on-merge.yml -f state="$state" -f datatype="$dt" \
+              || echo "::warning::Could not dispatch import for $state — verify import-on-merge ran."
+            echo "::endgroup::"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Merged $merged PR(s) this run** (cap $max)." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Health-unverifiable notice
+        if: steps.cfg.outputs.live == 'true' && steps.eval.outputs.health_err != 'null'
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> ⚠️ **No merges performed:** scraper-health triage failed (\`${{ steps.eval.outputs.health_err }}\`), so the health exclusion could not be verified this run." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto-merge-scraper-prs.yml
+++ b/.github/workflows/auto-merge-scraper-prs.yml
@@ -10,11 +10,13 @@ name: Auto-merge scraper PRs
 #   - The eligibility filter (scripts/lib/automerge-eligible.ts, unit-tested)
 #     requires bot provenance + data-only paths + single state + labels +
 #     mergeable + soak + file-cap + state-not-unhealthy (per scraper triage).
-#   - Before each merge we re-validate the PR's data against CURRENT main
-#     (scrape-diff + check:data on an overlay) — catching PRs that went stale
-#     because main grew since they opened. check:data never runs on these PRs
-#     today (bot-token PRs don't trigger pull_request CI), so this is strictly
-#     more validation than the status quo.
+#   - Before each merge we re-validate the PR's data against CURRENT main on an
+#     overlay: scrape-diff (50% row-count), check:data (parse/shape), and
+#     content-quality-diff (per-field fill/validity regression — catches
+#     title/mode collapse + instructor-column loss that count+schema miss).
+#     check:data + content-quality never run on these PRs today (bot-token PRs
+#     don't trigger pull_request CI), so this is strictly more validation than
+#     the status quo.
 #   - After merge, import-on-merge.yml re-checks 50% change-detection + schema
 #     per row before any Supabase upsert; cloud data is untouched on abort.
 #
@@ -157,6 +159,16 @@ jobs:
             # Parse/shape gate that normally never runs on these PRs.
             if [ "$ok" = "true" ] && ! npm run check:data -- --state "$state"; then
               echo "::warning::#$num failed check:data — skipping."; ok=false
+            fi
+            # Content-quality gate: catch SEMANTICALLY degraded data that count +
+            # schema miss — title/mode collapse, instructor-column loss — by
+            # comparing per-field fill/validity rates against current main.
+            if [ "$ok" = "true" ]; then
+              if ! npx tsx scripts/lib/content-quality-diff.ts --path "data/$state" --format json > /tmp/cq.json; then
+                echo "::warning::#$num content-quality-diff failed to run — skipping."; ok=false
+              elif [ "$(jq -r '.degraded' /tmp/cq.json)" != "false" ]; then
+                echo "::warning::#$num content quality degraded — skipping. $(jq -c '.findings' /tmp/cq.json)"; ok=false
+              fi
             fi
 
             # Restore clean main before merging (merge is a pure API call).

--- a/scripts/lib/__tests__/automerge-eligible.test.ts
+++ b/scripts/lib/__tests__/automerge-eligible.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluatePr,
+  type PrFacts,
+  type EligibilityConfig,
+} from "../automerge-eligible";
+
+// Fixed "now" so soak math is deterministic.
+const NOW = Date.parse("2026-06-23T12:00:00Z");
+
+// A base PR that passes every guard: bot-authored 1-file courses scrape for HI,
+// both labels, mergeable, 36h old.
+function basePr(over: Partial<PrFacts> = {}): PrFacts {
+  return {
+    number: 1538,
+    author: { login: "app/github-actions", is_bot: true },
+    headRefName: "scheduled-scrape/hi-courses",
+    labels: [{ name: "scraper-output" }, { name: "automated" }],
+    files: [{ path: "data/hi/courses/hawaii-community-college/2026FA.json" }],
+    mergeable: "MERGEABLE",
+    createdAt: "2026-06-22T00:00:00Z",
+    isDraft: false,
+    ...over,
+  };
+}
+
+function cfg(over: Partial<EligibilityConfig> = {}): EligibilityConfig {
+  return {
+    allowlist: ["hi"],
+    healthFlagged: new Set<string>(),
+    maxFiles: 25,
+    soakHours: 4,
+    nowMs: NOW,
+    ...over,
+  };
+}
+
+describe("evaluatePr — happy paths", () => {
+  it("a 1-file allowlisted courses PR is eligible", () => {
+    const r = evaluatePr(basePr(), cfg());
+    expect(r.reasons).toEqual([]);
+    expect(r.safe).toBe(true);
+    expect(r.inAllowlist).toBe(true);
+    expect(r.eligible).toBe(true);
+    expect(r.state).toBe("hi");
+    expect(r.datatype).toBe("courses");
+  });
+
+  it("a prereqs PR (single prereqs.json) is eligible", () => {
+    const r = evaluatePr(
+      basePr({
+        headRefName: "scheduled-scrape/nd-prereqs",
+        files: [{ path: "data/nd/prereqs.json" }],
+      }),
+      cfg({ allowlist: ["nd"] })
+    );
+    expect(r.safe).toBe(true);
+    expect(r.eligible).toBe(true);
+    expect(r.state).toBe("nd");
+    expect(r.datatype).toBe("prereqs");
+  });
+
+  it("a multi-file single-state courses PR within the cap is eligible", () => {
+    const files = Array.from({ length: 17 }, (_, i) => ({
+      path: `data/nc/courses/college-${i}/2026FA.json`,
+    }));
+    const r = evaluatePr(
+      basePr({ headRefName: "scheduled-scrape/nc-courses", files }),
+      cfg({ allowlist: ["nc"] })
+    );
+    expect(r.safe).toBe(true);
+    expect(r.eligible).toBe(true);
+    expect(r.fileCount).toBe(17);
+  });
+});
+
+describe("evaluatePr — allowlist tier", () => {
+  it("safe but not allowlisted ⇒ safe, not eligible", () => {
+    const r = evaluatePr(basePr(), cfg({ allowlist: ["nc"] }));
+    expect(r.safe).toBe(true);
+    expect(r.inAllowlist).toBe(false);
+    expect(r.eligible).toBe(false);
+    expect(r.reasons).toEqual([]); // allowlist is NOT a safety failure
+  });
+
+  it("empty allowlist ⇒ nothing eligible", () => {
+    const r = evaluatePr(basePr(), cfg({ allowlist: [] }));
+    expect(r.safe).toBe(true);
+    expect(r.eligible).toBe(false);
+  });
+});
+
+describe("evaluatePr — provenance guards", () => {
+  it("rejects a non-bot (human) author", () => {
+    const r = evaluatePr(
+      basePr({ author: { login: "rohan-c0de", is_bot: false } }),
+      cfg()
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/not the scrape bot/);
+  });
+
+  it("rejects a bot with a different login", () => {
+    const r = evaluatePr(
+      basePr({ author: { login: "dependabot", is_bot: true } }),
+      cfg()
+    );
+    expect(r.safe).toBe(false);
+  });
+
+  it("rejects a non-scheduled-scrape branch", () => {
+    const r = evaluatePr(basePr({ headRefName: "claude/hi-hotfix" }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/branch/);
+  });
+
+  it("rejects when a required label is missing", () => {
+    const r = evaluatePr(basePr({ labels: [{ name: "automated" }] }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/scraper-output/);
+  });
+
+  it("rejects when the do-not-automerge label is present", () => {
+    const r = evaluatePr(
+      basePr({
+        labels: [
+          { name: "scraper-output" },
+          { name: "automated" },
+          { name: "do-not-automerge" },
+        ],
+      }),
+      cfg()
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/do-not-automerge/);
+  });
+
+  it("rejects a draft PR", () => {
+    const r = evaluatePr(basePr({ isDraft: true }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/draft/);
+  });
+});
+
+describe("evaluatePr — content guards", () => {
+  it("rejects a PR touching a non-data path (e.g. lib/)", () => {
+    const r = evaluatePr(
+      basePr({
+        files: [
+          { path: "data/hi/courses/hawaii-community-college/2026FA.json" },
+          { path: "lib/states/hi/config.ts" },
+        ],
+      }),
+      cfg()
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/non-data path/);
+  });
+
+  it("rejects a transfers PR (transfer-equiv.json is out of phase-1 scope)", () => {
+    const r = evaluatePr(
+      basePr({
+        headRefName: "scheduled-scrape/hi-transfers",
+        files: [{ path: "data/hi/transfer-equiv.json" }],
+      }),
+      cfg()
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/non-data path/);
+  });
+
+  it("rejects a PR spanning multiple states", () => {
+    const r = evaluatePr(
+      basePr({
+        files: [
+          { path: "data/hi/courses/kapiolani/2026FA.json" },
+          { path: "data/nc/courses/alamance/2026FA.json" },
+        ],
+      }),
+      cfg({ allowlist: ["hi", "nc"] })
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/multiple states/);
+  });
+
+  it("rejects when branch state disagrees with path state", () => {
+    const r = evaluatePr(
+      basePr({ headRefName: "scheduled-scrape/nc-courses" }), // files are hi/
+      cfg({ allowlist: ["hi", "nc"] })
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/branch state/);
+  });
+
+  it("rejects a PR with zero files", () => {
+    const r = evaluatePr(basePr({ files: [] }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/no changed files/);
+  });
+
+  it("rejects when file count exceeds the cap", () => {
+    const files = Array.from({ length: 30 }, (_, i) => ({
+      path: `data/hi/courses/college-${i}/2026FA.json`,
+    }));
+    const r = evaluatePr(basePr({ files }), cfg({ maxFiles: 25 }));
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/> cap 25/);
+  });
+});
+
+describe("evaluatePr — state & timing guards", () => {
+  it("rejects a CONFLICTING PR", () => {
+    const r = evaluatePr(basePr({ mergeable: "CONFLICTING" }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/conflict/);
+  });
+
+  it("rejects an UNKNOWN-mergeability PR (retry next run)", () => {
+    const r = evaluatePr(basePr({ mergeable: "UNKNOWN" }), cfg());
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/not yet known/);
+  });
+
+  it("rejects a health-flagged state", () => {
+    const r = evaluatePr(basePr(), cfg({ healthFlagged: new Set(["hi"]) }));
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/unhealthy/);
+  });
+
+  it("rejects a PR still inside the soak window", () => {
+    const r = evaluatePr(
+      basePr({ createdAt: "2026-06-23T10:00:00Z" }), // 2h old
+      cfg({ soakHours: 4 })
+    );
+    expect(r.safe).toBe(false);
+    expect(r.reasons.join()).toMatch(/too new/);
+  });
+
+  it("accepts a PR exactly at the soak boundary", () => {
+    const r = evaluatePr(
+      basePr({ createdAt: "2026-06-23T08:00:00Z" }), // exactly 4h old
+      cfg({ soakHours: 4 })
+    );
+    expect(r.safe).toBe(true);
+  });
+});

--- a/scripts/lib/__tests__/content-quality-diff.test.ts
+++ b/scripts/lib/__tests__/content-quality-diff.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  measure,
+  compareQuality,
+  type SectionLike,
+} from "../content-quality-diff";
+
+// Build N section rows, overriding fields for a given fraction of them.
+function rows(
+  n: number,
+  base: SectionLike,
+  taint?: { count: number; over: Partial<SectionLike> }
+): SectionLike[] {
+  const out: SectionLike[] = [];
+  for (let i = 0; i < n; i++) {
+    const o = { ...base };
+    if (taint && i < taint.count) Object.assign(o, taint.over);
+    out.push(o);
+  }
+  return out;
+}
+
+const GOOD: SectionLike = {
+  course_prefix: "ENG",
+  course_number: "101",
+  course_title: "English Composition",
+  mode: "in-person",
+  instructor: "Jane Smith",
+};
+
+describe("measure", () => {
+  it("scores a clean catalog at 100% / 0 placeholder", () => {
+    const m = measure(rows(100, GOOD));
+    expect(m.rows).toBe(100);
+    expect(m.titleFill).toBe(1);
+    expect(m.keyFill).toBe(1);
+    expect(m.modeValid).toBe(1);
+    expect(m.instructorPlaceholder).toBe(0);
+  });
+
+  it("an empty array is neutral (scrape-diff owns empties)", () => {
+    const m = measure([]);
+    expect(m.rows).toBe(0);
+    expect(m.titleFill).toBe(1);
+    expect(m.instructorPlaceholder).toBe(0);
+  });
+
+  it("counts STAFF / TBA / null as instructor placeholders", () => {
+    const m = measure([
+      { ...GOOD, instructor: "STAFF" },
+      { ...GOOD, instructor: "tba" },
+      { ...GOOD, instructor: null },
+      { ...GOOD, instructor: "Real Person" },
+    ]);
+    expect(m.instructorPlaceholder).toBeCloseTo(0.75);
+  });
+
+  it("counts a leaked mode label as invalid", () => {
+    const m = measure([
+      { ...GOOD, mode: "in-person" },
+      { ...GOOD, mode: "Regular" }, // label leak — not in the enum
+    ]);
+    expect(m.modeValid).toBeCloseTo(0.5);
+  });
+});
+
+describe("compareQuality — existing files flag regression from healthy", () => {
+  it("flags a title collapse (parser shift blanked titles)", () => {
+    const before = measure(rows(100, GOOD));
+    const after = measure(rows(100, GOOD, { count: 70, over: { course_title: "" } }));
+    const f = compareQuality("data/x/courses/c/2026FA.json", before, after);
+    expect(f.some((x) => x.metric === "titleFill")).toBe(true);
+  });
+
+  it("flags a mode label leak (import would abort the term)", () => {
+    const before = measure(rows(100, GOOD));
+    const after = measure(rows(100, GOOD, { count: 40, over: { mode: "Lab Based" } }));
+    const f = compareQuality("data/x/courses/c/2026FA.json", before, after);
+    expect(f.some((x) => x.metric === "modeValid")).toBe(true);
+  });
+
+  it("flags an instructor-column collapse to placeholders", () => {
+    const before = measure(rows(100, GOOD, { count: 20, over: { instructor: "STAFF" } }));
+    const after = measure(rows(100, GOOD, { count: 96, over: { instructor: "STAFF" } }));
+    const f = compareQuality("data/x/courses/c/2026FA.json", before, after);
+    expect(f.some((x) => x.metric === "instructorPlaceholder")).toBe(true);
+  });
+
+  it("flags a key (prefix/number) fill regression", () => {
+    const before = measure(rows(100, GOOD));
+    const after = measure(rows(100, GOOD, { count: 20, over: { course_prefix: "" } }));
+    const f = compareQuality("data/x/courses/c/2026FA.json", before, after);
+    expect(f.some((x) => x.metric === "keyFill")).toBe(true);
+  });
+});
+
+describe("compareQuality — does NOT cry wolf", () => {
+  it("identical healthy before/after ⇒ no findings", () => {
+    const m = measure(rows(100, GOOD));
+    expect(compareQuality("f", m, m)).toEqual([]);
+  });
+
+  it("small legitimate churn stays within tolerance", () => {
+    const before = measure(rows(100, GOOD));
+    const after = measure(rows(100, GOOD, { count: 3, over: { course_title: "" } })); // 97%
+    expect(compareQuality("f", before, after)).toEqual([]);
+  });
+
+  it("STAFF→named (placeholders shrink) is an improvement, not a finding", () => {
+    const before = measure(rows(100, GOOD, { count: 60, over: { instructor: "STAFF" } }));
+    const after = measure(rows(100, GOOD, { count: 10, over: { instructor: "STAFF" } }));
+    expect(compareQuality("f", before, after)).toEqual([]);
+  });
+
+  it("chronically-sparse college (low but stable) is not flagged", () => {
+    // mode only 80% valid on BOTH sides — not a regression, so no finding.
+    const before = measure(rows(100, GOOD, { count: 20, over: { mode: "Regular" } }));
+    const after = measure(rows(100, GOOD, { count: 20, over: { mode: "Regular" } }));
+    expect(compareQuality("f", before, after)).toEqual([]);
+  });
+
+  it("an emptied AFTER file is left to scrape-diff (no finding here)", () => {
+    const before = measure(rows(100, GOOD));
+    const after = measure([]);
+    expect(compareQuality("f", before, after)).toEqual([]);
+  });
+});
+
+describe("compareQuality — new files judged on absolute floors", () => {
+  it("flags a brand-new garbage file (most titles missing)", () => {
+    const before = measure([]); // not on main
+    const after = measure(rows(100, GOOD, { count: 70, over: { course_title: "" } }));
+    const f = compareQuality("data/x/courses/new/2026FA.json", before, after);
+    expect(f.some((x) => x.metric === "titleFill")).toBe(true);
+  });
+
+  it("accepts a brand-new healthy file", () => {
+    const before = measure([]);
+    const after = measure(rows(100, GOOD));
+    expect(compareQuality("data/x/courses/new/2026FA.json", before, after)).toEqual([]);
+  });
+});

--- a/scripts/lib/automerge-eligible.ts
+++ b/scripts/lib/automerge-eligible.ts
@@ -1,0 +1,432 @@
+/**
+ * automerge-eligible.ts — decide which open scheduled-scrape PRs are safe to
+ * auto-merge.
+ *
+ * This is the cheap *metadata* filter behind the auto-merge sweeper
+ * (.github/workflows/auto-merge-scraper-prs.yml). It never merges anything; it
+ * classifies open PRs so the workflow can (a) REPORT what it *would* merge in
+ * dry-run mode, or (b) hand the eligible set to the per-PR validation +
+ * `gh pr merge` step in live mode.
+ *
+ * Why a separate, pure, unit-tested module: the eligibility rules ARE the
+ * security boundary of this feature, so they live in one place with tests
+ * rather than smeared across bash. The expensive checks stay in the workflow —
+ * checking out each PR's data onto *current* main and re-running
+ * `npm run check:data` + `scripts/lib/scrape-diff.ts` — to catch data that
+ * passes metadata but regressed because main moved since the PR opened.
+ *
+ * Eligibility is two-tiered, on purpose:
+ *   - SAFE      = provenance + path-allowlist + single-state + labels + not
+ *                 draft + mergeable + soak + file-cap + state-not-unhealthy.
+ *                 A PR a human would never need to think twice about.
+ *   - ELIGIBLE  = SAFE && state ∈ ALLOWLIST. The allowlist is the staged-rollout
+ *                 scope knob. Report mode surfaces "safe but not yet
+ *                 allowlisted" separately so you can watch the sweeper's
+ *                 judgement on states before widening scope to them.
+ *
+ * The dangerous failure mode (bad data replacing good data) is already blocked
+ * three times elsewhere — scrape-diff's 50% gate at PR-creation, and
+ * supabase-import.ts's 50% change-detection + schema validation at import. This
+ * module does not relax any of those; it only replaces the human "skim the
+ * diff" step, and adds the check:data gate that today never runs on these PRs
+ * (bot-token PRs don't trigger pull_request CI).
+ *
+ * Usage (CLI):
+ *   npx tsx scripts/lib/automerge-eligible.ts \
+ *     --allowlist nc,id,ny --max-files 25 --soak-hours 4 \
+ *     --history data/state-health/history.jsonl --window-days 14 \
+ *     --out /tmp/eligible.json
+ *
+ * Output JSON: { generatedAt, config, healthError, candidates,
+ *                safeNotAllowlisted, skipped, markdown }
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// Constants — the eligibility rules
+// ---------------------------------------------------------------------------
+
+/**
+ * The only two file shapes a phase-1 scrape PR may touch. Anchored: a single
+ * stray path (a lib/ edit, a config change, a migration) fails the whole PR and
+ * leaves it for a human. State slug is `[a-z]{2}` — verified against the
+ * registry: all 51 slugs (50 states + dc) are exactly two chars.
+ */
+const COURSES_RE = /^data\/([a-z]{2})\/courses\/[^/]+\/[^/]+\.json$/;
+const PREREQS_RE = /^data\/([a-z]{2})\/prereqs\.json$/;
+
+/** Branch the scrape workflow opens PRs on: scheduled-scrape/{state}-{datatype}. */
+const BRANCH_RE =
+  /^scheduled-scrape\/([a-z]{2})-(courses|transfers|prereqs|programs)$/;
+
+const BOT_LOGIN = "app/github-actions";
+const REQUIRED_LABELS = ["scraper-output", "automated"];
+const DENY_LABEL = "do-not-automerge";
+
+/** Triage classifications that exclude a state from auto-merge this run. */
+const UNHEALTHY_CLASSIFICATIONS = new Set([
+  "persistent-broken",
+  "regression",
+  "partial-coverage-degraded",
+]);
+
+const HOUR_MS = 3_600_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The subset of `gh pr list --json …` fields this module reads. */
+export interface PrFacts {
+  number: number;
+  author: { login: string; is_bot: boolean };
+  headRefName: string;
+  labels: Array<{ name: string }>;
+  files: Array<{ path: string }>;
+  mergeable: string; // "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
+  createdAt: string; // ISO 8601
+  isDraft: boolean;
+}
+
+export interface EligibilityConfig {
+  /** State slugs cleared for live auto-merge. Empty ⇒ nothing is eligible. */
+  allowlist: string[];
+  /** States currently classified unhealthy by triage — excluded. */
+  healthFlagged: Set<string>;
+  maxFiles: number;
+  soakHours: number;
+  /** Injected for deterministic tests; the CLI passes Date.now(). */
+  nowMs: number;
+}
+
+export interface EligibilityResult {
+  number: number;
+  state: string | null;
+  datatype: string | null;
+  fileCount: number;
+  /** True when every safety guard passes (allowlist NOT considered). */
+  safe: boolean;
+  inAllowlist: boolean;
+  /** safe && inAllowlist — the set the workflow may actually merge. */
+  eligible: boolean;
+  /** Human-readable reasons the PR is not SAFE (empty when safe). */
+  reasons: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure evaluation — the unit-tested core
+// ---------------------------------------------------------------------------
+
+function statesFromFiles(files: Array<{ path: string }>): {
+  states: Set<string>;
+  nonData: string[];
+} {
+  const states = new Set<string>();
+  const nonData: string[] = [];
+  for (const f of files) {
+    const m = COURSES_RE.exec(f.path) ?? PREREQS_RE.exec(f.path);
+    if (m) states.add(m[1]);
+    else nonData.push(f.path);
+  }
+  return { states, nonData };
+}
+
+/**
+ * Classify one PR. Pure: same inputs ⇒ same output, no I/O. This is the
+ * function the unit tests exercise and the function that gatekeeps every
+ * auto-merge.
+ */
+export function evaluatePr(
+  pr: PrFacts,
+  cfg: EligibilityConfig
+): EligibilityResult {
+  const reasons: string[] = [];
+  const files = pr.files ?? [];
+
+  // 1. Provenance — must be the scrape bot, not a human or another bot.
+  if (!pr.author?.is_bot || pr.author.login !== BOT_LOGIN) {
+    reasons.push(`author '${pr.author?.login ?? "?"}' is not the scrape bot`);
+  }
+
+  // 2. Branch — scheduled-scrape/{state}-{datatype}.
+  const branchMatch = BRANCH_RE.exec(pr.headRefName);
+  if (!branchMatch) {
+    reasons.push(`branch '${pr.headRefName}' is not scheduled-scrape/{state}-{datatype}`);
+  }
+  const branchState = branchMatch?.[1] ?? null;
+  const datatype = branchMatch?.[2] ?? null;
+
+  // 3. Labels — both required present, deny-label absent.
+  const labelNames = new Set((pr.labels ?? []).map((l) => l.name));
+  for (const req of REQUIRED_LABELS) {
+    if (!labelNames.has(req)) reasons.push(`missing label '${req}'`);
+  }
+  if (labelNames.has(DENY_LABEL)) reasons.push(`has '${DENY_LABEL}' label`);
+
+  // 4. Draft PRs are never auto-merged.
+  if (pr.isDraft) reasons.push("draft PR");
+
+  // 5. Path allowlist + exactly one state across all changed files.
+  const { states, nonData } = statesFromFiles(files);
+  if (nonData.length > 0) {
+    const shown = nonData.slice(0, 3).join(", ");
+    const more = nonData.length > 3 ? ` (+${nonData.length - 3} more)` : "";
+    reasons.push(`touches non-data path(s): ${shown}${more}`);
+  }
+  let state: string | null = null;
+  if (files.length === 0) {
+    reasons.push("no changed files");
+  } else if (states.size > 1) {
+    reasons.push(`touches multiple states: ${[...states].sort().join(", ")}`);
+  } else if (states.size === 1) {
+    state = [...states][0];
+    if (branchState && branchState !== state) {
+      reasons.push(`branch state '${branchState}' != path state '${state}'`);
+    }
+  }
+
+  // 6. File-count cap.
+  if (files.length > cfg.maxFiles) {
+    reasons.push(`${files.length} files > cap ${cfg.maxFiles}`);
+  }
+
+  // 7. Mergeable — skip conflicts; treat not-yet-computed as a retry, not a
+  //    pass. GitHub computes mergeability lazily, so UNKNOWN is common on a
+  //    fresh listing and simply means "look again next run".
+  if (pr.mergeable === "CONFLICTING") {
+    reasons.push("has merge conflicts");
+  } else if (pr.mergeable !== "MERGEABLE") {
+    reasons.push(`mergeability '${pr.mergeable}' not yet known (retry next run)`);
+  }
+
+  // 8. Health exclusion — never auto-merge a state whose scraper triage is
+  //    currently flagging trouble.
+  if (state && cfg.healthFlagged.has(state)) {
+    reasons.push(`state '${state}' flagged unhealthy by scraper triage`);
+  }
+
+  // 9. Soak — give a human a window to intervene before the sweeper acts.
+  const ageMs = cfg.nowMs - new Date(pr.createdAt).getTime();
+  if (Number.isNaN(ageMs)) {
+    reasons.push(`unparseable createdAt '${pr.createdAt}'`);
+  } else if (ageMs < cfg.soakHours * HOUR_MS) {
+    reasons.push(
+      `too new (${(ageMs / HOUR_MS).toFixed(1)}h < soak ${cfg.soakHours}h)`
+    );
+  }
+
+  const safe = reasons.length === 0;
+  const inAllowlist = state != null && cfg.allowlist.includes(state);
+  return {
+    number: pr.number,
+    state,
+    datatype,
+    fileCount: files.length,
+    safe,
+    inAllowlist,
+    eligible: safe && inAllowlist,
+    reasons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Health — derive the excluded-states set from triage
+// ---------------------------------------------------------------------------
+
+export function computeHealthFlagged(
+  historyPath: string,
+  windowDays: number
+): { flagged: Set<string>; error: string | null } {
+  const flagged = new Set<string>();
+  // Shell out to the existing triage classifier rather than import it: its
+  // module body runs main() on load (it's a CLI), so importing it would run
+  // the triage CLI against our argv. The scheduled-scrape workflow invokes it
+  // the same way. Resolve the script path from __dirname so cwd doesn't matter.
+  const triageScript = join(__dirname, "triage-scraper-health.ts");
+  const tmp = join(os.tmpdir(), `automerge-triage-${process.pid}.json`);
+  try {
+    execFileSync(
+      "npx",
+      [
+        "tsx",
+        triageScript,
+        "--history",
+        historyPath,
+        "--window-days",
+        String(windowDays),
+        "--out",
+        tmp,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "ignore", "pipe"], maxBuffer: 64 * 1024 * 1024 }
+    );
+    const parsed = JSON.parse(fs.readFileSync(tmp, "utf8")) as {
+      results: Array<{ state: string; classification: string }>;
+    };
+    for (const r of parsed.results ?? []) {
+      if (UNHEALTHY_CLASSIFICATIONS.has(r.classification)) flagged.add(r.state);
+    }
+    return { flagged, error: null };
+  } catch (e) {
+    // Surface the error. The workflow treats a non-null healthError as
+    // "can't verify health → do not merge this run" (report only), rather
+    // than silently merging without the health gate.
+    return { flagged, error: (e as Error).message };
+  } finally {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function table(rows: EligibilityResult[], withReasons: boolean): string {
+  if (rows.length === 0) return "_none_\n";
+  const head = withReasons
+    ? "| PR | State | Type | Files | Why skipped |\n|---:|---|---|---:|---|"
+    : "| PR | State | Type | Files |\n|---:|---|---|---:|";
+  const body = rows
+    .map((r) => {
+      const base = `| #${r.number} | ${r.state ?? "—"} | ${r.datatype ?? "—"} | ${r.fileCount}`;
+      return withReasons ? `${base} | ${r.reasons.join("; ")} |` : `${base} |`;
+    })
+    .join("\n");
+  return `${head}\n${body}\n`;
+}
+
+export function buildMarkdown(
+  candidates: EligibilityResult[],
+  safeNotAllowlisted: EligibilityResult[],
+  skipped: EligibilityResult[],
+  meta: {
+    allowlist: string[];
+    maxFiles: number;
+    soakHours: number;
+    healthError: string | null;
+  }
+): string {
+  const lines: string[] = [];
+  lines.push("## Auto-merge sweeper — eligibility report");
+  lines.push("");
+  lines.push(
+    `allowlist: \`${meta.allowlist.join(", ") || "(empty)"}\` · max-files: ${meta.maxFiles} · soak: ${meta.soakHours}h`
+  );
+  if (meta.healthError) {
+    lines.push("");
+    lines.push(
+      `> ⚠️ scraper-health triage failed (\`${meta.healthError}\`) — **no merges this run**; health exclusion could not be verified.`
+    );
+  }
+  lines.push("");
+  lines.push(`### ✅ Eligible (safe + allowlisted) — ${candidates.length}`);
+  lines.push(table(candidates, false));
+  lines.push(`### 🟡 Safe but not allowlisted — ${safeNotAllowlisted.length}`);
+  lines.push(table(safeNotAllowlisted, false));
+  lines.push(`### ⛔ Skipped — ${skipped.length}`);
+  lines.push(table(skipped, true));
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// PR fetch
+// ---------------------------------------------------------------------------
+
+function fetchOpenPrs(limit: number): PrFacts[] {
+  const out = execFileSync(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      String(limit),
+      "--json",
+      "number,author,headRefName,labels,files,mergeable,createdAt,isDraft",
+    ],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+  );
+  return JSON.parse(out) as PrFacts[];
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function arg(args: string[], flag: string): string | null {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] ?? null : null;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const allowlist = (arg(args, "--allowlist") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const maxFiles = parseInt(arg(args, "--max-files") ?? "25", 10);
+  const soakHours = parseFloat(arg(args, "--soak-hours") ?? "4");
+  const historyPath =
+    arg(args, "--history") ?? "data/state-health/history.jsonl";
+  const windowDays = parseInt(arg(args, "--window-days") ?? "14", 10);
+  const limit = parseInt(arg(args, "--limit") ?? "100", 10);
+  const outPath = arg(args, "--out");
+  const nowMs = Date.now();
+
+  const { flagged: healthFlagged, error: healthError } = computeHealthFlagged(
+    historyPath,
+    windowDays
+  );
+
+  const prs = fetchOpenPrs(limit);
+  const cfg: EligibilityConfig = {
+    allowlist,
+    healthFlagged,
+    maxFiles,
+    soakHours,
+    nowMs,
+  };
+  const evaluated = prs.map((p) => evaluatePr(p, cfg));
+
+  const candidates = evaluated.filter((r) => r.eligible);
+  const safeNotAllowlisted = evaluated.filter((r) => r.safe && !r.inAllowlist);
+  const skipped = evaluated.filter((r) => !r.safe);
+
+  const markdown = buildMarkdown(candidates, safeNotAllowlisted, skipped, {
+    allowlist,
+    maxFiles,
+    soakHours,
+    healthError,
+  });
+
+  const output = {
+    generatedAt: new Date(nowMs).toISOString(),
+    config: { allowlist, maxFiles, soakHours, windowDays },
+    healthError,
+    candidates,
+    safeNotAllowlisted,
+    skipped,
+    markdown,
+  };
+
+  const json = JSON.stringify(output, null, 2);
+  if (outPath) {
+    fs.writeFileSync(outPath, json);
+    console.error(`Wrote ${outPath}`);
+  }
+  console.log(json);
+  console.error("\n" + markdown);
+}
+
+// Only run the CLI when invoked directly (not when imported by tests).
+if (process.argv[1]?.includes("automerge-eligible")) {
+  main();
+}

--- a/scripts/lib/content-quality-diff.ts
+++ b/scripts/lib/content-quality-diff.ts
@@ -1,0 +1,248 @@
+/**
+ * content-quality-diff.ts — catch scraper output that is *semantically*
+ * degraded even though row-count and schema look fine.
+ *
+ * scrape-diff.ts gates on row COUNT (a file dropping <50% of prior rows). The
+ * import gates on per-row SCHEMA. Neither catches the middle ground: a refresh
+ * that keeps ~the same number of well-typed rows but whose CONTENT regressed —
+ * the source hid the instructor column (everything became "STAFF"), a parser
+ * shift blanked the titles, or a `mode` label leaked (the exact failure that
+ * silently dropped colleges before — import aborts a term at >5% invalid mode).
+ *
+ * This is the gate that narrows the "semantically wrong but plausible" gap the
+ * auto-merge sweeper would otherwise inherit from a human skim. It runs in the
+ * sweeper's per-PR re-validation, after scrape-diff + check:data, on the same
+ * overlay (PR data in the working tree, current main at HEAD).
+ *
+ * Philosophy — false-positive-resistant by construction:
+ *   - EXISTING files are judged only on REGRESSION FROM A HEALTHY BASELINE: a
+ *     metric that was healthy on main and dropped materially now. A college
+ *     whose data is chronically sparse never trips (it isn't a regression), so
+ *     we don't flag the same college every week.
+ *   - NEW files (no main baseline) are judged on absolute floors only, to catch
+ *     a brand-new garbage file.
+ *   - A false positive just means "merge it by hand" (status quo); a false
+ *     negative is still backstopped by import-time schema + 50% checks. So we
+ *     tune toward NOT crying wolf.
+ *
+ * Only `courses/**` files are analyzed (prereqs.json is a different shape and
+ * is already gated by scrape-diff's key-count + check:data).
+ *
+ * Usage:
+ *   npx tsx scripts/lib/content-quality-diff.ts --path data/nc --format json
+ *   npx tsx scripts/lib/content-quality-diff.ts --path data/nc --format markdown
+ *
+ * Output JSON: { degraded, filesChecked, findings: [...], summary }
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..");
+
+// Valid values for the required `mode` enum (lib/schemas.ts CourseSectionSchema).
+const VALID_MODES = new Set(["in-person", "online", "hybrid", "zoom"]);
+
+// Instructor strings that mean "no real instructor yet" — legitimate, so only
+// a *surge* relative to the prior file is suspicious, never the absolute level.
+const INSTRUCTOR_PLACEHOLDERS = new Set([
+  "",
+  "staff",
+  "tba",
+  "tbd",
+  "to be announced",
+  "to be determined",
+]);
+
+// A metric counts as "healthy on main" at/above this; below the relative drop
+// it's a regression. Tuned so normal refresh churn never trips.
+const HEALTHY = { titleFill: 0.95, keyFill: 0.98, modeValid: 0.95 } as const;
+const DROP = { titleFill: 0.1, keyFill: 0.05, modeValid: 0.05 } as const;
+// Absolute floors applied to NEW files only (no baseline to regress against).
+const NEW_FILE_FLOOR = { titleFill: 0.5, keyFill: 0.9, modeValid: 0.95 } as const;
+
+// ---------------------------------------------------------------------------
+// Pure core — unit-tested
+// ---------------------------------------------------------------------------
+
+export interface SectionLike {
+  course_prefix?: string | null;
+  course_number?: string | null;
+  course_title?: string | null;
+  mode?: string | null;
+  instructor?: string | null;
+}
+
+export interface QualityMetrics {
+  rows: number;
+  titleFill: number; // fraction with a non-empty course_title
+  keyFill: number; // fraction with both prefix AND number
+  modeValid: number; // fraction with mode ∈ enum
+  instructorPlaceholder: number; // fraction with placeholder/empty instructor
+}
+
+export interface QualityFinding {
+  file: string;
+  metric: string;
+  before: number;
+  after: number;
+  reason: string;
+}
+
+function nonEmpty(s: unknown): boolean {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+/** Compute content-quality metrics over a section array. */
+export function measure(rows: SectionLike[]): QualityMetrics {
+  const n = rows.length;
+  // Empty file ⇒ neutral. A 100%-row-drop is scrape-diff's job, not ours.
+  if (n === 0) {
+    return { rows: 0, titleFill: 1, keyFill: 1, modeValid: 1, instructorPlaceholder: 0 };
+  }
+  let title = 0;
+  let key = 0;
+  let mode = 0;
+  let placeholder = 0;
+  for (const r of rows) {
+    if (nonEmpty(r.course_title)) title++;
+    if (nonEmpty(r.course_prefix) && nonEmpty(r.course_number)) key++;
+    if (typeof r.mode === "string" && VALID_MODES.has(r.mode)) mode++;
+    const instr = (r.instructor ?? "").trim().toLowerCase();
+    if (INSTRUCTOR_PLACEHOLDERS.has(instr)) placeholder++;
+  }
+  return {
+    rows: n,
+    titleFill: title / n,
+    keyFill: key / n,
+    modeValid: mode / n,
+    instructorPlaceholder: placeholder / n,
+  };
+}
+
+/**
+ * Compare a file's before/after metrics and return regression findings. Empty
+ * `findings` ⇒ the change is acceptable.
+ */
+export function compareQuality(
+  file: string,
+  before: QualityMetrics,
+  after: QualityMetrics
+): QualityFinding[] {
+  const findings: QualityFinding[] = [];
+  // An empty AFTER file is handled by scrape-diff's 50% gate; don't double-flag.
+  if (after.rows === 0) return findings;
+
+  const pct = (x: number) => `${(x * 100).toFixed(0)}%`;
+
+  if (before.rows === 0) {
+    // New file — no baseline. Absolute floors catch brand-new garbage.
+    if (after.titleFill < NEW_FILE_FLOOR.titleFill) {
+      findings.push({ file, metric: "titleFill", before: before.titleFill, after: after.titleFill, reason: `new file titleFill ${pct(after.titleFill)} < ${pct(NEW_FILE_FLOOR.titleFill)} floor` });
+    }
+    if (after.keyFill < NEW_FILE_FLOOR.keyFill) {
+      findings.push({ file, metric: "keyFill", before: before.keyFill, after: after.keyFill, reason: `new file keyFill ${pct(after.keyFill)} < ${pct(NEW_FILE_FLOOR.keyFill)} floor` });
+    }
+    if (after.modeValid < NEW_FILE_FLOOR.modeValid) {
+      findings.push({ file, metric: "modeValid", before: before.modeValid, after: after.modeValid, reason: `new file modeValid ${pct(after.modeValid)} < ${pct(NEW_FILE_FLOOR.modeValid)} (import aborts a term >5% invalid mode)` });
+    }
+    return findings;
+  }
+
+  // Existing file — flag only a regression from a healthy baseline.
+  for (const m of ["titleFill", "keyFill", "modeValid"] as const) {
+    const b = before[m];
+    const a = after[m];
+    if (b >= HEALTHY[m] && a < b - DROP[m]) {
+      findings.push({ file, metric: m, before: b, after: a, reason: `${m} regressed ${pct(b)}→${pct(a)} (>${(DROP[m] * 100).toFixed(0)}pt drop from a healthy baseline)` });
+    }
+  }
+  // Instructor column collapse: nearly everything became a placeholder AND it
+  // jumped sharply. Specific to a lost column, not normal early-registration STAFF.
+  if (after.instructorPlaceholder > 0.8 && after.instructorPlaceholder - before.instructorPlaceholder > 0.5) {
+    findings.push({ file, metric: "instructorPlaceholder", before: before.instructorPlaceholder, after: after.instructorPlaceholder, reason: `instructor placeholder surged ${pct(before.instructorPlaceholder)}→${pct(after.instructorPlaceholder)} (column likely lost)` });
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Git plumbing (mirrors scrape-diff.ts) + CLI
+// ---------------------------------------------------------------------------
+
+function sh(cmd: string): string {
+  return execSync(cmd, { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+function parseRows(text: string): SectionLike[] {
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? (parsed as SectionLike[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function beforeRows(file: string): SectionLike[] {
+  try {
+    return parseRows(sh(`git show HEAD:${file}`));
+  } catch {
+    return []; // not on main ⇒ new file
+  }
+}
+
+function afterRows(file: string): SectionLike[] {
+  const abs = resolve(ROOT, file);
+  if (!existsSync(abs)) return [];
+  return parseRows(readFileSync(abs, "utf8"));
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const pathIdx = args.indexOf("--path");
+  const fmtIdx = args.indexOf("--format");
+  const pathPrefix = pathIdx >= 0 ? args[pathIdx + 1] : "data/";
+  const format = (fmtIdx >= 0 ? args[fmtIdx + 1] : "json") as "json" | "markdown";
+
+  const tracked = sh(`git ls-files ${pathPrefix}`).trim().split("\n");
+  const untracked = sh(`git ls-files --others --exclude-standard ${pathPrefix}`).trim().split("\n");
+  // Only course section files carry the fields we measure.
+  const files = Array.from(new Set([...tracked, ...untracked]))
+    .filter(Boolean)
+    .filter((f) => /\/courses\/.*\.json$/.test(f));
+
+  const findings: QualityFinding[] = [];
+  let filesChecked = 0;
+  for (const file of files) {
+    const before = measure(beforeRows(file));
+    const after = measure(afterRows(file));
+    // Skip files with no actual content change in the measured dimensions —
+    // identical before/after produces no findings anyway, but counting only
+    // meaningfully-evaluated files keeps the summary honest.
+    if (before.rows === 0 && after.rows === 0) continue;
+    filesChecked++;
+    findings.push(...compareQuality(file, before, after));
+  }
+
+  const degraded = findings.length > 0;
+  const summary = degraded
+    ? `CONTENT DEGRADED: ${findings.length} finding(s) across ${filesChecked} file(s) checked.`
+    : `Content quality OK across ${filesChecked} file(s) checked.`;
+
+  if (format === "markdown") {
+    const lines = [`**${summary}**`, ""];
+    if (degraded) {
+      lines.push("| File | Metric | Before | After | Why |", "|---|---|---:|---:|---|");
+      for (const f of findings) {
+        lines.push(`| \`${f.file}\` | ${f.metric} | ${(f.before * 100).toFixed(0)}% | ${(f.after * 100).toFixed(0)}% | ${f.reason} |`);
+      }
+    }
+    console.log(lines.join("\n"));
+  } else {
+    console.log(JSON.stringify({ degraded, filesChecked, findings, summary }, null, 2));
+  }
+}
+
+if (process.argv[1]?.includes("content-quality-diff")) {
+  main();
+}


### PR DESCRIPTION
## What this changes

**For you as the maintainer:** the weekly `scheduled-scrape/*` data PRs (16 open right now, all bot-authored) can start merging themselves once they pass the same checks you'd apply by hand — so you stop hand-merging routine course/prereq refreshes. **Nothing auto-merges yet:** this ships in **report-only mode**. Every scheduled run posts an "eligibility report" to its run summary listing what it *would* merge and why it skipped the rest. You keep merging manually and compare for ~2 weeks before flipping it live.

**For students:** no change now; once enabled, fresh course/prereq data reaches the site sooner because refreshes don't wait days for a manual merge.

## Why it's safe

This doesn't relax any existing guard — it replaces the human "skim the diff" step and *adds* validation that never runs today:

- A scrape PR only exists if `scrape-diff` already confirmed no file dropped below 50% of its prior row count (a broken scrape files an issue, never a PR).
- After merge, `import-on-merge.yml` re-checks 50% change-detection **and** per-row schema validation before any Supabase upsert — cloud data is untouched on abort.
- **New, pre-merge (these run on an overlay against *current* main, and never run on bot-token PRs today — verified, only Vercel does):**
  - `check:data` — parse/array-shape gate;
  - `scrape-diff` re-run vs current main — catches PRs gone stale because main grew since they opened;
  - **`content-quality-diff` (new) — the semantic gate.** Per-field fill/validity deltas (title, prefix+number, `mode` enum, instructor-placeholder rate) that catch a refresh which keeps the row count but whose *content* regressed: blanked titles, a leaked `mode` label (the failure that silently dropped colleges — import aborts a term >5% invalid mode), or the instructor column collapsing to `STAFF`.

## Eligibility — which PRs qualify

**SAFE** requires *all* (unit-tested in `scripts/lib/automerge-eligible.ts`): author is the `app/github-actions` bot **and** branch `scheduled-scrape/{state}-{datatype}` **and** labels `scraper-output`+`automated`; every changed path is `data/xx/courses/<col>/<term>.json` or `data/xx/prereqs.json`, all one state; not draft; `mergeable`; past a soak window; under a file cap; and the state is **not** flagged `regression`/`persistent-broken`/`partial-coverage-degraded` by scraper triage. **ELIGIBLE = SAFE && state ∈ allowlist** (health beats allowlist). Transfers/programs are phase 2.

## Live dry-run over the 16 open PRs

With a sample allowlist `hi,id,ny`:

| Bucket | PRs |
|---|---|
| ✅ Eligible | #1537 id (3f), #1531 ny (2f) — small, single-state, healthy, past soak |
| 🟡 Safe, not allowlisted | md, al, ia, wv, ok, ct, nv, in, nh (9) |
| ⛔ Skipped | #1538 hi, #1533 ca, #1509 nd (triage-unhealthy); #1534 nc (54f>cap), #1526 wa (70f>cap) |

The eligible set matches what I'd merge by hand; every skip has a concrete reason. The content-quality gate was also run on real PR #1531 data (54 files) → 0 false findings.

## Staged rollout & controls

- **Phase 0 (this PR):** `AUTOMERGE_ENABLED` unset ⇒ every scheduled run is report-only, merges nothing.
- **Phase 1:** set repo var `AUTOMERGE_ENABLED=true` + `AUTOMERGE_ALLOWLIST` to 2–3 stable states. Knobs: `AUTOMERGE_MAX_FILES` (25), `AUTOMERGE_SOAK_HOURS` (4), `AUTOMERGE_MAX_MERGES_PER_RUN` (3).
- **Kill switch:** unset/!=`true` `AUTOMERGE_ENABLED`. **Per-PR opt-out:** `do-not-automerge` label.
- For Phase 1, set `AUTOMERGE_PAT` (repo+workflow scope) so the squash-merge triggers `import-on-merge.yml` like a human merge; the workflow also dispatches the import explicitly as a backstop.

## The residual gap, now much smaller

The semantic gap is split in two. The **detectable** half — blanked titles, leaked `mode`, instructor-column collapse, partial loads that squeak past 50% — is now caught pre-merge by `content-quality-diff`. What remains is only a single **well-formed but factually wrong** value (a real-looking but incorrect instructor name) — undetectable without a second source, and **exactly what a human skim also misses**. That residue is covered by the report-only soak, a tiny blast radius (allowlist + cap 3), health-exclusion, and the post-merge prod health check. Big multi-college PRs (nc, wa) intentionally fall through to manual merge under the file cap.

The content-quality gate is tuned to **not cry wolf**: existing files flag only a regression from a healthy baseline (a chronically-sparse college never trips), new files use absolute floors, and a false positive just means "merge by hand" (status quo).

## Test plan

- `automerge-eligible.test.ts` (22) + `content-quality-diff.test.ts` (15) = **37 unit tests**, all green. Collapse/leak/surge caught; legit churn, STAFF→named improvements, and stable-but-sparse NOT flagged.
- `npm run typecheck`, `npx eslint`, `js-yaml` workflow parse — green.
- Live dry-run over the 16 open PRs + real-data content-quality run on #1531 (above).

**Do not merge on my account — this is for your review.** Once merged, the only active behavior is the hourly report-only run; flipping to live is a deliberate variable change later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
