### PR TITLE
seo: localize course-page titles to the single college (CTR lever)

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -185,12 +185,41 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
   const title = sections[0].course_title;
   const credits = sections[0].credits;
-  const collegeCount = new Set(sections.map((s) => s.college_code)).size;
+  const collegeCodes = new Set(sections.map((s) => s.college_code));
+  const collegeCount = collegeCodes.size;
   const onlineCount = sections.filter((s) => s.mode === "online" || s.mode === "zoom").length;
   const term = termLabel(currentTerm);
+  const creditLabel = `${credits} ${credits === 1 ? "credit" : "credits"}`;
 
-  const pageTitle = `${parsed.prefix} ${parsed.number}: ${title} — ${config.name} Community Colleges`;
-  const description = `${parsed.prefix} ${parsed.number} (${title}, ${credits} ${credits === 1 ? "credit" : "credits"}) — ${sections.length} sections at all ${collegeCount} ${config.name} community colleges for ${term}${onlineCount > 0 ? `, ${onlineCount} online` : ""}. See schedules, open seats, and transfer credit.`;
+  // CTR lever (SEO course-page analysis, 2026-06): these pages rank ~position
+  // 14 but convert at ~1.1% because the title advertised the whole state
+  // ("… — New York Community Colleges") while the searches that hit them are
+  // single-college ("phy 118 suffolk county"). When a course runs at exactly
+  // one college this term, the page effectively IS that college's course page,
+  // so lead the title with the college name to echo the query. Multi-college
+  // pages instead lead with the cross-college comparison — the thing no single
+  // college's own site offers. No transfer fetch here on purpose: getTransferInfo
+  // in metadata is what caused the 2026-05 504s (the #1444 regression).
+  let dominantCollegeName: string | null = null;
+  if (collegeCount === 1) {
+    const code = [...collegeCodes][0];
+    const inst = loadInstitutions(state).find(
+      (i) => i.college_slug === code || i.id === code,
+    );
+    dominantCollegeName = inst?.name ?? null;
+  }
+
+  let pageTitle: string;
+  let description: string;
+  if (dominantCollegeName) {
+    // Front-load code + college (the searched terms); the descriptive
+    // title/term tail may truncate in the SERP — that's fine.
+    pageTitle = `${parsed.prefix} ${parsed.number} at ${dominantCollegeName}: ${title} (${term})`;
+    description = `${parsed.prefix} ${parsed.number} (${title}, ${creditLabel}) at ${dominantCollegeName} for ${term}: ${sections.length} ${sections.length === 1 ? "section" : "sections"}${onlineCount > 0 ? `, ${onlineCount} online` : ""} — schedules, open seats, prerequisites, and where it transfers.`;
+  } else {
+    pageTitle = `${parsed.prefix} ${parsed.number}: ${title} at ${collegeCount} ${config.name} Colleges`;
+    description = `Compare every ${config.name} community college offering ${parsed.prefix} ${parsed.number} (${title}, ${creditLabel}) in ${term}: ${sections.length} sections across ${collegeCount} colleges${onlineCount > 0 ? `, ${onlineCount} online` : ""} — schedules, open seats, and which universities it transfers to.`;
+  }
 
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/course/${code}`;
 


### PR DESCRIPTION
## What changes for someone using the site

Nothing changes on the page itself — this is a **Google search-results** change. Today, when a student searches \`eng 131 danville\` or \`phy 118 suffolk county\`, our course page appears with a generic title that names the whole state, not their college — so it loses the click to the college's own site. After this change, when a course runs at only **one** college this term, the title names that college directly:

- Before: **ENG 131: Technical Report Writing I — Virginia Community Colleges**
- After: **ENG 131 at Danville Community College: Technical Report Writing I (Summer 2026)**

For courses offered at many colleges, the title now leads with the one thing no single college's site offers — the cross-college comparison:

- Before: **ENG 111: College Composition I — Virginia Community Colleges**
- After: **ENG 111: College Composition I at 23 Virginia Colleges**

## Why

Course pages are the largest slice of our search impressions but convert at only **~1.1% CTR** (vs ~5% for college-detail pages), despite ranking around position 14. The GSC query report shows the searches reaching them are overwhelmingly single-college / instructor / syllabus lookups — people want their *own* college's section, but the title advertised the whole state. This is the same "match the page to the searcher's intent" lever that recovered college-detail CTR in #1453.

This is **step 1** of a sequenced plan: the cheapest, fully-reversible, no-new-URLs test of the intent-match hypothesis. If course CTR moves over the next 2–3 weeks, it justifies step 2 (demand-gated per-college course pages).

## Technical

- File: \`app/[state]/course/[code]/page.tsx\`, \`generateMetadata\` only.
- When \`collegeCount === 1\`, resolve the college name via the already-imported \`loadInstitutions(state)\` (cached sync read) and lead the title/description with it; otherwise emit the comparison-framed title.
- **No \`getTransferInfo\` call added in metadata** — deliberately, since that per-page transfer load was the #1444 regression that 504'd big-state course pages in May. Transfer is referenced generically ("where it transfers").
- Untouched: the Supabase-outage guard, the no-sections noindex branch, and the thin-content \`isThin\` rule.

## Verification

- \`npm run typecheck\` → clean (exit 0).
- Rendered the new strings against **live VA data** through the same lib functions:
  - single-college \`/va/course/eng-131\` → \`ENG 131 at Danville Community College: Technical Report Writing I (Summer 2026)\`
  - multi-college \`/va/course/eng-111\` (23 colleges, 232 sections) → \`ENG 111: College Composition I at 23 Virginia Colleges\`
  - Both come out clean — no \`undefined\`/spacing artifacts. Single-college titles can exceed Google's ~60-char display and truncate the descriptive tail **by design**; the matching terms (code + college) are front-loaded.

## Known scope limits

- Only triggers when a course runs at **exactly one** college this term (the unambiguous case). Multi-college-but-dominant is intentionally out of scope for v1.
- CTR is a lagging, query-mix-dependent metric — expect a 2–3 week read before judging impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)