### PR TITLE
perf(vercel): CDN-cache sitemaps + lengthen ISR/Data-Cache TTLs (Tier-1 over-usage cut)

### DIFF
--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -16,7 +16,7 @@ import SubjectTermSection from "./SubjectTermSection";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
 
-export const revalidate = 86400;
+export const revalidate = 604800; // 7 days — high-cardinality pSEO page (college × prefix); longer window cuts ISR writes
 
 type PageProps = {
   params: Promise<{ state: string; id: string; prefix: string }>;

--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -26,7 +26,7 @@ import TrackView from "@/components/TrackView";
 import RelatedBlogPosts from "@/components/RelatedBlogPosts";
 import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
-export const revalidate = 86400; // 1 day — matches sitemap revalidation cycle to prevent stale soft-404s
+export const revalidate = 604800; // 7 days — pSEO content rarely changes; instructor pages are the largest on-demand ISR surface, so this is the single biggest ISR-write cut. Tradeoff: a vacated instructor may serve a stale page up to 7d (acceptable for these low-value pages; not in any sitemap).
 
 type PageProps = {
   params: Promise<{ state: string; id: string; slug: string }>;

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -37,8 +37,10 @@ import {
   formatPercent,
 } from "@/lib/scorecard";
 
-// Revalidate every 24 hours — course data only changes when re-scraped
-export const revalidate = 86400;
+// Revalidate weekly — course data only changes when re-scraped, and this is a
+// high-cardinality pSEO page (one per college × state), so the longer window
+// cuts on-demand ISR-cache writes. Busts sooner via the import tag if needed.
+export const revalidate = 604800;
 
 type PageProps = {
   params: Promise<{ state: string; id: string }>;

--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -24,7 +24,7 @@ import { termLabel } from "@/lib/terms";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import PlanClient from "./PlanClient";
 
-export const revalidate = 86400; // 1 day
+export const revalidate = 604800; // 7 days — high-cardinality pSEO page (college × program); longer window cuts ISR writes
 
 // Plain-English, jargon-free description of what each credential is. Coarse on
 // purpose (robust to AA/AS/AAS catalog quirks) — the goal is a first-gen

--- a/app/[state]/transfer/to/[universitySlug]/page.tsx
+++ b/app/[state]/transfer/to/[universitySlug]/page.tsx
@@ -20,7 +20,7 @@ import TrackView from "@/components/TrackView";
 import RelatedBlogPosts from "@/components/RelatedBlogPosts";
 import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
-export const revalidate = 86400;
+export const revalidate = 604800; // 7 days — high-cardinality pSEO page (per receiving university); longer window cuts ISR writes
 
 // Only serve pre-generated (state, university) combos. Any slug not in
 // Thin-content guard: only render pages for universities

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -108,14 +108,17 @@ export async function loadCoursesForCollege(
   );
 }
 
-// Cross-instance persistent cache (Vercel Data Cache). revalidate 1800s (30m)
-// matches the in-memory CACHE_TTL and is well within the ~3×/week scrape
-// cadence; unstable_cache keys on the arguments automatically.
+// Cross-instance persistent cache (Vercel Data Cache). revalidate 86400s (1d)
+// is well within the ~3×/week scrape cadence and busts immediately on the
+// "courses" tag when an import lands, so the long TTL carries no staleness
+// risk — it just stops crawler-driven cold instances from re-querying Postgres
+// ~48×/day (the egress + ISR-write win). unstable_cache keys on the arguments
+// automatically.
 const _xInstanceCoursesForCollege = unstable_cache(
   (collegeSlug: string, term: string, state: string) =>
     _loadCoursesForCollege(collegeSlug, term, state),
   ["courses-by-college"],
-  { revalidate: 1800, tags: ["courses"] },
+  { revalidate: 86400, tags: ["courses"] },
 );
 
 async function _loadCoursesForCollege(
@@ -529,7 +532,7 @@ const _xInstanceSearchSections = unstable_cache(
     parsed: { prefix: string | null; number: string | null; keyword: string | null },
   ) => _searchSections(term, state, parsed),
   ["search-sections"],
-  { revalidate: 1800, tags: ["courses"] },
+  { revalidate: 86400, tags: ["courses"] },
 );
 
 async function _searchSections(
@@ -654,7 +657,7 @@ const _xInstanceCourseByCode = unstable_cache(
   (prefix: string, number: string, term: string, state: string) =>
     _loadCourseByCode(prefix, number, term, state),
   ["course-by-code"],
-  { revalidate: 1800, tags: ["courses"] },
+  { revalidate: 86400, tags: ["courses"] },
 );
 
 async function _loadCourseByCode(

--- a/lib/sitemap-xml.ts
+++ b/lib/sitemap-xml.ts
@@ -47,6 +47,20 @@ export function siteOrigin(): string {
 
 export function xmlResponse(xml: string): Response {
   return new Response(xml, {
-    headers: { "Content-Type": "application/xml" },
+    headers: {
+      "Content-Type": "application/xml",
+      // Cache every sitemap at the Vercel CDN for a day so repeat crawls don't
+      // re-run the per-request work behind the heavy sitemaps: courses.xml and
+      // state-subjects.xml full-paginate the courses table across all states,
+      // and core.xml does a live online-mode scan. Sitemap contents only change
+      // after the daily scrape/import; stale-while-revalidate serves the cached
+      // copy while one background request refreshes it. Deliberately a response
+      // header rather than `export const revalidate`: those sitemaps are
+      // `force-dynamic`, and converting them to ISR would pre-render the
+      // multi-state scans at BUILD time and blow the 60s static-gen budget —
+      // the exact failure the data/sitemap-college-subjects.json snapshot exists
+      // to avoid.
+      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=43200",
+    },
   });
 }

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -156,7 +156,7 @@ const _xInstanceTransfersByUniversity = unstable_cache(
   (state: string, university: string, cap?: number) =>
     _loadTransferMappingsByUniversity(state, university, cap),
   ["transfer-by-university"],
-  { revalidate: 1800, tags: ["transfers"] },
+  { revalidate: 86400, tags: ["transfers"] },
 );
 
 async function _loadTransferMappingsByUniversity(


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible. This is an infrastructure/cost fix: it cuts the Vercel usage
that **paused the project** (every Hobby-tier metric was blown 21–80× over
limit), so the site can get back under limits without just paying for the
overage. Same root cause also drives the parallel Supabase egress overage, so
this relieves both vendors at once.

## What this is

The site is a large programmatic-SEO surface (course / subject / program /
college / instructor pages across all 50 states) and crawler traffic walks it at
huge volume. The problem isn't the traffic — it's that the routes serving it
**redo Supabase work on nearly every request with almost no cross-instance
caching**, and the sitemaps re-scan the whole `courses` table per fetch. This PR
removes the per-crawl re-computation. It does **not** touch crawlability — that
(robots.txt / bot firewall) is a separate, SEO-sensitive Tier-2 PR.

### Metric → confirmed driver (from a code audit off `origin/main`)

| Metric | Over by | Driver |
|---|---|---|
| ISR Writes 16M/200K | ~80× | Page routes with `generateStaticParams: []` + short `revalidate` → every unique crawled URL is an on-demand ISR write, re-written each window |
| Function Duration 5,094/100 GB-Hrs | ~51× | `force-dynamic` sitemaps re-paginate the whole `courses` table across all 50 states on every fetch (only a per-instance in-memory cache, ~0 hit rate) |
| Edge Requests + Function Invocations 21M/1M | ~21× | Crawler volume on an open surface; ~1:1 ratio = edge cache almost never serves a hit |

## The three levers

| Lever | File(s) | Change | Why |
|---|---|---|---|
| **1. CDN-cache sitemaps** | `lib/sitemap-xml.ts` (`xmlResponse`) | add `Cache-Control: public, s-maxage=86400, stale-while-revalidate=43200` | Repeat crawls of all 8 sitemaps hit the Vercel CDN instead of re-running the multi-state courses-table scans. Biggest cut to Function Duration / Fast Origin Transfer / Supabase egress. |
| **2. Lengthen ISR windows** | 5 high-cardinality page routes¹ | `revalidate` 86400 → 604800 (7d) | These return `generateStaticParams: []` (fully on-demand); the 1-day window multiplied regen ISR writes on the largest URL surfaces. |
| **3. Data-Cache TTL** | `lib/courses.ts` ×3, `lib/transfer.ts` | `revalidate: 1800` → `86400` | Recently added at 30 min; underlying data refreshes ≤ daily and each busts on its tag. Stops crawler cold-starts re-querying Postgres ~48×/day. The transfer loader is named in-code as ~50% of DB egress. |

¹ `college/[id]`, `college/[id]/courses/[prefix]`, `college/[id]/program/[slug]`, `college/[id]/instructor/[slug]`, `transfer/to/[universitySlug]`.

### Key design choice — why Lever 1 is a header, not ISR
The live-Supabase sitemaps (`courses.xml`, `state-subjects.xml`, `core.xml`) are
`force-dynamic`. Converting them to `export const revalidate` would make Next
**pre-render** those all-state table scans at **build time** — re-creating the
60s static-gen timeout the `data/sitemap-college-subjects.json` snapshot was
built to avoid. A CDN `Cache-Control` header caches the response without any
build-time render. Confirmed in `next build`: all sitemap routes remain
`ƒ (Dynamic)`.

## Test plan
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (pre-existing warnings only).
- `npm run test:run` — 950 passed / 12 skipped / 0 failed, incl.
  `app/__tests__/isr-route-config.test.ts` (verified: it only requires a
  `generateStaticParams`/`dynamic` export to coexist with `revalidate` — never
  checks the numeric value, so the lengthened windows pass).
- `npx next build` — green; sitemap routes stay `ƒ (Dynamic)` (no build-time
  pre-render regression).
- **Post-deploy check (reviewer):** `curl -I https://communitycollegepath.com/sitemap/courses.xml`
  should show `cache-control: public, s-maxage=86400, stale-while-revalidate=43200`.

## Out of scope (separate Tier-2 PR)
robots.txt tightening (disallow `?q=` / lowest-value long tail), bot
firewall/rate-limits, and the plan-upgrade decision — all SEO-sensitive, to be
reviewed deliberately given the May-2026 noindex-collapse history.
